### PR TITLE
feat: sprint resume after crash + agent/model display

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -385,15 +385,23 @@ program
         SprintRunner.sprintLoop(
           (sprintNumber) => buildSprintConfig(config, sprintNumber),
           eventBus,
-        ).finally(() => {
-          setTimeout(() => { cleanup(); process.exit(0); }, 2000);
+        ).then((results) => {
+          const allComplete = results.every((s) => s.phase === "complete");
+          if (allComplete && results.length > 0) {
+            // All sprints done — keep dashboard open, user can quit with [q]
+            eventBus.emitTyped("log", { level: "info", message: "All sprints complete. Press [q] to quit." });
+          }
+          // On failure: dashboard stays open so user can see the error
         });
       };
 
       // Start single sprint (called by --once flag)
       const startOnce = () => {
-        runner.fullCycle().finally(() => {
-          setTimeout(() => { cleanup(); process.exit(0); }, 2000);
+        runner.fullCycle().then((state) => {
+          if (state.phase === "complete") {
+            eventBus.emitTyped("log", { level: "info", message: "Sprint complete. Press [q] to quit." });
+          }
+          // On failure: dashboard stays open so user can see the error
         });
       };
 

--- a/src/tui/events.ts
+++ b/src/tui/events.ts
@@ -5,12 +5,12 @@ import type { SprintPhase } from "../runner.js";
 import type { SprintIssue, QualityResult } from "../types.js";
 
 export interface SprintEngineEvents {
-  "phase:change": { from: SprintPhase; to: SprintPhase };
-  "issue:start": { issue: SprintIssue };
+  "phase:change": { from: SprintPhase; to: SprintPhase; model?: string };
+  "issue:start": { issue: SprintIssue; model?: string };
   "issue:done": { issueNumber: number; quality: QualityResult; duration_ms: number };
   "issue:fail": { issueNumber: number; reason: string; duration_ms: number };
   "worker:output": { sessionId: string; text: string };
-  "sprint:start": { sprintNumber: number };
+  "sprint:start": { sprintNumber: number; resumed?: boolean };
   "sprint:complete": { sprintNumber: number };
   "sprint:error": { error: string };
   "sprint:paused": Record<string, never>;


### PR DESCRIPTION
## Three improvements

### 1. Resume after crash
If a sprint crashes, restarting the dashboard auto-detects the saved state file (`docs/sprints/sprint-N-state.json`) and resumes:
- Has plan? → skip refine+plan, go to execute
- Has result? → skip to review
- Already reviewed? → skip to retro

The log shows 'Resuming Sprint N from execute phase'.

### 2. Agent/model in Activity panel
Phase transitions and issue execution now show which model is working:
```
✓ Refining backlog
▸ Planning sprint — claude-opus-4.6
○ Executing issues — claude-sonnet-4.5
```

### 3. Stay open on failure
Dashboard no longer auto-closes when a sprint fails. Stays open so you can read the error in the log panel and press [q] to quit.

289 tests, build clean, lint clean.