### PR TITLE
docs(metrics): add JSDoc to exported functions (#21)

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,10 +1,21 @@
 import type { SprintResult, SprintMetrics } from "./types.js";
 
+/**
+ * Calculates a rounded integer percentage.
+ * @param part - The numerator value
+ * @param total - The denominator value
+ * @returns Rounded percentage (0–100). Returns 0 when total is 0.
+ */
 export function percent(part: number, total: number): number {
   if (total === 0) return 0;
   return Math.round((part / total) * 100);
 }
 
+/**
+ * Formats a duration in milliseconds into a human-readable string.
+ * @param ms - Duration in milliseconds
+ * @returns Formatted string (e.g. '500ms', '5s', '2m', '2m 30s')
+ */
 export function formatDuration(ms: number): string {
   if (ms < 1000) return `${ms}ms`;
   const totalSeconds = Math.floor(ms / 1000);
@@ -15,6 +26,13 @@ export function formatDuration(ms: number): string {
   return `${minutes}m ${seconds}s`;
 }
 
+/**
+ * Calculates aggregate metrics for a completed sprint.
+ * Computes counts (planned, completed, failed), story points,
+ * velocity, average duration, first-pass rate, and drift incidents.
+ * @param result - The sprint result containing all issue outcomes
+ * @returns Computed sprint metrics
+ */
 export function calculateSprintMetrics(result: SprintResult): SprintMetrics {
   const { results } = result;
   const planned = results.length;
@@ -48,6 +66,12 @@ export function calculateSprintMetrics(result: SprintResult): SprintMetrics {
   };
 }
 
+/**
+ * Returns the most commonly failed quality gates, sorted by frequency.
+ * @param result - The sprint result containing quality check details
+ * @returns Comma-separated string of gate names with counts (e.g. 'lint (2), tests (1)'),
+ *          or an empty string if no gates failed.
+ */
 export function topFailedGates(result: SprintResult): string {
   const counts = new Map<string, number>();
   for (const issue of result.results) {


### PR DESCRIPTION
Closes #21

## Summary
Added JSDoc comments to all 4 exported functions in `src/metrics.ts`:
- `percent()` - Percentage calculation with zero-total safety
- `formatDuration()` - Human-readable duration formatting
- `calculateSprintMetrics()` - Sprint metrics computation
- `topFailedGates()` - Quality gate failure summary

## Changes
- **Single file modified**: `src/metrics.ts` (+24 lines)
- **Documentation-only** — no logic changes

## Test Coverage
All existing tests pass (289/289 tests):
- `tests/metrics.test.ts`: 15 test cases covering all functions
- No new tests needed for documentation-only change

## Definition of Done ✅
- [x] Code implemented — JSDoc added to all 4 exported functions
- [x] Lint clean — 0 errors (23 pre-existing warnings in unrelated files)
- [x] Type clean — 0 errors
- [x] Tests pass — 289/289 passed
- [x] Diff size — 24 lines (well under 300 limit)
- [x] No unrelated changes — only `src/metrics.ts` modified