### PR TITLE
fix: load saved sprint state on dashboard startup

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -109,6 +109,16 @@ export class SprintRunner {
     return this.client;
   }
 
+  /** Load saved state from disk (if any). Updates the runner's state for dashboard display. */
+  loadSavedState(): SprintState | null {
+    const previous = this.tryLoadPreviousState();
+    if (previous) {
+      this.state = { ...previous };
+      this.log.info({ phase: previous.phase }, "Loaded saved sprint state");
+    }
+    return previous;
+  }
+
   /** Run the full sprint cycle, resuming from a previous crash if state exists. */
   async fullCycle(): Promise<SprintState> {
     try {


### PR DESCRIPTION
## Problem
When restarting the dashboard after a crash/exit, it showed 'Initializing' with no memory of the previous run. The saved state file existed but wasn't loaded.

## Solution
- Added `Runner.loadSavedState()` to restore phase, plan, and results from state file
- Dashboard builds initial activities from saved state (completed phases shown as done)
- Log panel shows context: 'Loaded saved state — phase: plan' or 'Previous run failed: No JSON found'
- Issue list marks already-completed issues from saved results
- Pressing [g]o continues from where the sprint left off (resume logic in fullCycle)

## Files
- `src/runner.ts` — loadSavedState() method
- `src/index.ts` — call loadSavedState, enrich initialIssues with completion status
- `src/tui/App.tsx` — buildInitialActivities(), initial log entries from saved state

## Testing
- 289 tests passing, build clean