### PR TITLE
docs(contributing): add CONTRIBUTING.md with development setup guide (#3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing
+
+Thank you for your interest in contributing! This guide covers setup, workflow, and conventions.
+
+## Prerequisites
+
+- **Node.js 20+**
+- **npm** (comes with Node.js)
+
+## Development Setup
+
+```bash
+# Clone and install
+git clone <repo-url>
+cd ai-scrum-autonomous-v2
+npm install
+```
+
+## Available Commands
+
+```bash
+npm test           # Run tests (vitest)
+npm run lint       # Lint source and tests (eslint)
+npm run build      # Build (tsc)
+npm run typecheck  # Type-check without emitting
+```
+
+## Branch Naming
+
+Use prefixed branch names based on the type of change:
+
+| Prefix   | Use for                        |
+|----------|--------------------------------|
+| `feat/`  | New features                   |
+| `fix/`   | Bug fixes                      |
+| `docs/`  | Documentation changes          |
+| `chore/` | Maintenance, tooling, configs  |
+
+Example: `feat/42-add-search-endpoint`
+
+## Commit Messages
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <description> (#<issue>)
+```
+
+**Types**: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`
+
+Examples:
+
+```
+feat(api): add user search endpoint (#42)
+fix(auth): handle expired tokens (#15)
+docs(readme): update setup instructions (#7)
+```
+
+## Workflow
+
+1. Create a branch from `main` using the naming convention above
+2. Make your changes — keep diffs small and focused
+3. Run all checks before pushing:
+   ```bash
+   npm run lint && npm run typecheck && npm test
+   ```
+4. Push and open a pull request against `main`
+5. Ensure CI passes before requesting review
+
+## Code Style
+
+- TypeScript with strict mode
+- ESM modules with `.js` extensions on local imports
+- Zod for runtime validation
+- Keep code readable — avoid clever one-liners
+
+## Tests
+
+- Write tests for new features (minimum 3: happy path, edge case, parameter variation)
+- Write a regression test for bug fixes
+- Use [Vitest](https://vitest.dev/) as the test framework

--- a/tests/contributing.test.ts
+++ b/tests/contributing.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const CONTRIBUTING_PATH = resolve(import.meta.dirname, "../CONTRIBUTING.md");
+
+describe("CONTRIBUTING.md", () => {
+  const content = readFileSync(CONTRIBUTING_PATH, "utf-8");
+  const lines = content.split("\n");
+
+  it("should contain development setup with prerequisites", () => {
+    expect(content).toMatch(/Node\s*(\.js)?\s*20\+?/i);
+    expect(content.toLowerCase()).toContain("npm");
+    expect(content).toMatch(/prerequisites|setup|getting started/i);
+  });
+
+  it("should document test, lint, and build commands", () => {
+    expect(content).toContain("npm test");
+    expect(content).toContain("npm run lint");
+    expect(content).toContain("npm run build");
+  });
+
+  it("should include branch naming conventions", () => {
+    expect(content).toContain("feat/");
+    expect(content).toContain("fix/");
+    expect(content).toContain("docs/");
+  });
+
+  it("should include conventional commit format", () => {
+    expect(content).toMatch(/conventional commits?/i);
+    expect(content).toMatch(/feat|fix|docs|chore/);
+  });
+
+  it("should be under 100 lines", () => {
+    expect(lines.length).toBeLessThanOrEqual(100);
+  });
+});


### PR DESCRIPTION
Closes #3

## Summary

Adds `CONTRIBUTING.md` at the repo root with:
- **Development setup** — prerequisites (Node.js 20+, npm), install steps
- **Available commands** — `npm test`, `npm run lint`, `npm run build`, `npm run typecheck`
- **Branch naming** — `feat/`, `fix/`, `docs/`, `chore/` prefixes
- **Commit messages** — Conventional Commits format with examples
- **Workflow** — branch → PR → CI → review process
- **Code style** and **test expectations**

81 lines total (under the 100-line limit).

## Tests Added

`tests/contributing.test.ts` — 5 tests verifying:
1. Development setup section with Node 20+ and npm prerequisites
2. Test, lint, and build commands documented
3. Branch naming conventions (`feat/`, `fix/`, `docs/`)
4. Conventional commit format
5. File is under 100 lines

## Definition of Done

- [x] Code implemented — all acceptance criteria addressed
- [x] Lint clean — 0 errors
- [x] Type clean — 0 errors
- [x] Tests written — 5 tests covering all acceptance criteria
- [x] Tests pass — 267 tests, 0 failures
- [x] Diff size — 118 lines (limit: 300)
- [x] No unrelated changes