### PR TITLE
fix: show agent roles and prevent app close on errors

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -46,7 +46,7 @@ export function App({ runner, onStart, initialIssues }: AppProps): React.ReactEl
   React.useEffect(() => {
     const bus = runner.events;
 
-    bus.onTyped("phase:change", ({ from, to, model }) => {
+    bus.onTyped("phase:change", ({ from, to, model, agent }) => {
       setPhase(to);
       if (to === "init" && (from === "complete" || from === "failed")) {
         setIssues([]);
@@ -66,7 +66,9 @@ export function App({ runner, onStart, initialIssues }: AppProps): React.ReactEl
           failed: "Sprint failed",
         };
         const status = (to === "complete" || to === "failed") ? "done" as const : "active" as const;
-        addActivity(labels[to] ?? to, status, model);
+        // Show agent role + model: "Planning Agent (claude-opus-4.6)"
+        const detail = agent && model ? `${agent} (${model})` : agent ?? model;
+        addActivity(labels[to] ?? to, status, detail);
       }
     });
 

--- a/src/tui/events.ts
+++ b/src/tui/events.ts
@@ -5,7 +5,7 @@ import type { SprintPhase } from "../runner.js";
 import type { SprintIssue, QualityResult } from "../types.js";
 
 export interface SprintEngineEvents {
-  "phase:change": { from: SprintPhase; to: SprintPhase; model?: string };
+  "phase:change": { from: SprintPhase; to: SprintPhase; model?: string; agent?: string };
   "issue:start": { issue: SprintIssue; model?: string };
   "issue:done": { issueNumber: number; quality: QualityResult; duration_ms: number };
   "issue:fail": { issueNumber: number; reason: string; duration_ms: number };


### PR DESCRIPTION
## Changes

### Agent Roles in Activity Panel
- Phase transitions now include agent role name alongside model
- Activity shows: Planning sprint — Planning Agent (claude-opus-4.6)
- Roles: Refinement Agent, Planning Agent, Worker Agent, Review Agent, Retro Agent

### Prevent App Close on Errors
- Added .catch() to startLoop and startOnce
- Added unhandledRejection + uncaughtException handlers in TUI mode
- Wrapped getNextOpenMilestone() in try/catch in sprintLoop
- Dashboard stays open on ANY error

### Testing
- 289 tests passing, 0 lint errors