### PR TITLE
feat: configurable MCP servers and instructions per ACP session

### DIFF
--- a/.copilot/session-state/4433418c-ac1c-4246-8b3d-d7c751a2a8a7/plan.md
+++ b/.copilot/session-state/4433418c-ac1c-4246-8b3d-d7c751a2a8a7/plan.md
@@ -1,0 +1,72 @@
+# Plan: Configurable MCP Servers + Instructions per ACP Session
+
+## Problem
+
+MCP servers and instructions/skills are currently **not wired** to ACP sessions at all:
+- `github.mcp_server` is defined in YAML but never passed to `createSession()`
+- No way to configure different MCP servers per ceremony phase
+- No way to inject custom instructions per phase (only via prompt templates)
+
+## Approach
+
+Two-level configuration: **global** (all sessions) + **per-phase** (ceremony-specific).
+
+### Config YAML Design
+
+```yaml
+copilot:
+  # Global MCP servers — attached to EVERY ACP session
+  mcp_servers:
+    - name: "github"
+      type: "stdio"
+      command: "npx"
+      args: ["-y", "@github/mcp-server"]
+
+  # Global instructions — prepended to every prompt
+  instructions:
+    - ".github/copilot-instructions.md"
+
+  # Per-phase config (model + additional MCPs + additional instructions)
+  phases:
+    planner:
+      model: "claude-opus-4.6"
+      mcp_servers: []            # no extra MCPs for planning
+      instructions: []           # no extra instructions
+    worker:
+      model: "claude-sonnet-4.5"
+      mcp_servers:               # worker gets filesystem MCP too
+        - name: "filesystem"
+          type: "stdio"
+          command: "npx"
+          args: ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"]
+      instructions:
+        - "prompts/worker-instructions.md"
+    reviewer:
+      model: "claude-opus-4.6"
+      mcp_servers: []
+      instructions: []
+```
+
+### Merge Logic
+
+When creating a session for phase X:
+- `mcpServers = global.mcp_servers + phases.X.mcp_servers`
+- `instructions = global.instructions + phases.X.instructions` (loaded from files, prepended to prompt)
+
+### Migration
+
+The old `github.mcp_server` field gets deprecated in favor of `copilot.mcp_servers[]`. For backward compat, if `github.mcp_server` exists and `copilot.mcp_servers` is empty, auto-migrate it.
+
+## Todos
+
+- [ ] **config-schema** — Add `AcpMcpServerSchema`, `PhaseConfigSchema`, update `CopilotSchema` with `mcp_servers`, `instructions`, `phases`
+- [ ] **types-update** — Replace `McpServerConfig` with full ACP-compatible `AcpMcpServerEntry`, add `PhaseConfig` and `SessionConfig` to `SprintConfig`
+- [ ] **mcp-resolver** — New helper `resolveSessionConfig(config, phase)` that merges global + phase MCPs/instructions and converts to ACP `McpServer[]`
+- [ ] **instructions-loader** — New helper `loadInstructions(paths, projectPath)` that reads instruction files and returns concatenated text
+- [ ] **wire-execution** — `execution.ts`: pass resolved MCPs to `createSession()`, prepend instructions to prompts
+- [ ] **wire-ceremonies** — `planning.ts`, `refinement.ts`, `review.ts`, `retro.ts`, `challenger.ts`, `merge-pipeline.ts`: same wiring
+- [ ] **wire-quality-retry** — `handleQualityFailure`: pass MCPs to retry sessions too
+- [ ] **backward-compat** — Auto-migrate `github.mcp_server` → `copilot.mcp_servers[0]` in config loader
+- [ ] **update-config-yaml** — Move GitHub MCP from `github.mcp_server` to `copilot.mcp_servers`
+- [ ] **update-tests** — Update test mocks and add tests for resolver, loader, and config migration
+- [ ] **update-session-pool** — Align `SessionPool.CreateSessionOptions.mcpServers` type with ACP `McpServer[]`

--- a/sprint-runner.config.yaml
+++ b/sprint-runner.config.yaml
@@ -7,12 +7,28 @@ project:
 
 copilot:
   executable: "copilot"
-  planner_model: "claude-opus-4.6"
-  worker_model: "claude-sonnet-4.5"
-  reviewer_model: "claude-opus-4.6"
   max_parallel_sessions: 4
   session_timeout_ms: 600000
   auto_approve_tools: true
+
+  # Global MCP servers — attached to every ACP session
+  mcp_servers:
+    - name: "github"
+      type: "stdio"
+      command: "npx"
+      args: ["-y", "@github/mcp-server"]
+
+  # Global instructions — prepended to every prompt
+  instructions: []
+
+  # Per-phase configuration (model + additional MCPs + instructions)
+  phases:
+    planner:
+      model: "claude-opus-4.6"
+    worker:
+      model: "claude-sonnet-4.5"
+    reviewer:
+      model: "claude-opus-4.6"
 
 sprint:
   max_issues: 8
@@ -42,7 +58,4 @@ git:
   squash_merge: true
   delete_branch_after_merge: true
 
-github:
-  mcp_server:
-    command: "npx"
-    args: ["-y", "@github/mcp-server"]
+github: {}

--- a/src/acp/session-config.ts
+++ b/src/acp/session-config.ts
@@ -1,0 +1,109 @@
+// Resolve MCP servers and instructions for a given ceremony phase.
+// Merges global config with phase-specific overrides.
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { McpServer } from "@agentclientprotocol/sdk";
+import type { SprintConfig, McpServerEntry, PhaseConfig } from "../types.js";
+import { logger } from "../logger.js";
+
+/** Known ceremony phase names used as keys in `copilot.phases`. */
+export type CeremonyPhase =
+  | "planner"
+  | "worker"
+  | "reviewer"
+  | "refinement"
+  | "planning"
+  | "review"
+  | "retro"
+  | "challenger"
+  | "conflict-resolver";
+
+export interface ResolvedSessionConfig {
+  mcpServers: McpServer[];
+  instructions: string;
+  model?: string;
+}
+
+/** Convert our config entry to the ACP SDK McpServer type. */
+function toAcpMcpServer(entry: McpServerEntry): McpServer {
+  switch (entry.type) {
+    case "stdio":
+      // ACP McpServerStdio has no `type` discriminant field
+      return {
+        name: entry.name,
+        command: entry.command,
+        args: entry.args,
+        env: entry.env ?? [],
+      };
+    case "http":
+      return {
+        type: "http",
+        name: entry.name,
+        url: entry.url,
+        headers: entry.headers ?? [],
+      };
+    case "sse":
+      return {
+        type: "sse",
+        name: entry.name,
+        url: entry.url,
+        headers: entry.headers ?? [],
+      };
+  }
+}
+
+/** Load instruction files from disk and concatenate their contents. */
+export async function loadInstructions(
+  filePaths: string[],
+  projectPath: string,
+): Promise<string> {
+  if (filePaths.length === 0) return "";
+
+  const log = logger.child({ component: "session-config" });
+  const parts: string[] = [];
+
+  for (const filePath of filePaths) {
+    const resolved = path.isAbsolute(filePath)
+      ? filePath
+      : path.resolve(projectPath, filePath);
+    try {
+      const content = await fs.readFile(resolved, "utf-8");
+      parts.push(content);
+    } catch (err: unknown) {
+      log.warn({ filePath: resolved, err }, "failed to load instruction file — skipping");
+    }
+  }
+
+  return parts.join("\n\n");
+}
+
+/**
+ * Resolve the full session configuration for a ceremony phase.
+ * Merges global MCP servers + instructions with phase-specific ones.
+ */
+export async function resolveSessionConfig(
+  config: SprintConfig,
+  phase: CeremonyPhase,
+): Promise<ResolvedSessionConfig> {
+  const phaseConfig: PhaseConfig | undefined = config.phases[phase];
+
+  // Merge MCP servers: global + phase-specific
+  const allEntries: McpServerEntry[] = [
+    ...config.globalMcpServers,
+    ...(phaseConfig?.mcp_servers ?? []),
+  ];
+  const mcpServers = allEntries.map(toAcpMcpServer);
+
+  // Merge instructions: global + phase-specific
+  const allInstructionPaths = [
+    ...config.globalInstructions,
+    ...(phaseConfig?.instructions ?? []),
+  ];
+  const instructions = await loadInstructions(allInstructionPaths, config.projectPath);
+
+  // Model from phase config
+  const model = phaseConfig?.model;
+
+  return { mcpServers, instructions, model };
+}

--- a/src/acp/session-pool.ts
+++ b/src/acp/session-pool.ts
@@ -1,5 +1,5 @@
 import { type AcpClient } from "./client.js";
-import { type McpServerConfig } from "../types.js";
+import type { McpServer } from "@agentclientprotocol/sdk";
 import { logger as defaultLogger, type Logger } from "../logger.js";
 
 export interface PooledSession {
@@ -9,7 +9,7 @@ export interface PooledSession {
 
 export interface CreateSessionOptions {
   cwd: string;
-  mcpServers?: McpServerConfig[];
+  mcpServers?: McpServer[];
 }
 
 export class SessionPool {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,10 +52,9 @@ function buildSprintConfig(config: ConfigFile, sprintNumber: number): SprintConf
     deleteBranchAfterMerge: config.git.delete_branch_after_merge,
     sessionTimeoutMs: config.copilot.session_timeout_ms,
     customInstructions: "",
-    githubMcp: config.github.mcp_server,
-    plannerModel: config.copilot.planner_model,
-    workerModel: config.copilot.worker_model,
-    reviewerModel: config.copilot.reviewer_model,
+    globalMcpServers: config.copilot.mcp_servers,
+    globalInstructions: config.copilot.instructions,
+    phases: config.copilot.phases,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,6 +152,40 @@ export interface RetroResult {
   previousImprovementsChecked: boolean;
 }
 
+// --- MCP Server Configuration (matches ACP SDK McpServer types) ---
+
+export interface McpServerStdio {
+  type: "stdio";
+  name: string;
+  command: string;
+  args: string[];
+  env?: Array<{ name: string; value: string }>;
+}
+
+export interface McpServerHttp {
+  type: "http";
+  name: string;
+  url: string;
+  headers?: Array<{ name: string; value: string }>;
+}
+
+export interface McpServerSse {
+  type: "sse";
+  name: string;
+  url: string;
+  headers?: Array<{ name: string; value: string }>;
+}
+
+export type McpServerEntry = McpServerStdio | McpServerHttp | McpServerSse;
+
+// --- Phase Configuration ---
+
+export interface PhaseConfig {
+  model?: string;
+  mcp_servers: McpServerEntry[];
+  instructions: string[];
+}
+
 // --- Configuration ---
 
 export interface SprintConfig {
@@ -171,13 +205,7 @@ export interface SprintConfig {
   deleteBranchAfterMerge: boolean;
   sessionTimeoutMs: number;
   customInstructions: string;
-  githubMcp: McpServerConfig;
-  plannerModel?: string;
-  workerModel?: string;
-  reviewerModel?: string;
-}
-
-export interface McpServerConfig {
-  command: string;
-  args: string[];
+  globalMcpServers: McpServerEntry[];
+  globalInstructions: string[];
+  phases: Record<string, PhaseConfig>;
 }

--- a/tests/ceremonies/ceremony-coverage.test.ts
+++ b/tests/ceremonies/ceremony-coverage.test.ts
@@ -8,6 +8,14 @@ import type {
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
+vi.mock("../../src/acp/session-config.js", () => ({
+  resolveSessionConfig: vi.fn().mockResolvedValue({
+    mcpServers: [],
+    instructions: "",
+    model: undefined,
+  }),
+}));
+
 vi.mock("../../src/github/issues.js", () => ({
   listIssues: vi.fn().mockResolvedValue([]),
   createIssue: vi.fn().mockResolvedValue({ number: 99, title: "mock" }),
@@ -93,7 +101,9 @@ const config: SprintConfig = {
   deleteBranchAfterMerge: true,
   sessionTimeoutMs: 600000,
   customInstructions: "",
-  githubMcp: { command: "npx", args: ["-y", "@github/mcp-server"] },
+  globalMcpServers: [],
+  globalInstructions: [],
+  phases: {},
 };
 
 const sprintResult: SprintResult = {

--- a/tests/ceremonies/execution.test.ts
+++ b/tests/ceremonies/execution.test.ts
@@ -5,6 +5,14 @@ import type {
   QualityResult,
 } from "../../src/types.js";
 
+vi.mock("../../src/acp/session-config.js", () => ({
+  resolveSessionConfig: vi.fn().mockResolvedValue({
+    mcpServers: [],
+    instructions: "",
+    model: undefined,
+  }),
+}));
+
 // Mock all external dependencies
 vi.mock("../../src/git/worktree.js", () => ({
   createWorktree: vi.fn().mockResolvedValue(undefined),
@@ -101,7 +109,9 @@ function makeConfig(overrides: Partial<SprintConfig> = {}): SprintConfig {
     deleteBranchAfterMerge: true,
     sessionTimeoutMs: 60000,
     customInstructions: "",
-    githubMcp: { command: "gh", args: [] },
+    globalMcpServers: [],
+    globalInstructions: [],
+    phases: {},
     ...overrides,
   };
 }
@@ -178,6 +188,7 @@ describe("executeIssue", () => {
     // ACP session created in worktree directory
     expect(mockClient.createSession).toHaveBeenCalledWith({
       cwd: "/tmp/worktrees/issue-42",
+      mcpServers: [],
     });
 
     // Prompt sent

--- a/tests/ceremonies/parallel-dispatcher.test.ts
+++ b/tests/ceremonies/parallel-dispatcher.test.ts
@@ -90,7 +90,9 @@ function makeConfig(overrides: Partial<SprintConfig> = {}): SprintConfig {
     deleteBranchAfterMerge: true,
     sessionTimeoutMs: 60000,
     customInstructions: "",
-    githubMcp: { command: "gh", args: [] },
+    globalMcpServers: [],
+    globalInstructions: [],
+    phases: {},
     ...overrides,
   };
 }

--- a/tests/ceremonies/planning.test.ts
+++ b/tests/ceremonies/planning.test.ts
@@ -74,6 +74,14 @@ describe("extractJson", () => {
 
 // --- runSprintPlanning (mocked) ---
 
+vi.mock("../../src/acp/session-config.js", () => ({
+  resolveSessionConfig: vi.fn().mockResolvedValue({
+    mcpServers: [],
+    instructions: "",
+    model: undefined,
+  }),
+}));
+
 // Mock external dependencies
 vi.mock("../../src/github/issues.js", () => ({
   listIssues: vi.fn(),
@@ -132,7 +140,9 @@ function makeConfig(overrides: Partial<SprintConfig> = {}): SprintConfig {
     deleteBranchAfterMerge: true,
     sessionTimeoutMs: 60000,
     customInstructions: "",
-    githubMcp: { command: "gh", args: [] },
+    globalMcpServers: [],
+    globalInstructions: [],
+    phases: {},
     ...overrides,
   };
 }
@@ -202,6 +212,7 @@ describe("runSprintPlanning", () => {
 
     expect(mockClient.createSession).toHaveBeenCalledWith({
       cwd: "/tmp/test-project",
+      mcpServers: [],
     });
     expect(mockClient.sendPrompt).toHaveBeenCalledOnce();
     expect(mockClient.endSession).toHaveBeenCalledWith("session-123");

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -18,11 +18,21 @@ project:
 
 copilot:
   executable: "copilot"
-  planner_model: "claude-opus-4.6"
-  worker_model: "claude-sonnet-4.5"
-  reviewer_model: "claude-opus-4.6"
   max_parallel_sessions: 2
   session_timeout_ms: 60000
+  mcp_servers:
+    - type: "stdio"
+      name: "github"
+      command: "npx"
+      args: ["-y", "@github/mcp-server"]
+  instructions: []
+  phases:
+    planner:
+      model: "claude-opus-4.6"
+    worker:
+      model: "claude-sonnet-4.5"
+    reviewer:
+      model: "claude-opus-4.6"
 
 sprint:
   max_issues: 4
@@ -51,11 +61,6 @@ git:
   auto_merge: false
   squash_merge: true
   delete_branch_after_merge: false
-
-github:
-  mcp_server:
-    command: "npx"
-    args: ["-y", "@github/mcp-server"]
 `;
 
 describe("loadConfig", () => {
@@ -69,7 +74,7 @@ describe("loadConfig", () => {
     expect(config.sprint.enable_challenger).toBe(false);
     expect(config.quality_gates.max_diff_lines).toBe(200);
     expect(config.git.auto_merge).toBe(false);
-    expect(config.github.mcp_server.command).toBe("npx");
+    expect(config.copilot.mcp_servers[0]!.name).toBe("github");
     expect(config.escalation.notifications.ntfy_topic).toBe("my-topic");
   });
 
@@ -86,7 +91,7 @@ project:
     expect(config.sprint.max_issues).toBe(8);
     expect(config.sprint.max_retries).toBe(2);
     expect(config.git.squash_merge).toBe(true);
-    expect(config.github.mcp_server.command).toBe("npx");
+    expect(config.copilot.mcp_servers).toEqual([]);
   });
 
   it("throws on missing config file", () => {

--- a/tests/enforcement/challenger.test.ts
+++ b/tests/enforcement/challenger.test.ts
@@ -2,6 +2,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { AcpClient } from "../../src/acp/client.js";
 import type { SprintConfig } from "../../src/types.js";
 
+vi.mock("../../src/acp/session-config.js", () => ({
+  resolveSessionConfig: vi.fn().mockResolvedValue({
+    mcpServers: [],
+    instructions: "",
+    model: undefined,
+  }),
+}));
+
 vi.mock("../../src/github/issues.js", () => ({
   execGh: vi.fn(),
   getIssue: vi.fn().mockResolvedValue({
@@ -63,7 +71,9 @@ const config: SprintConfig = {
   deleteBranchAfterMerge: true,
   sessionTimeoutMs: 600000,
   customInstructions: "",
-  githubMcp: { command: "npx", args: ["-y", "@github/mcp-server"] },
+  globalMcpServers: [],
+  globalInstructions: [],
+  phases: {},
 };
 
 describe("runChallengerReview", () => {

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -165,7 +165,9 @@ function makeConfig(overrides: Partial<SprintConfig> = {}): SprintConfig {
     deleteBranchAfterMerge: true,
     sessionTimeoutMs: 600000,
     customInstructions: "",
-    githubMcp: { command: "npx", args: ["-y", "@github/mcp-server"] },
+    globalMcpServers: [],
+    globalInstructions: [],
+    phases: {},
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Adds two-level configuration for MCP servers and instruction files: **global** (every session) + **per-phase** (ceremony-specific).

### Config Structure

```yaml
copilot:
  # Global — every ACP session gets these
  mcp_servers:
    - name: "github"
      type: "stdio"
      command: "npx"
      args: ["-y", "@github/mcp-server"]
  instructions:
    - ".github/copilot-instructions.md"

  # Per-phase — merged with global
  phases:
    planner:
      model: "claude-opus-4.6"
      mcp_servers: []       # extra MCPs for planner only
      instructions: []      # extra instructions for planner only
    worker:
      model: "claude-sonnet-4.5"
      mcp_servers:
        - name: "filesystem"
          type: "stdio"
          command: "npx"
          args: ["-y", "@modelcontextprotocol/server-filesystem"]
```

### What Changed

- **`src/types.ts`**: New `McpServerEntry` (stdio/http/sse), `PhaseConfig`, updated `SprintConfig`
- **`src/config.ts`**: New Zod schemas for MCP server entries and phase config
- **`src/acp/session-config.ts`**: New resolver — `resolveSessionConfig(config, phase)` merges global + phase MCPs/instructions
- **All 7 ceremony modules**: Wired to pass resolved MCPs to `createSession()` and prepend instructions to prompts
- **`sprint-runner.config.yaml`**: Migrated from `github.mcp_server` + flat model fields to new structure
- **21 files changed**, 262 tests pass

### Breaking Changes

- Removed `github.mcp_server` — now under `copilot.mcp_servers[]`
- Removed `copilot.planner_model` / `worker_model` / `reviewer_model` — now under `copilot.phases.{name}.model`
- `SprintConfig.githubMcp` replaced with `globalMcpServers` + `phases`