### PR TITLE
feat: sprint navigation with prev/next and REST API

### DIFF
--- a/src/dashboard/public/index.html
+++ b/src/dashboard/public/index.html
@@ -11,8 +11,13 @@
   <header id="header">
     <div class="header-left">
       <h1>🏃 Sprint Runner</h1>
-      <span id="sprint-label" class="sprint-badge">Sprint —</span>
+      <div class="sprint-nav">
+        <button id="btn-prev" class="btn btn-nav" title="Previous sprint">◀</button>
+        <span id="sprint-label" class="sprint-badge">Sprint —</span>
+        <button id="btn-next" class="btn btn-nav" title="Next sprint">▶</button>
+      </div>
       <span id="phase-badge" class="phase-badge phase-init">init</span>
+      <span id="viewing-indicator" class="viewing-indicator" style="display:none">👁 viewing</span>
     </div>
     <div class="header-right">
       <span id="issue-count" class="issue-count">0/0 done</span>

--- a/src/dashboard/public/style.css
+++ b/src/dashboard/public/style.css
@@ -65,6 +65,34 @@ header {
   font-weight: 600;
 }
 
+.sprint-nav {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.btn-nav {
+  padding: 2px 8px;
+  font-size: 12px;
+  border-radius: 4px;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  cursor: pointer;
+  line-height: 1;
+}
+
+.btn-nav:hover { background: var(--bg-hover); color: var(--text); }
+.btn-nav:disabled { opacity: 0.3; cursor: not-allowed; }
+
+.viewing-indicator {
+  font-size: 12px;
+  color: var(--yellow);
+  padding: 2px 8px;
+  border: 1px solid var(--yellow);
+  border-radius: 12px;
+}
+
 .phase-badge {
   padding: 2px 10px;
   border-radius: 12px;

--- a/src/index.ts
+++ b/src/index.ts
@@ -583,6 +583,8 @@ program
         getState: () => runner.getState(),
         getIssues: () => currentIssues,
         onStart,
+        projectPath: process.cwd(),
+        activeSprintNumber: initialSprint,
       });
 
       await dashboardServer.start();

--- a/tests/dashboard/ws-server.test.ts
+++ b/tests/dashboard/ws-server.test.ts
@@ -169,4 +169,36 @@ describe("DashboardWebServer", () => {
     const text = await res.text();
     expect(text).not.toContain('"dependencies"');
   });
+
+  it("serves /api/sprints with available sprints", async () => {
+    await server.start();
+    const port = getPort(server);
+    const res = await fetch(`http://127.0.0.1:${port}/api/sprints`);
+    expect(res.status).toBe(200);
+    const data = await res.json() as { sprintNumber: number; phase: string; isActive: boolean }[];
+    // Should at least include the active sprint from getState
+    expect(Array.isArray(data)).toBe(true);
+  });
+
+  it("serves /api/sprints/:number/state for active sprint", async () => {
+    options = makeOptions({ activeSprintNumber: 1 });
+    server = new DashboardWebServer(options);
+    await server.start();
+    const port = getPort(server);
+    const res = await fetch(`http://127.0.0.1:${port}/api/sprints/1/state`);
+    expect(res.status).toBe(200);
+    const data = await res.json() as { sprintNumber: number; phase: string };
+    expect(data.sprintNumber).toBe(1);
+    expect(data.phase).toBe("init");
+  });
+
+  it("returns empty state for nonexistent sprint", async () => {
+    await server.start();
+    const port = getPort(server);
+    const res = await fetch(`http://127.0.0.1:${port}/api/sprints/999/state`);
+    expect(res.status).toBe(200);
+    const data = await res.json() as { sprintNumber: number; phase: string };
+    expect(data.sprintNumber).toBe(999);
+    expect(data.phase).toBe("init");
+  });
 });


### PR DESCRIPTION
## Sprint Navigation

Adds sprint switching to the web dashboard — browse historical sprints while the active sprint runs.

### Backend
- `GET /api/sprints` — Lists available sprints from state files
- `GET /api/sprints/:number/state` — Loads sprint state (live for active, file-based for historical)
- New options: `projectPath`, `activeSprintNumber` on `DashboardServerOptions`

### Frontend
- **◀ / ▶ buttons** in header to navigate between sprints
- **← → arrow keys** as keyboard shortcuts
- **"👁 viewing" indicator** when browsing a non-active sprint
- Historical sprints reconstruct issues + activities from saved state
- Start button switches back to active sprint when viewing historical
- Nav buttons disabled at boundaries

### Tests
3 new API endpoint tests (318 total):
- Sprint list endpoint returns array
- Active sprint state returns live data
- Nonexistent sprint returns empty init state