### PR TITLE
refactor(github): remove redundant execGh call in ensureLabelExists (#4)

### DIFF
--- a/src/github/labels.ts
+++ b/src/github/labels.ts
@@ -42,8 +42,6 @@ export async function ensureLabelExists(
   description?: string,
 ): Promise<void> {
   try {
-    // Check if label exists by listing it
-    await execGh(["label", "list", "--search", name, "--json", "name"]);
     const json = await execGh([
       "label",
       "list",

--- a/tests/github/labels.test.ts
+++ b/tests/github/labels.test.ts
@@ -52,12 +52,10 @@ describe("labels", () => {
   });
 
   it("ensureLabelExists creates label when not found", async () => {
-    mockExecGh
-      .mockResolvedValueOnce("[]") // first list call
-      .mockResolvedValueOnce("[]"); // second list call
+    mockExecGh.mockResolvedValueOnce("[]"); // list call
     await ensureLabelExists("new-label");
-    expect(mockExecGh).toHaveBeenCalledTimes(3);
-    expect(mockExecGh).toHaveBeenNthCalledWith(3, [
+    expect(mockExecGh).toHaveBeenCalledTimes(2);
+    expect(mockExecGh).toHaveBeenNthCalledWith(2, [
       "label",
       "create",
       "new-label",
@@ -66,19 +64,15 @@ describe("labels", () => {
   });
 
   it("ensureLabelExists skips creation when label exists", async () => {
-    mockExecGh
-      .mockResolvedValueOnce('[{"name": "bug"}]') // first list call
-      .mockResolvedValueOnce('[{"name": "bug"}]'); // second list call
+    mockExecGh.mockResolvedValueOnce('[{"name": "bug"}]'); // list call
     await ensureLabelExists("bug");
-    expect(mockExecGh).toHaveBeenCalledTimes(2);
+    expect(mockExecGh).toHaveBeenCalledTimes(1);
   });
 
   it("ensureLabelExists passes color and description", async () => {
-    mockExecGh
-      .mockResolvedValueOnce("[]")
-      .mockResolvedValueOnce("[]");
+    mockExecGh.mockResolvedValueOnce("[]"); // list call
     await ensureLabelExists("label", "ff0000", "A label");
-    expect(mockExecGh).toHaveBeenNthCalledWith(3, [
+    expect(mockExecGh).toHaveBeenNthCalledWith(2, [
       "label",
       "create",
       "label",


### PR DESCRIPTION
Closes #4

## Summary
Removes duplicate `gh label list` invocation in `ensureLabelExists` function where the first call's result was discarded, making it redundant.

## Changes
- **src/github/labels.ts**: Removed redundant `execGh` call (line 46) and its comment
- **tests/github/labels.test.ts**: Updated 3 test cases to expect single list call instead of two

## Test Coverage
All existing tests updated and passing:
- ✅ `ensureLabelExists creates label when not found` — expects 2 calls (1 list + 1 create)
- ✅ `ensureLabelExists skips creation when label exists` — expects 1 call (list only)
- ✅ `ensureLabelExists passes color and description` — expects 2 calls with params

## Definition of Done
- [x] Code implemented — redundant call removed
- [x] Lint clean — 0 errors
- [x] Type clean — 0 errors
- [x] Tests updated — 3 test cases adjusted
- [x] Tests pass — 333/333 passing
- [x] Diff size — 22 lines (7 added, 15 removed)
- [x] No unrelated changes — only labels.ts and labels.test.ts modified

## Verification
```
npm run test   # ✅ 333 tests passed
npm run lint   # ✅ 0 errors
npx tsc        # ✅ 0 type errors
git diff --stat # ✅ 22 lines total
```