### PR TITLE
fix: reuse existing branches/worktrees on resume instead of crashing

### DIFF
--- a/tests/git/worktree.test.ts
+++ b/tests/git/worktree.test.ts
@@ -59,34 +59,79 @@ describe("worktree", () => {
       expect(stdout.trim()).toContain("feature/test-1");
     });
 
-    it("throws when the branch already exists", async () => {
-      await execFile("git", ["branch", "existing-branch"]);
+    it("reuses an existing branch by resetting it to base", async () => {
+      // Simulate a leftover branch from a previous failed run
+      await execFile("git", ["branch", "leftover-branch"]);
 
-      await expect(
-        createWorktree({
-          path: path.join(repoDir, "wt-dup"),
-          branch: "existing-branch",
-          base: "HEAD",
-        }),
-      ).rejects.toThrow("already exists");
-    });
+      // Add a new commit so base (HEAD) is ahead of the leftover branch
+      await fs.writeFile(path.join(repoDir, "new-file.txt"), "new\n");
+      await execFile("git", ["add", "."]);
+      await execFile("git", ["commit", "-m", "second commit"]);
 
-    it("throws when the worktree path already exists as a worktree", async () => {
-      const worktreePath = path.join(repoDir, "wt-dup-path");
-
+      const worktreePath = path.join(repoDir, "wt-reuse");
       await createWorktree({
         path: worktreePath,
-        branch: "branch-a",
+        branch: "leftover-branch",
         base: "HEAD",
       });
 
-      await expect(
-        createWorktree({
-          path: worktreePath,
-          branch: "branch-b",
-          base: "HEAD",
-        }),
-      ).rejects.toThrow("already exists");
+      // Verify worktree was created
+      const stat = await fs.stat(worktreePath);
+      expect(stat.isDirectory()).toBe(true);
+
+      // Verify the branch was reset to HEAD (should contain new-file.txt)
+      const newFile = path.join(worktreePath, "new-file.txt");
+      const content = await fs.readFile(newFile, "utf-8");
+      expect(content).toBe("new\n");
+    });
+
+    it("recovers from a stale worktree at the same path", async () => {
+      const worktreePath = path.join(repoDir, "wt-stale");
+
+      // Create first worktree
+      await createWorktree({
+        path: worktreePath,
+        branch: "branch-first",
+        base: "HEAD",
+      });
+
+      // Manually delete the directory but leave git's worktree registry intact
+      await fs.rm(worktreePath, { recursive: true, force: true });
+
+      // Now create a second worktree at the same path — should not throw
+      await createWorktree({
+        path: worktreePath,
+        branch: "branch-second",
+        base: "HEAD",
+      });
+
+      const stat = await fs.stat(worktreePath);
+      expect(stat.isDirectory()).toBe(true);
+
+      const { stdout } = await execFile("git", ["branch", "--list", "branch-second"]);
+      expect(stdout.trim()).toContain("branch-second");
+    });
+
+    it("recovers when both branch and worktree exist from a previous run", async () => {
+      const worktreePath = path.join(repoDir, "wt-both");
+
+      // First run: create worktree normally
+      await createWorktree({
+        path: worktreePath,
+        branch: "sprint/1/issue-99",
+        base: "HEAD",
+      });
+
+      // Simulate crash: worktree and branch both still exist
+      // Second run: should reset branch and recreate worktree
+      await createWorktree({
+        path: worktreePath,
+        branch: "sprint/1/issue-99",
+        base: "HEAD",
+      });
+
+      const stat = await fs.stat(worktreePath);
+      expect(stat.isDirectory()).toBe(true);
     });
 
     it("throws when the base ref does not exist", async () => {
@@ -97,6 +142,46 @@ describe("worktree", () => {
           base: "nonexistent-ref",
         }),
       ).rejects.toThrow();
+    });
+
+    it("creates worktree with correct content from base", async () => {
+      // Add a file on main
+      await fs.writeFile(path.join(repoDir, "main-only.txt"), "main content\n");
+      await execFile("git", ["add", "."]);
+      await execFile("git", ["commit", "-m", "add main-only"]);
+
+      const worktreePath = path.join(repoDir, "wt-content");
+      await createWorktree({
+        path: worktreePath,
+        branch: "feature/content-test",
+        base: "HEAD",
+      });
+
+      // Verify content is available in the worktree
+      const content = await fs.readFile(path.join(worktreePath, "main-only.txt"), "utf-8");
+      expect(content).toBe("main content\n");
+    });
+
+    it("cleans up branch when worktree creation fails", async () => {
+      // Use an invalid path that git worktree add can't use
+      // We'll create a regular file at the path so git can't make a directory there
+      const blockerPath = path.join(repoDir, "wt-blocker");
+      // Create nested so git worktree add fails trying to use a non-directory parent
+      await fs.mkdir(blockerPath);
+      // Put a .git file there to make it look like an existing worktree/repo
+      await fs.writeFile(path.join(blockerPath, ".git"), "gitdir: /nonexistent\n");
+
+      await expect(
+        createWorktree({
+          path: blockerPath,
+          branch: "should-be-cleaned-up",
+          base: "HEAD",
+        }),
+      ).rejects.toThrow();
+
+      // Branch should have been cleaned up
+      const { stdout } = await execFile("git", ["branch", "--list", "should-be-cleaned-up"]);
+      expect(stdout.trim()).toBe("");
     });
   });
 
@@ -120,6 +205,23 @@ describe("worktree", () => {
       await expect(
         removeWorktree(path.join(repoDir, "nonexistent")),
       ).rejects.toThrow();
+    });
+
+    it("removes worktree even with uncommitted changes (force)", async () => {
+      const worktreePath = path.join(repoDir, "wt-dirty");
+
+      await createWorktree({
+        path: worktreePath,
+        branch: "feature/dirty",
+        base: "HEAD",
+      });
+
+      // Make uncommitted changes in the worktree
+      await fs.writeFile(path.join(worktreePath, "dirty.txt"), "uncommitted\n");
+
+      // Should still succeed (we use --force)
+      await removeWorktree(worktreePath);
+      await expect(fs.stat(worktreePath)).rejects.toThrow();
     });
   });
 
@@ -145,6 +247,71 @@ describe("worktree", () => {
 
       expect(found).toBeDefined();
       expect(found!.path).toBe(worktreePath);
+    });
+
+    it("does not list removed worktrees", async () => {
+      const worktreePath = path.join(repoDir, "wt-removed");
+
+      await createWorktree({
+        path: worktreePath,
+        branch: "feature/gone",
+        base: "HEAD",
+      });
+      await removeWorktree(worktreePath);
+
+      const worktrees = await listWorktrees();
+      const found = worktrees.find((w) => w.branch === "feature/gone");
+      expect(found).toBeUndefined();
+    });
+
+    it("lists multiple worktrees simultaneously", async () => {
+      await createWorktree({ path: path.join(repoDir, "wt-a"), branch: "branch-a", base: "HEAD" });
+      await createWorktree({ path: path.join(repoDir, "wt-b"), branch: "branch-b", base: "HEAD" });
+      await createWorktree({ path: path.join(repoDir, "wt-c"), branch: "branch-c", base: "HEAD" });
+
+      const worktrees = await listWorktrees();
+      const branches = worktrees.map((w) => w.branch);
+
+      expect(branches).toContain("branch-a");
+      expect(branches).toContain("branch-b");
+      expect(branches).toContain("branch-c");
+    });
+  });
+
+  describe("full lifecycle", () => {
+    it("create → remove → recreate at same path works", async () => {
+      const worktreePath = path.join(repoDir, "wt-lifecycle");
+
+      await createWorktree({ path: worktreePath, branch: "cycle-1", base: "HEAD" });
+      await removeWorktree(worktreePath);
+      await createWorktree({ path: worktreePath, branch: "cycle-2", base: "HEAD" });
+
+      const stat = await fs.stat(worktreePath);
+      expect(stat.isDirectory()).toBe(true);
+
+      const worktrees = await listWorktrees();
+      expect(worktrees.find((w) => w.branch === "cycle-2")).toBeDefined();
+      expect(worktrees.find((w) => w.branch === "cycle-1")).toBeUndefined();
+    });
+
+    it("simulates crash-resume: create → crash (no cleanup) → create again", async () => {
+      const worktreePath = path.join(repoDir, "wt-crash");
+
+      // First run creates worktree
+      await createWorktree({ path: worktreePath, branch: "sprint/2/issue-1", base: "HEAD" });
+
+      // Crash: no removeWorktree called. Branch and worktree both survive.
+      // Resume: try to create the same worktree again
+      await createWorktree({ path: worktreePath, branch: "sprint/2/issue-1", base: "HEAD" });
+
+      // Should succeed — worktree is usable
+      const stat = await fs.stat(worktreePath);
+      expect(stat.isDirectory()).toBe(true);
+
+      // Should appear exactly once in worktree list
+      const worktrees = await listWorktrees();
+      const matches = worktrees.filter((w) => w.branch === "sprint/2/issue-1");
+      expect(matches).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
## Problem
All 8 issues failed with `Branch 'sprint/1/issue-X' already exists` because a previous run left branches behind and `createWorktree` refused to reuse them.

## Root Cause
`createWorktree` threw on existing branches instead of recovering. After a crash, branches and worktrees survive but the next run can't create new ones at the same paths.

## Fix
Reordered cleanup logic:
1. Remove stale worktree FIRST (must happen before branch reset — git won't `branch -f` on a checked-out branch)
2. If branch exists, reset it to base with `git branch -f`
3. Create fresh worktree

## Tests (8 → 16)
Added edge cases the old tests missed:
- `reuses an existing branch by resetting it to base` — verifies content matches base
- `recovers from a stale worktree at the same path` — directory deleted, registry intact
- `recovers when both branch and worktree exist` — full crash scenario
- `crash-resume simulation` — create, no cleanup, create again
- `removes worktree even with uncommitted changes`
- `does not list removed worktrees`
- `lists multiple worktrees simultaneously`
- `create → remove → recreate lifecycle`
- `cleans up branch when worktree creation fails`

## Testing
297 tests passing (was 289), build clean, lint clean