### PR TITLE
docs(ci): add test coverage badge (#25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,33 @@ jobs:
       - name: Type check
         run: npm run typecheck
 
-      - name: Test
-        run: npm run test
+      - name: Test with Coverage
+        run: npm run test:coverage
+
+      - name: Extract Coverage
+        if: github.ref == 'refs/heads/main'
+        id: coverage
+        run: |
+          COVERAGE=$(jq '.total.lines.pct' coverage/coverage-summary.json)
+          echo "percentage=$COVERAGE" >> $GITHUB_OUTPUT
+          if (( $(echo "$COVERAGE >= 80" | bc -l) )); then
+            echo "color=brightgreen" >> $GITHUB_OUTPUT
+          elif (( $(echo "$COVERAGE >= 60" | bc -l) )); then
+            echo "color=yellow" >> $GITHUB_OUTPUT
+          else
+            echo "color=red" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update Coverage Badge
+        if: github.ref == 'refs/heads/main'
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: TBD
+          filename: coverage-badge.json
+          label: coverage
+          message: ${{ steps.coverage.outputs.percentage }}%
+          color: ${{ steps.coverage.outputs.color }}
 
       - name: Build
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Optimized for GitHub Copilot CLI](https://img.shields.io/badge/Optimized%20for-GitHub%20Copilot%20CLI-blue?logo=github)](https://docs.github.com/en/copilot)
 [![Framework Docs](https://img.shields.io/badge/Framework-AI--Scrum-6c63ff)](https://trsdn.github.io/ai-scrum/)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/trsdn/TBD/raw/coverage-badge.json)](https://github.com/trsdn/ai-scrum-autonomous-v2/actions)
 
 A template repository for **autonomous Scrum development** powered by GitHub Copilot CLI. The AI agent acts as both **Product Owner and Scrum Master**, while the human serves as a **Stakeholder** with veto rights.
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     include: ["tests/**/*.test.ts"],
     coverage: {
       provider: "v8",
+      reporter: ["json-summary"],
       include: ["src/**/*.ts"],
       exclude: ["src/index.ts"],
     },


### PR DESCRIPTION
Closes #25

## Summary

Adds a dynamic test coverage badge to the README, powered by CI-generated coverage data stored in a GitHub Gist.

## Changes

- Modified `vitest.config.ts` to add `json-summary` reporter for coverage parsing
- Updated `.github/workflows/ci.yml` to:
  - Run `test:coverage` instead of `test`
  - Extract coverage percentage from `coverage-summary.json`
  - Update Gist-backed badge (main branch only)
- Added coverage badge to README after existing badges

## Test Strategy

This is a CI/documentation change — no new test files required.

**Verification performed:**
- ✅ `npm run test` — 333 tests passed
- ✅ `npm run test:coverage` — generates `coverage-summary.json` with expected structure (78.63% coverage)
- ✅ `npm run lint` — 0 errors
- ✅ `npm run typecheck` — clean
- ✅ Diff size — 31 lines (under 300 limit)

## Setup Required

**One-time manual steps** (to be completed before/after merge):

1. Create a GitHub Gist named `coverage-badge.json` — note the Gist ID
2. Create a GitHub PAT with `gist` scope
3. Add repository secret `GIST_SECRET` with the PAT value
4. Replace `TBD` placeholders in `.github/workflows/ci.yml` and `README.md` with actual Gist ID

## Definition of Done

- [x] Code implemented — addresses all acceptance criteria
- [x] Lint clean — `npm run lint` shows 0 errors
- [x] Type clean — `npm run typecheck` shows 0 errors
- [x] Tests pass — `npm run test` shows 0 failures
- [x] Diff size — 31 lines (well under 300 limit)
- [x] No unrelated changes — only CI/docs files modified
- [x] Conventional commit format used