### PR TITLE
fix: wire ACP permissions and resolve worktree paths

### DIFF
--- a/docs/sprints/sprint-1-log.md
+++ b/docs/sprints/sprint-1-log.md
@@ -1,0 +1,32 @@
+# Sprint 1 Log — 2026-02-26
+
+**Goal**: First sprint with 3 small foundational tasks. No stakeholder-flagged or critical issues exist. All issues are independent with no dependencies, so they form a single parallel execution group. ICE ordering: #2 (400) > #3 (360) > #4 (300). Total effort of 3 points is well within the 8-point capacity, leaving ample buffer for first-sprint uncertainty.
+**Planned**: 3 issues
+
+## Huddles
+### ❌ #4 — Remove redundant execGh call in ensureLabelExists
+
+- **Status**: failed
+- **Duration**: 2s
+- **Quality**: FAILED
+- **Files changed**: 0
+
+**Quality Checks**:
+
+
+_2026-02-26T20:41:22.782Z_
+### ✅ #4 — Remove redundant execGh call in ensureLabelExists
+
+- **Status**: completed
+- **Duration**: 7m 13s
+- **Quality**: PASSED
+- **Files changed**: 2
+
+**Quality Checks**:
+  - ✅ tests-exist: Found 27 test file(s)
+  - ✅ tests-pass: Tests passed
+  - ✅ lint-clean: Lint clean
+  - ✅ types-clean: Types clean
+  - ✅ diff-size: 22 lines changed (max 300)
+
+_2026-02-26T20:49:21.406Z_

--- a/sprint-runner.config.yaml
+++ b/sprint-runner.config.yaml
@@ -12,6 +12,7 @@ copilot:
   reviewer_model: "claude-opus-4.6"
   max_parallel_sessions: 4
   session_timeout_ms: 600000
+  auto_approve_tools: true
 
 sprint:
   max_issues: 8

--- a/src/ceremonies/execution.ts
+++ b/src/ceremonies/execution.ts
@@ -108,7 +108,7 @@ export async function executeIssue(
   const startTime = Date.now();
 
   const branch = `sprint/${config.sprintNumber}/issue-${issue.number}`;
-  const worktreePath = path.join(config.worktreeBase, `issue-${issue.number}`);
+  const worktreePath = path.resolve(config.worktreeBase, `issue-${issue.number}`);
 
   // Step 1: Set in-progress label
   await setLabel(issue.number, "status:in-progress");

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,8 @@ const CopilotSchema = z.object({
   reviewer_model: z.string().default("claude-opus-4.6"),
   max_parallel_sessions: z.number().int().min(1).max(20).default(4),
   session_timeout_ms: z.number().int().min(0).default(600000),
+  auto_approve_tools: z.boolean().default(true),
+  allow_tool_patterns: z.array(z.string()).default([]),
 });
 
 const SprintSchema = z.object({

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,10 @@ async function createConnectedClient(config: ConfigFile): Promise<AcpClient> {
   const client = new AcpClient({
     command: config.copilot.executable,
     timeoutMs: config.copilot.session_timeout_ms,
+    permissions: {
+      autoApprove: config.copilot.auto_approve_tools,
+      allowPatterns: config.copilot.allow_tool_patterns,
+    },
   });
   await client.connect();
   return client;


### PR DESCRIPTION
## Summary

Fixes two bugs discovered during the first real end-to-end sprint execution.

### Bugs Fixed

1. **ACP permission handler wasn't wired to config** — `createConnectedClient()` didn't pass permission config to `AcpClient`, so all tool calls from Copilot were rejected (default `autoApprove: false`). Sprint planning returned empty responses.

2. **Worktree paths must be absolute for ACP** — `executeIssue()` used `path.join()` which preserved relative paths from config (`../sprint-worktrees/...`). ACP's `createSession` requires absolute paths. Changed to `path.resolve()`.

### Changes

- `src/config.ts`: Added `auto_approve_tools` (bool, default true) and `allow_tool_patterns` (string[]) to CopilotSchema
- `src/index.ts`: `createConnectedClient()` now passes `permissions` config to `AcpClient`
- `src/ceremonies/execution.ts`: Changed `path.join` → `path.resolve` for worktree path
- `sprint-runner.config.yaml`: Added `auto_approve_tools: true`

### Validation

All 3 sprint issues executed successfully after these fixes:
- Issue #4: Remove redundant execGh call — ✅ quality gate passed
- Issue #2: Add .editorconfig — ✅ quality gate passed
- Issue #3: Add CONTRIBUTING.md — ✅ quality gate passed

262 tests pass.