### PR TITLE
feat: agent chat panel with ACP sessions in web dashboard

### DIFF
--- a/src/dashboard/chat-manager.ts
+++ b/src/dashboard/chat-manager.ts
@@ -1,0 +1,214 @@
+/**
+ * Chat Manager — manages interactive ACP chat sessions for the web dashboard.
+ *
+ * Each chat session gets its own ACP session pre-primed with a role-specific
+ * system prompt. Responses stream via callbacks.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { AcpClient, ACP_MODES, type SessionInfo } from "../acp/client.js";
+import type { PermissionConfig } from "../acp/permissions.js";
+import { logger } from "../logger.js";
+
+const log = logger.child({ component: "chat-manager" });
+
+export type ChatRole = "researcher" | "planner" | "reviewer" | "general";
+
+export interface ChatSession {
+  id: string;
+  role: ChatRole;
+  acpSessionId: string;
+  model: string;
+  createdAt: Date;
+  messages: ChatMessage[];
+}
+
+export interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+  timestamp: Date;
+}
+
+const ROLE_PROMPTS: Record<ChatRole, string> = {
+  researcher: `You are a Research Agent for the AI Scrum Sprint Runner project.
+Your role is to research topics, analyze code, investigate issues, and provide detailed findings.
+You have access to the full codebase and can read files, search code, and explore the project structure.
+Be thorough, provide evidence-based answers with file references, and suggest actionable next steps.`,
+
+  planner: `You are a Planning Agent for the AI Scrum Sprint Runner project.
+Your role is to help plan sprints, break down issues, create acceptance criteria, and estimate work.
+You understand Scrum methodology, ICE scoring, and velocity-based planning.
+When creating issues, include clear titles, descriptions, and testable acceptance criteria.`,
+
+  reviewer: `You are a Code Review Agent for the AI Scrum Sprint Runner project.
+Your role is to review code changes, identify bugs, security issues, and logic errors.
+Focus on correctness and robustness. Do not comment on style or formatting.
+Flag blocking issues clearly and explain why they matter.`,
+
+  general: `You are a General Assistant for the AI Scrum Sprint Runner project.
+You can help with any task: coding, debugging, documentation, architecture, or answering questions.
+You have access to the full codebase and development tools.`,
+};
+
+export interface ChatManagerOptions {
+  projectPath: string;
+  permissions?: PermissionConfig;
+  timeoutMs?: number;
+  onStreamChunk?: (sessionId: string, text: string) => void;
+}
+
+export class ChatManager {
+  private client: AcpClient | null = null;
+  private sessions = new Map<string, ChatSession>();
+  private readonly options: ChatManagerOptions;
+  private connected = false;
+
+  constructor(options: ChatManagerOptions) {
+    this.options = options;
+  }
+
+  /** Ensure ACP client is connected. Lazy-connects on first use. */
+  private async ensureClient(): Promise<AcpClient> {
+    if (this.client && this.connected) return this.client;
+
+    this.client = new AcpClient({
+      timeoutMs: this.options.timeoutMs ?? 600_000,
+      permissions: this.options.permissions ?? {
+        autoApprove: true,
+        allowPatterns: [],
+      },
+      onStreamChunk: (acpSessionId, text) => {
+        // Find our chat session by ACP session ID and relay chunk
+        for (const [chatId, session] of this.sessions) {
+          if (session.acpSessionId === acpSessionId) {
+            this.options.onStreamChunk?.(chatId, text);
+            break;
+          }
+        }
+      },
+    });
+
+    await this.client.connect();
+    this.connected = true;
+    log.info("Chat ACP client connected");
+    return this.client;
+  }
+
+  /** Create a new chat session with a specific role. */
+  async createSession(role: ChatRole): Promise<ChatSession> {
+    const client = await this.ensureClient();
+
+    const sessionInfo: SessionInfo = await client.createSession({
+      cwd: this.options.projectPath,
+    });
+
+    // Set to agent mode
+    await client.setMode(sessionInfo.sessionId, ACP_MODES.AGENT);
+
+    const chatId = `chat-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    const session: ChatSession = {
+      id: chatId,
+      role,
+      acpSessionId: sessionInfo.sessionId,
+      model: sessionInfo.currentModel,
+      createdAt: new Date(),
+      messages: [],
+    };
+
+    this.sessions.set(chatId, session);
+
+    // Prime with role system prompt + project context
+    const systemPrompt = this.buildSystemPrompt(role);
+    log.info({ chatId, role, acpSessionId: sessionInfo.sessionId }, "Chat session created");
+
+    // Send system prompt as first message (but don't store it as a user message)
+    await client.sendPrompt(sessionInfo.sessionId, systemPrompt, 120_000);
+
+    return session;
+  }
+
+  /** Send a message in an existing chat session. Returns the assistant's response. */
+  async sendMessage(chatId: string, message: string): Promise<string> {
+    const session = this.sessions.get(chatId);
+    if (!session) throw new Error(`Chat session ${chatId} not found`);
+
+    const client = await this.ensureClient();
+
+    session.messages.push({
+      role: "user",
+      content: message,
+      timestamp: new Date(),
+    });
+
+    log.info({ chatId, messageLength: message.length }, "Sending chat message");
+
+    const result = await client.sendPrompt(
+      session.acpSessionId,
+      message,
+      this.options.timeoutMs ?? 600_000,
+    );
+
+    session.messages.push({
+      role: "assistant",
+      content: result.response,
+      timestamp: new Date(),
+    });
+
+    return result.response;
+  }
+
+  /** Close a chat session. */
+  async closeSession(chatId: string): Promise<void> {
+    const session = this.sessions.get(chatId);
+    if (!session) return;
+
+    if (this.client) {
+      await this.client.endSession(session.acpSessionId);
+    }
+
+    this.sessions.delete(chatId);
+    log.info({ chatId }, "Chat session closed");
+  }
+
+  /** Get a chat session by ID. */
+  getSession(chatId: string): ChatSession | undefined {
+    return this.sessions.get(chatId);
+  }
+
+  /** List all active chat sessions. */
+  listSessions(): ChatSession[] {
+    return Array.from(this.sessions.values());
+  }
+
+  /** Disconnect the ACP client and close all sessions. */
+  async shutdown(): Promise<void> {
+    for (const [chatId] of this.sessions) {
+      await this.closeSession(chatId);
+    }
+    if (this.client) {
+      await this.client.disconnect();
+      this.client = null;
+      this.connected = false;
+    }
+    log.info("Chat manager shut down");
+  }
+
+  private buildSystemPrompt(role: ChatRole): string {
+    const rolePrompt = ROLE_PROMPTS[role];
+
+    // Try to load AGENTS.md for project context
+    let agentsContext = "";
+    try {
+      const agentsPath = path.join(this.options.projectPath, "AGENTS.md");
+      if (fs.existsSync(agentsPath)) {
+        agentsContext = `\n\n## Project Context (from AGENTS.md)\n\n${fs.readFileSync(agentsPath, "utf-8")}`;
+      }
+    } catch {
+      // Non-critical
+    }
+
+    return `${rolePrompt}${agentsContext}\n\nRespond helpfully and concisely. You are in an interactive chat session.`;
+  }
+}

--- a/src/dashboard/public/index.html
+++ b/src/dashboard/public/index.html
@@ -23,6 +23,7 @@
       <span id="issue-count" class="issue-count">0/0 done</span>
       <span id="elapsed" class="elapsed">0m 00s</span>
       <button id="btn-start" class="btn btn-primary" title="Start sprint">▶ Start</button>
+      <button id="btn-chat" class="btn" title="Open Agent Chat">💬 Chat</button>
     </div>
   </header>
 
@@ -40,6 +41,29 @@
       <ul id="activity-list"></ul>
       <h2>Log</h2>
       <div id="log-panel"></div>
+    </section>
+
+    <!-- Chat panel (slide-out) -->
+    <section id="chat-panel" class="panel chat-panel" style="display:none">
+      <div class="chat-header">
+        <h2>Agent Chat</h2>
+        <div class="chat-controls">
+          <select id="chat-role">
+            <option value="general">General</option>
+            <option value="researcher">Researcher</option>
+            <option value="planner">Planner</option>
+            <option value="reviewer">Reviewer</option>
+          </select>
+          <button id="btn-new-chat" class="btn btn-small">+ New</button>
+          <button id="btn-close-chat" class="btn btn-small" title="Close panel">✕</button>
+        </div>
+      </div>
+      <div id="chat-sessions-bar"></div>
+      <div id="chat-messages"></div>
+      <div class="chat-input-row">
+        <textarea id="chat-input" placeholder="Type a message…" rows="2"></textarea>
+        <button id="btn-send" class="btn btn-primary btn-small" disabled>Send</button>
+      </div>
     </section>
   </main>
 

--- a/src/dashboard/public/style.css
+++ b/src/dashboard/public/style.css
@@ -312,3 +312,142 @@ footer {
 .status-connected { background: var(--green); }
 .status-disconnected { background: var(--red); }
 .status-connecting { background: var(--yellow); }
+
+/* Chat panel */
+.chat-panel {
+  border-left: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  min-width: 380px;
+  max-width: 480px;
+}
+
+.chat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 8px;
+}
+
+.chat-header h2 { margin: 0; border: none; padding: 0; }
+
+.chat-controls {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.chat-controls select {
+  background: var(--bg-hover);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 3px 6px;
+  font-size: 12px;
+}
+
+.btn-small {
+  padding: 3px 8px;
+  font-size: 12px;
+}
+
+#chat-sessions-bar {
+  display: flex;
+  gap: 4px;
+  padding-bottom: 8px;
+  overflow-x: auto;
+  flex-shrink: 0;
+}
+
+.chat-tab {
+  padding: 3px 10px;
+  font-size: 12px;
+  border-radius: 4px;
+  background: var(--bg-hover);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.chat-tab.active {
+  background: var(--blue);
+  color: #fff;
+  border-color: var(--blue);
+}
+
+#chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-msg {
+  padding: 8px 10px;
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.5;
+  max-width: 90%;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+.chat-msg-user {
+  background: var(--blue);
+  color: #fff;
+  align-self: flex-end;
+  border-bottom-right-radius: 2px;
+}
+
+.chat-msg-assistant {
+  background: var(--bg-hover);
+  color: var(--text);
+  align-self: flex-start;
+  border-bottom-left-radius: 2px;
+}
+
+.chat-msg-streaming {
+  opacity: 0.8;
+}
+
+.chat-msg-system {
+  color: var(--text-dim);
+  font-style: italic;
+  text-align: center;
+  font-size: 12px;
+}
+
+.chat-input-row {
+  display: flex;
+  gap: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+#chat-input {
+  flex: 1;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px;
+  font-family: var(--font);
+  font-size: 13px;
+  resize: none;
+  outline: none;
+}
+
+#chat-input:focus { border-color: var(--blue); }
+
+.chat-input-row .btn { align-self: flex-end; }
+
+/* Adjust main grid when chat is open */
+main.chat-open {
+  grid-template-columns: 280px 1fr 380px;
+}


### PR DESCRIPTION
## Agent Chat

Interactive chat in the web dashboard — open ACP sessions with pre-configured agent roles.

### Chat Manager (`src/dashboard/chat-manager.ts`)
- **Four roles**: Researcher, Planner, Reviewer, General
- Each role pre-primed with system prompt + AGENTS.md project context
- Lazy ACP client init (connection created on first chat)
- Multiple concurrent sessions
- Streaming responses via WebSocket

### WebSocket Protocol
| Message | Direction | Purpose |
|---------|-----------|---------|
| `chat:create` | Client→Server | Create session with role |
| `chat:chunk` | Server→Client | Streaming response text |
| `chat:done` | Server→Client | Final complete response |
| `chat:error` | Server→Client | Error handling |
| `chat:send` | Client→Server | Send user message |
| `chat:close` | Client→Server | End session |

### Frontend
- **💬 Chat button** in header toggles chat panel
- **Role selector** dropdown
- **Session tabs** for multiple concurrent chats
- **Streaming display** — text appears as it's generated
- **Enter to send** (Shift+Enter for newline)
- Chat panel slides in, resizes main grid to 3-column

### Tests
318 tests passing, 0 lint errors.