### PR TITLE
fix: make huddle comment and label posting resilient to API failures

### DIFF
--- a/src/ceremonies/execution.ts
+++ b/src/ceremonies/execution.ts
@@ -277,15 +277,23 @@ export async function executeIssue(
     };
 
     const comment = formatHuddleComment(huddleEntry);
-    await addComment(issue.number, comment);
+    try {
+      await addComment(issue.number, comment);
+    } catch (err: unknown) {
+      log.warn({ err, issueNumber: issue.number }, "failed to post huddle comment — non-critical");
+    }
 
     const logEntry = formatSprintLogEntry(huddleEntry);
     appendToSprintLog(config.sprintNumber, logEntry);
 
     // Step 9: Set final label
     const finalLabel = status === "completed" ? "status:done" : "status:blocked";
-    await setLabel(issue.number, finalLabel);
-    log.info({ status, finalLabel }, "final status set");
+    try {
+      await setLabel(issue.number, finalLabel);
+      log.info({ status, finalLabel }, "final status set");
+    } catch (err: unknown) {
+      log.warn({ err, issueNumber: issue.number, finalLabel }, "failed to set final label — non-critical");
+    }
   }
 
   const duration_ms = Date.now() - startTime;


### PR DESCRIPTION
Wraps post-execution GitHub API calls (huddle comment + final label) in try/catch so transient API failures don't crash the run when the actual work already passed quality gates.

Found during E2E test: issue #15 completed successfully (plan + implement + 5/5 QG) but a GitHub API connectivity blip during huddle comment posting threw an unhandled error.