### PR TITLE
docs(readme): add Quick Start section with CLI examples (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,21 @@ copilot
 # Execution starts automatically after planning
 ```
 
+## Quick Start
+
+Once you have the sprint runner CLI installed, here are the main commands:
+
+```bash
+# Run sprint planning (selects and assigns issues)
+sprint-runner plan --sprint 1
+
+# Execute a specific issue in the current sprint
+sprint-runner execute-issue --issue 42 --sprint 1
+
+# Launch TUI dashboard for sprint oversight and control
+sprint-runner dashboard --sprint 1
+```
+
 ## How It Works
 
 ### The Sprint Cycle in Detail


### PR DESCRIPTION
Closes #15

## Summary

Adds a Quick Start section to README.md with concise CLI usage examples for the sprint-runner commands.

## Changes

- Added Quick Start section after "Start Your First Sprint" subsection
- Includes examples for three main commands:
  - `sprint-runner plan --sprint N` — Run sprint planning
  - `sprint-runner execute-issue --issue N --sprint N` — Execute a specific issue
  - `sprint-runner dashboard --sprint N` — Launch TUI dashboard

## Test Coverage

Documentation-only change. Verified:
- ✅ Lint clean (0 errors)
- ✅ Type check clean (0 errors)
- ✅ All tests pass (274/274)
- ✅ Diff size: 15 lines (well under 300)

## Definition of Done

- [x] Code implemented — addresses all acceptance criteria
- [x] Lint clean — 0 errors
- [x] Type clean — 0 errors
- [x] Tests pass — 274/274 passing
- [x] Diff size — 15 lines (≤ 300)
- [x] No unrelated changes — only README.md modified