### PR TITLE
feat: elapsed timer and execution progress in dashboard

### DIFF
--- a/src/ceremonies/parallel-dispatcher.ts
+++ b/src/ceremonies/parallel-dispatcher.ts
@@ -12,6 +12,8 @@ import { mergeBranch } from "../git/merge.js";
 import { setLabel } from "../github/labels.js";
 import { logger } from "../logger.js";
 
+import type { SprintEventBus } from "../tui/events.js";
+
 /**
  * Execute sprint issues in parallel, respecting dependency groups.
  * Groups run sequentially; issues within a group run concurrently
@@ -21,6 +23,7 @@ export async function runParallelExecution(
   client: AcpClient,
   config: SprintConfig,
   plan: SprintPlan,
+  eventBus?: SprintEventBus,
 ): Promise<SprintResult> {
   const log = logger.child({ ceremony: "parallel-dispatcher" });
   const groups = buildExecutionGroups(plan.sprint_issues);
@@ -41,7 +44,7 @@ export async function runParallelExecution(
           if (!issue) {
             throw new Error(`Issue #${issueNumber} not found in sprint plan`);
           }
-          return executeIssue(client, config, issue);
+          return executeIssue(client, config, issue, eventBus);
         }),
       ),
     );

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -306,7 +306,7 @@ export class SprintRunner {
       this.events.emitTyped("issue:start", { issue, model: workerModel });
     }
 
-    const result = await runParallelExecution(this.client, this.config, plan);
+    const result = await runParallelExecution(this.client, this.config, plan, this.events);
     this.state.result = result;
 
     // Emit issue:done / issue:fail for each result

--- a/src/tui/WorkerPanel.tsx
+++ b/src/tui/WorkerPanel.tsx
@@ -6,6 +6,7 @@ export interface ActivityItem {
   label: string;
   status: "active" | "done" | "waiting";
   detail?: string;
+  startedAt?: number;
 }
 
 export interface ActivityPanelProps {
@@ -28,6 +29,14 @@ function phaseLabel(phase: SprintPhase): string {
   }
 }
 
+function formatElapsed(ms: number): string {
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  const rem = secs % 60;
+  return `${mins}m${rem.toString().padStart(2, "0")}s`;
+}
+
 function statusIcon(status: ActivityItem["status"]): React.ReactElement {
   switch (status) {
     case "active":
@@ -37,6 +46,15 @@ function statusIcon(status: ActivityItem["status"]): React.ReactElement {
     case "waiting":
       return <Text dimColor>○ </Text>;
   }
+}
+
+function ElapsedTimer({ startedAt }: { startedAt: number }): React.ReactElement {
+  const [elapsed, setElapsed] = React.useState(Date.now() - startedAt);
+  React.useEffect(() => {
+    const interval = setInterval(() => setElapsed(Date.now() - startedAt), 1000);
+    return () => clearInterval(interval);
+  }, [startedAt]);
+  return <Text color="cyan"> {formatElapsed(elapsed)}</Text>;
 }
 
 export function ActivityPanel({ phase, currentIssue, activities }: ActivityPanelProps): React.ReactElement {
@@ -55,6 +73,7 @@ export function ActivityPanel({ phase, currentIssue, activities }: ActivityPanel
             {statusIcon(a.status)}
             <Text dimColor={a.status === "waiting"}>{a.label}</Text>
             {a.detail && <Text dimColor> — {a.detail}</Text>}
+            {a.status === "active" && a.startedAt && <ElapsedTimer startedAt={a.startedAt} />}
           </Box>
         ))}
       </Box>

--- a/src/tui/events.ts
+++ b/src/tui/events.ts
@@ -7,6 +7,7 @@ import type { SprintIssue, QualityResult } from "../types.js";
 export interface SprintEngineEvents {
   "phase:change": { from: SprintPhase; to: SprintPhase; model?: string; agent?: string };
   "issue:start": { issue: SprintIssue; model?: string };
+  "issue:progress": { issueNumber: number; step: string };
   "issue:done": { issueNumber: number; quality: QualityResult; duration_ms: number };
   "issue:fail": { issueNumber: number; reason: string; duration_ms: number };
   "worker:output": { sessionId: string; text: string };


### PR DESCRIPTION
## Problem
Dashboard showed zero feedback during long-running operations (planning: 3+ min, execution per issue: 2+ min). User thought the app was stuck.

## Solution

### Elapsed Timer
- Active items show a live elapsed timer: `▸ Planning sprint — Planning Agent (opus-4.6) 2m30s`
- Timer updates every second, stops when item completes

### Granular Execution Progress
- New `issue:progress` event emitted at each execution step
- Steps: creating worktree → planning implementation → implementing → quality gate → code review
- Each issue shows its current step in real-time: `▸ #27 Add @deprecated tag — implementing 1m15s`

### Parallel Issue Tracking
- Issues run in parallel and each has its own activity line
- Completion/failure updates the existing line (no duplicate entries)

### Files Changed
- `src/tui/WorkerPanel.tsx` — ElapsedTimer component, startedAt on ActivityItem
- `src/tui/events.ts` — issue:progress event type
- `src/tui/App.tsx` — parallel activity tracking, in-place updates, formatDuration
- `src/ceremonies/execution.ts` — progress() calls at each step
- `src/ceremonies/parallel-dispatcher.ts` — pass eventBus through
- `src/runner.ts` — pass this.events to runParallelExecution

### Testing
- 289 tests passing, 0 lint errors