### PR TITLE
fix: prevent crash on missing arrays in review/retro responses

### DIFF
--- a/src/ceremonies/retro.ts
+++ b/src/ceremonies/retro.ts
@@ -88,6 +88,11 @@ export async function runSprintRetro(
     const response = await client.sendPrompt(sessionId, fullPrompt, config.sessionTimeoutMs);
     const retro = extractJson<RetroResult>(response.response);
 
+    // Ensure arrays exist (model may omit them)
+    retro.wentWell = retro.wentWell ?? [];
+    retro.wentBadly = retro.wentBadly ?? [];
+    retro.improvements = retro.improvements ?? [];
+
     log.info(
       {
         wentWell: retro.wentWell.length,

--- a/src/ceremonies/review.ts
+++ b/src/ceremonies/review.ts
@@ -70,6 +70,10 @@ export async function runSprintReview(
     const response = await client.sendPrompt(sessionId, fullPrompt, config.sessionTimeoutMs);
     const review = extractJson<ReviewResult>(response.response);
 
+    // Ensure arrays exist (model may omit them)
+    review.demoItems = review.demoItems ?? [];
+    review.openItems = review.openItems ?? [];
+
     log.info(
       { demoItems: review.demoItems.length, openItems: review.openItems.length },
       "Sprint review completed",


### PR DESCRIPTION
## Problem
Sprint review crashed with `Cannot read properties of undefined (reading 'length')` because the ACP model response didn't include `demoItems` or `openItems` arrays.

## Fix
- `review.ts`: Default `demoItems` and `openItems` to `[]` after JSON extraction
- `retro.ts`: Default `wentWell`, `wentBadly`, and `improvements` to `[]`

289 tests passing, build clean.