### PR TITLE
feat: add item planner with native ACP Plan Mode + model selection

### DIFF
--- a/docs/sprints/sprint-2-log.md
+++ b/docs/sprints/sprint-2-log.md
@@ -1,0 +1,15 @@
+### ✅ #9 — Add ntfy topic validation in escalation handler
+
+- **Status**: completed
+- **Duration**: 4m 8s
+- **Quality**: PASSED
+- **Files changed**: 2
+
+**Quality Checks**:
+  - ✅ tests-exist: Found 27 test file(s)
+  - ✅ tests-pass: Tests passed
+  - ✅ lint-clean: Lint clean
+  - ✅ types-clean: Types clean
+  - ✅ diff-size: 66 lines changed (max 300)
+
+_2026-02-26T21:23:59.376Z_

--- a/prompts/item-planner.md
+++ b/prompts/item-planner.md
@@ -1,0 +1,55 @@
+# Item Planner Session Prompt
+
+You are the **Item Planner Agent** for the AI-Scrum autonomous sprint runner.
+
+## Context
+
+- **Project**: {{PROJECT_NAME}}
+- **Repository**: {{REPO_OWNER}}/{{REPO_NAME}}
+- **Sprint**: {{SPRINT_NUMBER}}
+- **Issue**: #{{ISSUE_NUMBER}} — {{ISSUE_TITLE}}
+- **Issue body**: {{ISSUE_BODY}}
+- **Branch**: {{BRANCH_NAME}}
+- **Base branch**: {{BASE_BRANCH}}
+
+## Your Task
+
+Create a detailed implementation plan for issue #{{ISSUE_NUMBER}} **without making any changes**.
+
+Analyze the codebase to understand:
+1. Which files need to be modified or created
+2. What the current code looks like in those areas
+3. What dependencies exist between changes
+4. What tests need to be written
+
+## Output Format
+
+Respond with a structured implementation plan in this exact JSON format:
+
+```json
+{
+  "summary": "One-sentence description of the approach",
+  "steps": [
+    {
+      "order": 1,
+      "action": "create|modify|test",
+      "file": "path/to/file.ts",
+      "description": "What to do in this file and why",
+      "details": "Specific implementation details — function signatures, logic, edge cases"
+    }
+  ],
+  "test_strategy": "How to test this change — which test file, what scenarios",
+  "risks": ["Potential issues to watch for"],
+  "estimated_diff_lines": 50
+}
+```
+
+## Rules
+
+- **DO NOT modify any files** — only analyze and plan
+- List files in dependency order (create before use)
+- Include test files in the steps
+- Keep the plan under {{MAX_DIFF_LINES}} estimated diff lines
+- If the issue is too large, plan only the minimal viable slice and note what's deferred
+- Be specific — include function names, parameter types, return types
+- Check existing tests for patterns to follow

--- a/src/acp/session-pool.ts
+++ b/src/acp/session-pool.ts
@@ -38,9 +38,10 @@ export class SessionPool {
 
     let sessionId: string;
     try {
-      sessionId = await this.client.createSession(
+      const info = await this.client.createSession(
         options as Parameters<AcpClient["createSession"]>[0],
       );
+      sessionId = info.sessionId;
     } catch (err: unknown) {
       // Wake next waiter so pool doesn't deadlock
       const next = this.waitQueue.shift();

--- a/src/ceremonies/merge-pipeline.ts
+++ b/src/ceremonies/merge-pipeline.ts
@@ -111,7 +111,7 @@ export async function resolveConflictsViaAcp(
   ].join("\n");
 
   try {
-    const sessionId = await client.createSession({ cwd: process.cwd() });
+    const { sessionId } = await client.createSession({ cwd: process.cwd() });
 
     const result = await client.sendPrompt(sessionId, prompt);
 

--- a/src/ceremonies/planning.ts
+++ b/src/ceremonies/planning.ts
@@ -47,7 +47,7 @@ export async function runSprintPlanning(
   });
 
   // Create ACP session and send prompt
-  const sessionId = await client.createSession({ cwd: config.projectPath });
+  const { sessionId } = await client.createSession({ cwd: config.projectPath });
   try {
     const result = await client.sendPrompt(sessionId, prompt, config.sessionTimeoutMs);
     const plan = extractJson<SprintPlan>(result.response);

--- a/src/ceremonies/refinement.ts
+++ b/src/ceremonies/refinement.ts
@@ -51,7 +51,7 @@ export async function runRefinement(
   });
 
   // Create ACP session and send prompt
-  const sessionId = await client.createSession({ cwd: config.projectPath });
+  const { sessionId } = await client.createSession({ cwd: config.projectPath });
   try {
     const result = await client.sendPrompt(sessionId, prompt, config.sessionTimeoutMs);
     const parsed = extractJson<RefinementResponse>(result.response);

--- a/src/ceremonies/retro.ts
+++ b/src/ceremonies/retro.ts
@@ -71,7 +71,7 @@ export async function runSprintRetro(
   });
 
   // Create ACP session and send prompt
-  const sessionId = await client.createSession({ cwd: config.projectPath });
+  const { sessionId } = await client.createSession({ cwd: config.projectPath });
   try {
     const response = await client.sendPrompt(sessionId, prompt, config.sessionTimeoutMs);
     const retro = extractJson<RetroResult>(response.response);

--- a/src/ceremonies/review.ts
+++ b/src/ceremonies/review.ts
@@ -53,7 +53,7 @@ export async function runSprintReview(
   });
 
   // Create ACP session and send prompt
-  const sessionId = await client.createSession({ cwd: config.projectPath });
+  const { sessionId } = await client.createSession({ cwd: config.projectPath });
   try {
     const response = await client.sendPrompt(sessionId, prompt, config.sessionTimeoutMs);
     const review = extractJson<ReviewResult>(response.response);

--- a/src/enforcement/challenger.ts
+++ b/src/enforcement/challenger.ts
@@ -24,7 +24,7 @@ export async function runChallengerReview(
     diffStat(branch, config.baseBranch),
   ]);
 
-  const sessionId = await client.createSession({
+  const { sessionId } = await client.createSession({
     cwd: config.projectPath,
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,9 @@ function buildSprintConfig(config: ConfigFile, sprintNumber: number): SprintConf
     sessionTimeoutMs: config.copilot.session_timeout_ms,
     customInstructions: "",
     githubMcp: config.github.mcp_server,
+    plannerModel: config.copilot.planner_model,
+    workerModel: config.copilot.worker_model,
+    reviewerModel: config.copilot.reviewer_model,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,6 +172,9 @@ export interface SprintConfig {
   sessionTimeoutMs: number;
   customInstructions: string;
   githubMcp: McpServerConfig;
+  plannerModel?: string;
+  workerModel?: string;
+  reviewerModel?: string;
 }
 
 export interface McpServerConfig {

--- a/tests/acp/client.test.ts
+++ b/tests/acp/client.test.ts
@@ -86,6 +86,14 @@ describe("AcpClient", () => {
     });
     mockNewSession.mockResolvedValue({
       sessionId: "session-123",
+      modes: {
+        availableModes: [{ id: "agent", name: "Agent" }, { id: "plan", name: "Plan" }],
+        currentModeId: "agent",
+      },
+      models: {
+        availableModels: [{ modelId: "claude-sonnet-4.6", name: "Claude Sonnet 4.6" }],
+        currentModelId: "claude-sonnet-4.6",
+      },
     });
     mockPrompt.mockResolvedValue({
       stopReason: "end_turn",
@@ -241,9 +249,11 @@ describe("AcpClient", () => {
       const client = new AcpClient({ logger: silentLogger });
       await client.connect();
 
-      const sessionId = await client.createSession({ cwd: "/tmp/project" });
+      const sessionInfo = await client.createSession({ cwd: "/tmp/project" });
 
-      expect(sessionId).toBe("session-123");
+      expect(sessionInfo.sessionId).toBe("session-123");
+      expect(sessionInfo.availableModes).toEqual(["agent", "plan"]);
+      expect(sessionInfo.currentModel).toBe("claude-sonnet-4.6");
       expect(mockNewSession).toHaveBeenCalledWith({
         cwd: "/tmp/project",
         mcpServers: [],

--- a/tests/acp/session-pool.test.ts
+++ b/tests/acp/session-pool.test.ts
@@ -16,7 +16,13 @@ vi.mock("../../src/logger.js", () => {
 function createMockClient(): AcpClient {
   let counter = 0;
   return {
-    createSession: vi.fn(async () => `session-${++counter}`),
+    createSession: vi.fn(async () => ({
+      sessionId: `session-${++counter}`,
+      availableModes: [],
+      currentMode: "",
+      availableModels: [],
+      currentModel: "",
+    })),
     endSession: vi.fn(async () => {}),
   } as unknown as AcpClient;
 }

--- a/tests/ceremonies/ceremony-coverage.test.ts
+++ b/tests/ceremonies/ceremony-coverage.test.ts
@@ -66,11 +66,13 @@ import { listIssues, createIssue } from "../../src/github/issues.js";
 
 function makeMockClient() {
   return {
-    createSession: vi.fn().mockResolvedValue("session-1"),
+    createSession: vi.fn().mockResolvedValue({ sessionId: "session-1", availableModes: [], currentMode: "", availableModels: [], currentModel: "" }),
     sendPrompt: vi
       .fn()
       .mockResolvedValue({ response: "", stopReason: "end_turn" }),
     endSession: vi.fn().mockResolvedValue(undefined),
+    setMode: vi.fn().mockResolvedValue(undefined),
+    setModel: vi.fn().mockResolvedValue(undefined),
   } as unknown as AcpClient;
 }
 

--- a/tests/ceremonies/planning.test.ts
+++ b/tests/ceremonies/planning.test.ts
@@ -166,7 +166,7 @@ const planResponse: SprintPlan = {
 
 function makeMockClient() {
   return {
-    createSession: vi.fn().mockResolvedValue("session-123"),
+    createSession: vi.fn().mockResolvedValue({ sessionId: "session-123", availableModes: [], currentMode: "", availableModels: [], currentModel: "" }),
     sendPrompt: vi.fn().mockResolvedValue({
       response: "```json\n" + JSON.stringify(planResponse) + "\n```",
       stopReason: "end_turn",

--- a/tests/enforcement/challenger.test.ts
+++ b/tests/enforcement/challenger.test.ts
@@ -36,11 +36,13 @@ import { runChallengerReview } from "../../src/enforcement/challenger.js";
 
 function makeMockClient(response = "APPROVED: Looks good") {
   return {
-    createSession: vi.fn().mockResolvedValue("session-1"),
+    createSession: vi.fn().mockResolvedValue({ sessionId: "session-1", availableModes: [], currentMode: "", availableModels: [], currentModel: "" }),
     sendPrompt: vi
       .fn()
       .mockResolvedValue({ response, stopReason: "end_turn" }),
     endSession: vi.fn().mockResolvedValue(undefined),
+    setMode: vi.fn().mockResolvedValue(undefined),
+    setModel: vi.fn().mockResolvedValue(undefined),
   } as unknown as AcpClient;
 }
 


### PR DESCRIPTION
## Summary

Adds a two-phase execution flow that uses Copilot's **native Plan Mode** via ACP before the worker implements:

### New Flow
```
Plan Mode (#plan, opus)  →  Agent Mode (#agent, sonnet)  →  Quality Gate
     ↓                           ↓
  JSON plan                 Implementation
  posted to issue           following plan
```

### What changed

- **`src/acp/client.ts`**: Added `setMode()`, `setModel()`, `SessionInfo`, `ACP_MODES` constants. `createSession()` now returns session info including available modes and models.
- **`src/ceremonies/execution.ts`**: Two-phase execution — Plan Mode with planner prompt first, then Agent Mode with worker prompt + plan appended.
- **`prompts/item-planner.md`**: New prompt template for the plan phase.
- **`src/types.ts`**: Added `plannerModel`, `workerModel`, `reviewerModel` to `SprintConfig`.
- **`src/index.ts`**: Wires model config from YAML to `SprintConfig`.
- **Test updates**: All mocks updated for new `SessionInfo` return type.

### ACP Modes (discovered via probe)

| Mode | ID | Use |
|------|----|-----|
| Agent | `#agent` | Default — implements changes |
| Plan | `#plan` | Analyzes codebase, creates plan without changes |
| Autopilot | `#autopilot` | Autonomous until completion (experimental) |

### Model Selection

| Phase | Config Field | Default |
|-------|-------------|---------|
| Planning | `copilot.planner_model` | claude-opus-4.6 |
| Execution | `copilot.worker_model` | claude-sonnet-4.5 |
| Review | `copilot.reviewer_model` | claude-opus-4.6 |

### Validation

Tested end-to-end with issue #9 (ntfy topic validation):
- Plan Mode created a 2-step plan in 50s (opus)
- Agent Mode implemented in 3m (sonnet)
- Quality gate: 5/5 ✅
- Plan posted as issue comment ✅

262 tests pass.