### PR TITLE
feat: sprint history API and browser notifications

### DIFF
--- a/src/dashboard/public/app.js
+++ b/src/dashboard/public/app.js
@@ -176,12 +176,14 @@
         state.phase = "complete";
         renderHeader();
         addActivity("sprint", `Sprint ${payload.sprintNumber} complete`, null, "done");
+        showNotification("Sprint Complete", `Sprint ${payload.sprintNumber} finished successfully`);
         break;
 
       case "sprint:error":
         state.phase = "failed";
         renderHeader();
         addActivity("sprint", "Sprint error", payload.error, "failed");
+        showNotification("Sprint Error", payload.error, true);
         break;
 
       case "log":
@@ -467,6 +469,24 @@
     }
   }, 1000);
 
+  // --- Browser notifications ---
+
+  function requestNotificationPermission() {
+    if ("Notification" in window && Notification.permission === "default") {
+      Notification.requestPermission();
+    }
+  }
+
+  function showNotification(title, body, isError) {
+    if ("Notification" in window && Notification.permission === "granted") {
+      new Notification(title, {
+        body: body,
+        icon: isError ? "❌" : "✅",
+        tag: "sprint-runner",
+      });
+    }
+  }
+
   // --- Chat functions ---
 
   function handleChatCreated(payload) {
@@ -636,4 +656,5 @@
   });
 
   connect();
+  requestNotificationPermission();
 })();

--- a/src/dashboard/sprint-history.ts
+++ b/src/dashboard/sprint-history.ts
@@ -1,36 +1,41 @@
 /**
- * Sprint History — Phase 5 (Dashboard)
+ * Sprint History — Dashboard
  *
- * Loads and structures historical sprint data for dashboard
- * visualization (velocity charts, trend lines, improvement tracking).
+ * Loads historical sprint data from velocity.md for dashboard display.
  */
 
+import { readVelocity } from "../documentation/velocity.js";
 import type { SprintMetrics } from "../types.js";
 
 /** A single sprint's historical record for visualization. */
 export interface SprintHistoryEntry {
-  /** Sequential sprint number. */
   sprintNumber: number;
-  /** ISO-8601 date string of sprint completion. */
   date: string;
-  /** The sprint's computed metrics. */
   metrics: SprintMetrics;
-  /** List of improvements applied during or after this sprint. */
   improvements: string[];
 }
 
 /**
  * Load historical sprint data for dashboard display.
- *
- * @returns Sprint history entries sorted by sprintNumber ascending.
+ * Parses velocity.md into structured entries.
  */
-export async function loadSprintHistory(): Promise<SprintHistoryEntry[]> {
-  // TODO: Phase 5 — load historical sprint data from velocity.md and sprint logs
-  //
-  // Planned approach:
-  //   1. Parse docs/sprints/velocity.md for per-sprint metrics
-  //   2. Parse individual sprint-NNN-retro.md files for improvements
-  //   3. Merge into SprintHistoryEntry[] sorted chronologically
+export function loadSprintHistory(velocityPath?: string): SprintHistoryEntry[] {
+  const entries = readVelocity(velocityPath);
 
-  return [];
+  return entries.map((e) => ({
+    sprintNumber: e.sprint,
+    date: e.date,
+    metrics: {
+      planned: e.planned,
+      completed: e.done,
+      failed: e.carry,
+      pointsPlanned: e.planned,
+      pointsCompleted: e.done,
+      velocity: e.issuesPerHr,
+      avgDuration: e.hours > 0 && e.done > 0 ? (e.hours / e.done) * 60 : 0,
+      firstPassRate: e.planned > 0 ? e.done / e.planned : 0,
+      driftIncidents: 0,
+    },
+    improvements: [],
+  }));
 }

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -13,6 +13,7 @@ import type { SprintEventBus, SprintEngineEvents } from "../tui/events.js";
 import type { SprintState } from "../runner.js";
 import { logger } from "../logger.js";
 import { ChatManager, type ChatRole } from "./chat-manager.js";
+import { loadSprintHistory } from "./sprint-history.js";
 
 const log = logger.child({ component: "ws-server" });
 
@@ -303,10 +304,18 @@ export class DashboardWebServer {
     res.setHeader("Content-Type", "application/json");
 
     if (pathname === "/api/sprints") {
-      // List available sprints from state files
       const sprints = this.listSprints();
       res.writeHead(200);
       res.end(JSON.stringify(sprints));
+      return;
+    }
+
+    if (pathname === "/api/sprints/history") {
+      const projectPath = this.options.projectPath ?? process.cwd();
+      const velocityPath = path.join(projectPath, "docs", "sprints", "velocity.md");
+      const history = loadSprintHistory(velocityPath);
+      res.writeHead(200);
+      res.end(JSON.stringify(history));
       return;
     }
 

--- a/tests/dashboard/ws-server.test.ts
+++ b/tests/dashboard/ws-server.test.ts
@@ -201,4 +201,13 @@ describe("DashboardWebServer", () => {
     expect(data.sprintNumber).toBe(999);
     expect(data.phase).toBe("init");
   });
+
+  it("serves /api/sprints/history", async () => {
+    await server.start();
+    const port = getPort(server);
+    const res = await fetch(`http://127.0.0.1:${port}/api/sprints/history`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Phase 4 Polish

### Sprint History
- Implement `loadSprintHistory()` — parses `velocity.md` into `SprintHistoryEntry[]`
- `GET /api/sprints/history` endpoint
- Maps velocity table data (planned, done, carry, hours, issues/hr) to `SprintMetrics` format

### Browser Notifications
- Request permission on page load
- Browser notification on sprint complete / sprint error
- Tag-based deduplication

### Tests
319 total (1 new API endpoint test).