### PR TITLE
feat: add code review step to execution pipeline

### DIFF
--- a/src/documentation/huddle.ts
+++ b/src/documentation/huddle.ts
@@ -33,10 +33,24 @@ export function formatHuddleComment(entry: HuddleEntry): string {
     "",
     "**Quality Checks**:",
     checks,
+  ];
+
+  if (entry.codeReview) {
+    const reviewIcon = entry.codeReview.approved ? "✅" : "⚠️";
+    lines.push(
+      "",
+      `**Code Review**: ${reviewIcon} ${entry.codeReview.approved ? "APPROVED" : "CHANGES REQUESTED"}`,
+    );
+    if (entry.codeReview.issues.length > 0) {
+      lines.push(...entry.codeReview.issues.map((i) => `  - ${i}`));
+    }
+  }
+
+  lines.push(
     "",
     `**Files Changed** (${entry.filesChanged.length}):`,
     files,
-  ];
+  );
 
   if (entry.cleanupWarning) {
     lines.push("", entry.cleanupWarning);

--- a/src/enforcement/code-review.ts
+++ b/src/enforcement/code-review.ts
@@ -1,0 +1,90 @@
+// Automated code review step in the execution pipeline.
+// Runs after quality gate passes. Uses ACP with the reviewer model
+// to analyze the diff for bugs, security issues, and logic errors.
+
+import type { AcpClient } from "../acp/client.js";
+import type { SprintConfig, SprintIssue, CodeReviewResult } from "../types.js";
+import { resolveSessionConfig } from "../acp/session-config.js";
+import { diffStat } from "../git/diff-analysis.js";
+import { logger } from "../logger.js";
+
+/**
+ * Run an automated code review on a branch via ACP.
+ * Returns approval status and feedback. If rejected, the caller
+ * can send feedback to the worker for a fix attempt.
+ */
+export async function runCodeReview(
+  client: AcpClient,
+  config: SprintConfig,
+  issue: SprintIssue,
+  branch: string,
+  worktreePath: string,
+): Promise<CodeReviewResult> {
+  const log = logger.child({ module: "code-review", issue: issue.number });
+
+  log.info({ branch }, "starting automated code review");
+
+  const stat = await diffStat(branch, config.baseBranch);
+
+  const sessionConfig = await resolveSessionConfig(config, "reviewer");
+  const { sessionId } = await client.createSession({
+    cwd: worktreePath,
+    mcpServers: sessionConfig.mcpServers,
+  });
+
+  try {
+    if (sessionConfig.model) {
+      await client.setModel(sessionId, sessionConfig.model);
+    }
+
+    const prompt = [
+      ...(sessionConfig.instructions ? [sessionConfig.instructions, ""] : []),
+      "You are an automated code reviewer. Review the changes on this branch.",
+      "Focus ONLY on issues that genuinely matter:",
+      "- Bugs and logic errors",
+      "- Security vulnerabilities",
+      "- Missing error handling that could cause crashes",
+      "- Breaking changes to public APIs",
+      "",
+      "Do NOT comment on: style, formatting, naming preferences, or minor suggestions.",
+      "",
+      `## Issue #${issue.number}: ${issue.title}`,
+      `Acceptance criteria: ${issue.acceptanceCriteria}`,
+      "",
+      `## Diff Stats`,
+      `- Lines changed: ${stat.linesChanged}`,
+      `- Files changed: ${stat.filesChanged}`,
+      `- Files: ${stat.files.join(", ")}`,
+      "",
+      `## Branch: ${branch} (base: ${config.baseBranch})`,
+      "",
+      "Review the actual file changes using the tools available to you.",
+      "Read the changed files and the diff to understand what was modified.",
+      "",
+      "Respond with EXACTLY one of these on the FIRST line:",
+      "APPROVED: <one-line summary of what looks good>",
+      "CHANGES_REQUESTED: <one-line summary of what needs fixing>",
+      "",
+      "Then list any issues found, one per line, prefixed with '- '.",
+      "If approved, you may still list non-blocking suggestions prefixed with '- [suggestion] '.",
+    ].join("\n");
+
+    const result = await client.sendPrompt(sessionId, prompt, config.sessionTimeoutMs);
+    const response = result.response.trim();
+
+    const firstLine = response.split("\n")[0] ?? "";
+    const approved = firstLine.toUpperCase().startsWith("APPROVED");
+
+    // Extract issue lines
+    const issues = response
+      .split("\n")
+      .filter((line) => line.startsWith("- ") && !line.toLowerCase().includes("[suggestion]"))
+      .map((line) => line.slice(2).trim());
+
+    log.info({ approved, issueCount: issues.length }, "code review completed");
+
+    return { approved, feedback: response, issues };
+  } finally {
+    await client.endSession(sessionId);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,11 +22,18 @@ export interface SprintPlan {
 
 // --- Issue Execution ---
 
+export interface CodeReviewResult {
+  approved: boolean;
+  feedback: string;
+  issues: string[];
+}
+
 export interface IssueResult {
   issueNumber: number;
   status: "completed" | "failed" | "in-progress";
   qualityGatePassed: boolean;
   qualityDetails: QualityResult;
+  codeReview?: CodeReviewResult;
   branch: string;
   duration_ms: number;
   filesChanged: string[];
@@ -117,6 +124,7 @@ export interface HuddleEntry {
   issueTitle: string;
   status: "completed" | "failed";
   qualityResult: QualityResult;
+  codeReview?: CodeReviewResult;
   duration_ms: number;
   filesChanged: string[];
   timestamp: Date;

--- a/tests/enforcement/code-review.test.ts
+++ b/tests/enforcement/code-review.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { runCodeReview } from "../../src/enforcement/code-review.js";
+import type { SprintConfig, SprintIssue } from "../../src/types.js";
+
+vi.mock("../../src/acp/session-config.js", () => ({
+  resolveSessionConfig: vi.fn().mockResolvedValue({
+    mcpServers: [],
+    model: "claude-sonnet-4",
+    instructions: null,
+  }),
+}));
+
+vi.mock("../../src/git/diff-analysis.js", () => ({
+  diffStat: vi.fn().mockResolvedValue({
+    linesChanged: 42,
+    filesChanged: 2,
+    files: ["src/foo.ts", "tests/foo.test.ts"],
+  }),
+}));
+
+vi.mock("../../src/logger.js", () => ({
+  logger: {
+    child: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}));
+
+function createMockClient() {
+  return {
+    createSession: vi.fn().mockResolvedValue({ sessionId: "review-session-1" }),
+    endSession: vi.fn().mockResolvedValue(undefined),
+    sendPrompt: vi.fn(),
+    setModel: vi.fn().mockResolvedValue(undefined),
+    setMode: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const baseConfig: SprintConfig = {
+  sprintNumber: 1,
+  baseBranch: "main",
+  projectPath: "/test/project",
+  maxRetries: 1,
+  maxParallelSessions: 2,
+  sessionTimeoutMs: 60000,
+  worktreeBase: "/tmp/worktrees",
+  autoApproveTools: true,
+  globalMcpServers: [],
+  globalInstructions: [],
+  phases: {},
+};
+
+const issue: SprintIssue = {
+  number: 42,
+  title: "Add foo feature",
+  acceptanceCriteria: "Should do foo",
+  points: 3,
+};
+
+describe("runCodeReview", () => {
+  let client: ReturnType<typeof createMockClient>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = createMockClient();
+  });
+
+  it("returns approved when reviewer says APPROVED", async () => {
+    client.sendPrompt.mockResolvedValue({
+      response: "APPROVED: Clean implementation, tests cover all cases.\n- [suggestion] Consider adding JSDoc.",
+    });
+
+    const result = await runCodeReview(
+      client as never,
+      baseConfig,
+      issue,
+      "sprint/1/issue-42",
+      "/tmp/worktrees/issue-42",
+    );
+
+    expect(result.approved).toBe(true);
+    expect(result.issues).toHaveLength(0); // suggestions are filtered out
+    expect(result.feedback).toContain("APPROVED");
+  });
+
+  it("returns rejected with issues when reviewer says CHANGES_REQUESTED", async () => {
+    client.sendPrompt.mockResolvedValue({
+      response: [
+        "CHANGES_REQUESTED: Missing error handling in edge case",
+        "- uncaught exception in parseInput when input is null",
+        "- no validation for negative numbers",
+      ].join("\n"),
+    });
+
+    const result = await runCodeReview(
+      client as never,
+      baseConfig,
+      issue,
+      "sprint/1/issue-42",
+      "/tmp/worktrees/issue-42",
+    );
+
+    expect(result.approved).toBe(false);
+    expect(result.issues).toHaveLength(2);
+    expect(result.issues[0]).toContain("uncaught exception");
+    expect(result.issues[1]).toContain("no validation");
+  });
+
+  it("creates and tears down a session", async () => {
+    client.sendPrompt.mockResolvedValue({ response: "APPROVED: looks good" });
+
+    await runCodeReview(
+      client as never,
+      baseConfig,
+      issue,
+      "sprint/1/issue-42",
+      "/tmp/worktrees/issue-42",
+    );
+
+    expect(client.createSession).toHaveBeenCalledWith({
+      cwd: "/tmp/worktrees/issue-42",
+      mcpServers: [],
+    });
+    expect(client.endSession).toHaveBeenCalledWith("review-session-1");
+  });
+
+  it("sets the reviewer model", async () => {
+    client.sendPrompt.mockResolvedValue({ response: "APPROVED: ok" });
+
+    await runCodeReview(
+      client as never,
+      baseConfig,
+      issue,
+      "sprint/1/issue-42",
+      "/tmp/worktrees/issue-42",
+    );
+
+    expect(client.setModel).toHaveBeenCalledWith("review-session-1", "claude-sonnet-4");
+  });
+
+  it("ends session even if sendPrompt throws", async () => {
+    client.sendPrompt.mockRejectedValue(new Error("timeout"));
+
+    await expect(
+      runCodeReview(
+        client as never,
+        baseConfig,
+        issue,
+        "sprint/1/issue-42",
+        "/tmp/worktrees/issue-42",
+      ),
+    ).rejects.toThrow("timeout");
+
+    expect(client.endSession).toHaveBeenCalledWith("review-session-1");
+  });
+
+  it("handles empty response", async () => {
+    client.sendPrompt.mockResolvedValue({ response: "" });
+
+    const result = await runCodeReview(
+      client as never,
+      baseConfig,
+      issue,
+      "sprint/1/issue-42",
+      "/tmp/worktrees/issue-42",
+    );
+
+    // Empty response defaults to not-approved (doesn't start with APPROVED)
+    expect(result.approved).toBe(false);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it("filters out suggestion lines from issues list", async () => {
+    client.sendPrompt.mockResolvedValue({
+      response: [
+        "APPROVED: implementation is correct",
+        "- [suggestion] rename variable for clarity",
+        "- [Suggestion] add more tests",
+      ].join("\n"),
+    });
+
+    const result = await runCodeReview(
+      client as never,
+      baseConfig,
+      issue,
+      "sprint/1/issue-42",
+      "/tmp/worktrees/issue-42",
+    );
+
+    expect(result.approved).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an automated code review step to the execution pipeline, running after the quality gate passes.

### Pipeline Flow

```
Plan → Implement → Quality Gate → Code Review → (fix if rejected) → Huddle
```

### Changes

- **New**: `src/enforcement/code-review.ts` — `runCodeReview()` sends diff to ACP reviewer model
- **New**: `tests/enforcement/code-review.test.ts` — 7 tests
- **Modified**: `src/ceremonies/execution.ts` — wired code review into pipeline (Step 8)
- **Modified**: `src/types.ts` — added `CodeReviewResult` type, added to `IssueResult` and `HuddleEntry`
- **Modified**: `src/documentation/huddle.ts` — shows code review result in huddle comment

### How it works

1. After quality gate passes, `runCodeReview()` creates an ACP session with the `reviewer` phase config
2. Reviewer analyzes the diff for bugs, security issues, logic errors (not style/formatting)
3. If APPROVED → proceed to huddle
4. If CHANGES_REQUESTED → send feedback to worker, re-run quality gate + review (one retry)
5. Code review failure is non-blocking — logged but doesn't fail the issue

### Test Results

281 tests passing across 30 files. Build clean, lint clean.