### PR TITLE
feat: dashboard starts idle, press [g]o to start

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -14,9 +14,10 @@ const MAX_WORKER_LINES = 20;
 
 export interface AppProps {
   runner: SprintRunner;
+  onStart?: () => void;
 }
 
-export function App({ runner }: AppProps): React.ReactElement {
+export function App({ runner, onStart }: AppProps): React.ReactElement {
   const { exit } = useApp();
   const initialState = runner.getState();
 
@@ -118,8 +119,16 @@ export function App({ runner }: AppProps): React.ReactElement {
     });
   }, [runner]);
 
+  const [isRunning, setIsRunning] = React.useState(false);
+
   useInput((input) => {
     switch (input) {
+      case "g":
+        if (!isRunning && onStart) {
+          setIsRunning(true);
+          onStart();
+        }
+        break;
       case "p":
         runner.pause();
         break;
@@ -158,7 +167,7 @@ export function App({ runner }: AppProps): React.ReactElement {
         />
       </Box>
       <LogPanel entries={logEntries} maxEntries={logHeight - 2} />
-      <CommandBar isPaused={isPaused} />
+      <CommandBar isPaused={isPaused} isRunning={isRunning} />
     </Box>
   );
 }

--- a/src/tui/CommandBar.tsx
+++ b/src/tui/CommandBar.tsx
@@ -3,18 +3,26 @@ import { Box, Text } from "ink";
 
 export interface CommandBarProps {
   isPaused: boolean;
+  isRunning: boolean;
 }
 
-export function CommandBar({ isPaused }: CommandBarProps): React.ReactElement {
+export function CommandBar({ isPaused, isRunning }: CommandBarProps): React.ReactElement {
   return (
     <Box paddingX={1} gap={2}>
-      <Text dimColor={isPaused} bold={!isPaused} color={!isPaused ? "yellow" : undefined}>
-        [p]ause
-      </Text>
-      <Text dimColor={!isPaused} bold={isPaused} color={isPaused ? "green" : undefined}>
-        [r]esume
-      </Text>
-      <Text bold color="cyan">[s]kip</Text>
+      {!isRunning && (
+        <Text bold color="green">[g]o</Text>
+      )}
+      {isRunning && (
+        <>
+          <Text dimColor={isPaused} bold={!isPaused} color={!isPaused ? "yellow" : undefined}>
+            [p]ause
+          </Text>
+          <Text dimColor={!isPaused} bold={isPaused} color={isPaused ? "green" : undefined}>
+            [r]esume
+          </Text>
+          <Text bold color="cyan">[s]kip</Text>
+        </>
+      )}
       <Text bold color="red">[q]uit</Text>
     </Box>
   );


### PR DESCRIPTION
Dashboard no longer auto-starts. Opens idle, press `g` to go.

- Default: idle dashboard with `[g]o` button
- `--run`: auto-start sprint loop on launch  
- `--once`: auto-start single sprint
- CommandBar shows `[g]o` when idle, `[p]ause/[r]esume` when running

289 tests, build clean, lint clean.