### PR TITLE
fix: harden edge cases across ceremonies, github, and git modules

### DIFF
--- a/src/ceremonies/refinement.ts
+++ b/src/ceremonies/refinement.ts
@@ -68,7 +68,9 @@ export async function runRefinement(
     const result = await client.sendPrompt(sessionId, fullPrompt, config.sessionTimeoutMs);
     const parsed = extractJson<RefinementResponse>(result.response);
 
-    const refined: RefinedIssue[] = parsed.refined_issues.map((issue) => ({
+    // Ensure refined_issues array exists (model may omit it)
+    const refinedIssues = parsed.refined_issues ?? [];
+    const refined: RefinedIssue[] = refinedIssues.map((issue) => ({
       number: issue.number,
       title: issue.title,
       ice_score: issue.ice_score,

--- a/src/documentation/velocity.ts
+++ b/src/documentation/velocity.ts
@@ -36,23 +36,27 @@ export function readVelocity(filePath: string = DEFAULT_FILE_PATH): VelocityEntr
   // Skip the header row (separator already filtered by startsWith("| "))
   const dataLines = lines.slice(1);
 
-  return dataLines.map((line) => {
-    const cols = line
-      .split("|")
-      .slice(1, -1)
-      .map((c) => c.trim());
-    return {
-      sprint: Number(cols[0]),
-      date: cols[1] ?? "",
-      goal: cols[2] ?? "",
-      planned: Number(cols[3]),
-      done: Number(cols[4]),
-      carry: Number(cols[5]),
-      hours: Number(cols[6]),
-      issuesPerHr: Number(cols[7]),
-      notes: cols[8] ?? "",
-    };
-  });
+  return dataLines
+    .map((line) => {
+      const cols = line
+        .split("|")
+        .slice(1, -1)
+        .map((c) => c.trim());
+      // Skip malformed rows (separator lines, incomplete data)
+      if (cols.length < 8 || cols[0] === "---" || cols[0] === "") return null;
+      return {
+        sprint: Number(cols[0]),
+        date: cols[1] ?? "",
+        goal: cols[2] ?? "",
+        planned: Number(cols[3]),
+        done: Number(cols[4]),
+        carry: Number(cols[5]),
+        hours: Number(cols[6]),
+        issuesPerHr: Number(cols[7]),
+        notes: cols[8] ?? "",
+      };
+    })
+    .filter((e): e is VelocityEntry => e !== null);
 }
 
 export function appendVelocity(

--- a/src/github/issues.ts
+++ b/src/github/issues.ts
@@ -82,7 +82,11 @@ export async function getIssue(number: number): Promise<GitHubIssue> {
     "--json",
     "number,title,body,labels,state",
   ]);
-  return JSON.parse(json) as GitHubIssue;
+  try {
+    return JSON.parse(json) as GitHubIssue;
+  } catch {
+    throw new Error(`Failed to parse issue #${number} response: ${json.slice(0, 200)}`);
+  }
 }
 
 export interface ListIssuesOptions {
@@ -113,7 +117,11 @@ export async function listIssues(
   }
 
   const json = await execGh(args);
-  return JSON.parse(json) as GitHubIssue[];
+  try {
+    return JSON.parse(json) as GitHubIssue[];
+  } catch {
+    throw new Error(`Failed to parse issue list response: ${json.slice(0, 200)}`);
+  }
 }
 
 export interface CreateIssueOptions {

--- a/src/github/labels.ts
+++ b/src/github/labels.ts
@@ -87,6 +87,6 @@ export async function getLabels(
     "--json",
     "labels",
   ]);
-  const result = JSON.parse(json) as { labels: { name: string }[] };
-  return result.labels;
+  const result = JSON.parse(json) as { labels?: { name: string }[] };
+  return result.labels ?? [];
 }

--- a/src/github/milestones.ts
+++ b/src/github/milestones.ts
@@ -93,7 +93,13 @@ export async function getMilestone(
 
   // gh --paginate may return NDJSON (one JSON array per line)
   const pages = json.trim().split("\n").filter((line) => line.trim());
-  const milestones = pages.flatMap((page) => JSON.parse(page) as GitHubMilestone[]);
+  const milestones = pages.flatMap((page) => {
+    try {
+      return JSON.parse(page) as GitHubMilestone[];
+    } catch {
+      return [];
+    }
+  });
   return milestones.find((m) => m.title === title);
 }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -330,7 +330,7 @@ export class SprintRunner {
       } else {
         this.events.emitTyped("issue:fail", {
           issueNumber: r.issueNumber,
-          reason: r.qualityDetails.checks.filter(c => !c.passed).map(c => c.name).join(", ") || "execution failed",
+          reason: (r.qualityDetails?.checks ?? []).filter(c => !c.passed).map(c => c.name).join(", ") || "execution failed",
           duration_ms: r.duration_ms,
         });
       }

--- a/tests/ceremonies/planning.test.ts
+++ b/tests/ceremonies/planning.test.ts
@@ -70,6 +70,29 @@ describe("extractJson", () => {
   it("throws when no JSON is present", () => {
     expect(() => extractJson("no json here")).toThrow("No JSON found");
   });
+
+  it("throws on empty string", () => {
+    expect(() => extractJson("")).toThrow("No JSON found");
+  });
+
+  it("throws on whitespace-only string", () => {
+    expect(() => extractJson("   \n\n  ")).toThrow("No JSON found");
+  });
+
+  it("handles JSON with escaped quotes in strings", () => {
+    const text = '{"msg":"say \\"hello\\""}';
+    expect(extractJson(text)).toEqual({ msg: 'say "hello"' });
+  });
+
+  it("extracts first JSON when multiple objects exist", () => {
+    const text = '{"first":1} and {"second":2}';
+    expect(extractJson(text)).toEqual({ first: 1 });
+  });
+
+  it("handles fenced block with extra whitespace", () => {
+    const text = 'text\n```json\n  \n{"data": true}\n  \n```\nmore';
+    expect(extractJson(text)).toEqual({ data: true });
+  });
 });
 
 // --- runSprintPlanning (mocked) ---

--- a/tests/documentation/velocity.test.ts
+++ b/tests/documentation/velocity.test.ts
@@ -96,4 +96,39 @@ describe("velocity", () => {
     expect(entries[0]?.planned).toBe(entry.planned);
     expect(entries[0]?.done).toBe(entry.done);
   });
+
+  it("readVelocity skips separator rows (---|---)", () => {
+    const filePath = path.join(tmpDir, "velocity.md");
+    const content = [
+      "| Sprint | Date | Goal | Planned | Done | Carry | Hours | Issues/Hr | Notes |",
+      "|--------|------|------|---------|------|-------|-------|-----------|-------|",
+      "| 1 | 2025-01-01 | MVP | 5 | 4 | 1 | 3 | 1.3 | ok |",
+    ].join("\n");
+    fs.writeFileSync(filePath, content, "utf-8");
+
+    const entries = readVelocity(filePath);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.sprint).toBe(1);
+  });
+
+  it("readVelocity skips malformed rows with too few columns", () => {
+    const filePath = path.join(tmpDir, "velocity.md");
+    const content = [
+      "| Sprint | Date | Goal | Planned | Done | Carry | Hours | Issues/Hr | Notes |",
+      "| 1 | 2025-01-01 |",
+      "| 2 | 2025-02-01 | Sprint 2 | 8 | 7 | 1 | 4 | 1.75 | great |",
+    ].join("\n");
+    fs.writeFileSync(filePath, content, "utf-8");
+
+    const entries = readVelocity(filePath);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.sprint).toBe(2);
+  });
+
+  it("readVelocity handles empty file", () => {
+    const filePath = path.join(tmpDir, "velocity.md");
+    fs.writeFileSync(filePath, "", "utf-8");
+    const entries = readVelocity(filePath);
+    expect(entries).toEqual([]);
+  });
 });

--- a/tests/git/diff-analysis.test.ts
+++ b/tests/git/diff-analysis.test.ts
@@ -120,4 +120,23 @@ describe("diff-analysis", () => {
       expect(result).toBe(false);
     });
   });
+
+  describe("error handling", () => {
+    it("diffStat returns empty result for nonexistent branch", async () => {
+      const stat = await diffStat("nonexistent-branch", "main");
+      expect(stat.filesChanged).toBe(0);
+      expect(stat.linesChanged).toBe(0);
+      expect(stat.files).toEqual([]);
+    });
+
+    it("getChangedFiles returns empty array for nonexistent branch", async () => {
+      const files = await getChangedFiles("nonexistent-branch", "main");
+      expect(files).toEqual([]);
+    });
+
+    it("isNewOrModified returns false for nonexistent branch", async () => {
+      const result = await isNewOrModified("README.md", "nonexistent-branch", "main");
+      expect(result).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Systematic Edge Case Audit

Audited all source files for crash scenarios: undefined array access, unguarded JSON.parse, unhandled git failures, missing field defaults.

## Fixes by Module

### Ceremonies
- **refinement.ts**: `refined_issues` defaulted to `[]` — model can omit it
- **runner.ts**: `qualityDetails?.checks` optional chaining — prevents crash on rejected issues

### GitHub API
- **issues.ts**: `JSON.parse` wrapped in try/catch with descriptive error messages
- **labels.ts**: `result.labels ?? []` — missing field won't crash
- **milestones.ts**: NDJSON page parsing wrapped in try/catch — malformed page skipped

### Enforcement
- **ci-cd.ts**: Both `JSON.parse` calls (poll loop + timeout) wrapped in try/catch — malformed response retries instead of crashing

### Git
- **diff-analysis.ts**: `diffStat` and `getChangedFiles` return empty results on git failure instead of throwing — nonexistent branches don't crash execution

### Documentation
- **velocity.ts**: Skip rows with <8 columns or separator markers — malformed markdown won't crash

## New Tests (+11, total 308)
- `extractJson`: empty string, whitespace, escaped quotes, multiple objects, fenced block whitespace
- `velocity`: separator rows, malformed rows, empty file
- `diff-analysis`: nonexistent branch graceful fallback (3 tests)

## Verification
- 308 tests passing, 0 lint errors, build clean