### PR TITLE
feat: replace raw stream WorkerPanel with ActivityPanel

### DIFF
--- a/src/tui/WorkerPanel.tsx
+++ b/src/tui/WorkerPanel.tsx
@@ -1,25 +1,61 @@
 import React from "react";
 import { Box, Text } from "ink";
+import type { SprintPhase } from "../runner.js";
 
-export interface WorkerPanelProps {
-  lines: string[];
-  currentIssue: number | null;
-  model: string | null;
-  duration: string | null;
+export interface ActivityItem {
+  label: string;
+  status: "active" | "done" | "waiting";
+  detail?: string;
 }
 
-export function WorkerPanel({ lines, currentIssue, model, duration }: WorkerPanelProps): React.ReactElement {
+export interface ActivityPanelProps {
+  phase: SprintPhase;
+  currentIssue: number | null;
+  activities: ActivityItem[];
+}
+
+function phaseLabel(phase: SprintPhase): string {
+  switch (phase) {
+    case "init": return "Initializing…";
+    case "refine": return "Refining backlog…";
+    case "plan": return "Planning sprint…";
+    case "execute": return "Executing issues…";
+    case "review": return "Running sprint review…";
+    case "retro": return "Running retrospective…";
+    case "complete": return "Sprint complete ✓";
+    case "paused": return "Paused";
+    case "failed": return "Sprint failed ✗";
+  }
+}
+
+function statusIcon(status: ActivityItem["status"]): React.ReactElement {
+  switch (status) {
+    case "active":
+      return <Text color="yellow">▸ </Text>;
+    case "done":
+      return <Text color="green">✓ </Text>;
+    case "waiting":
+      return <Text dimColor>○ </Text>;
+  }
+}
+
+export function ActivityPanel({ phase, currentIssue, activities }: ActivityPanelProps): React.ReactElement {
   return (
     <Box flexDirection="column" borderStyle="single" paddingX={1} flexGrow={2}>
       <Box>
-        <Text bold underline>Worker</Text>
+        <Text bold underline>Activity</Text>
         {currentIssue != null && <Text> │ #{currentIssue}</Text>}
-        {model && <Text> │ {model}</Text>}
-        {duration && <Text> │ {duration}</Text>}
+      </Box>
+      <Box marginTop={1}>
+        <Text bold>{phaseLabel(phase)}</Text>
       </Box>
       <Box flexDirection="column" marginTop={1}>
-        {lines.map((line, i) => (
-          <Text key={i} dimColor>{line}</Text>
+        {activities.map((a, i) => (
+          <Box key={i}>
+            {statusIcon(a.status)}
+            <Text dimColor={a.status === "waiting"}>{a.label}</Text>
+            {a.detail && <Text dimColor> — {a.detail}</Text>}
+          </Box>
         ))}
       </Box>
     </Box>


### PR DESCRIPTION
The WorkerPanel showed unreadable raw ACP stream chunks. Replaced with a structured ActivityPanel:

```
┌ Activity │ #20 ─────────────────┐
│ Executing issues…               │
│                                  │
│ ✓ Refining backlog               │
│ ✓ Planning sprint                │
│ ▸ #20 Add JSDoc to logger.ts     │
│ ○ #21 Add JSDoc to metrics.ts    │
└──────────────────────────────────┘
```

289 tests, build clean, lint clean.