### PR TITLE
feat: add GitHub links for issues and milestones in dashboard

### DIFF
--- a/src/dashboard/public/style.css
+++ b/src/dashboard/public/style.css
@@ -451,3 +451,19 @@ footer {
 main.chat-open {
   grid-template-columns: 280px 1fr 380px;
 }
+
+/* GitHub links */
+.gh-link {
+  color: var(--blue);
+  text-decoration: none;
+}
+.gh-link:hover {
+  text-decoration: underline;
+  color: #79c0ff;
+}
+#sprint-label .gh-link {
+  color: inherit;
+}
+#sprint-label .gh-link:hover {
+  color: var(--blue);
+}

--- a/tests/dashboard/ws-server.test.ts
+++ b/tests/dashboard/ws-server.test.ts
@@ -269,4 +269,23 @@ describe("DashboardWebServer", () => {
     const res = await fetch(`http://127.0.0.1:${port}/api/unknown`);
     expect(res.status).toBe(404);
   });
+
+  it("serves /api/repo with repo URL", async () => {
+    await server.start();
+    const port = getPort(server);
+    const res = await fetch(`http://127.0.0.1:${port}/api/repo`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    // Should have a url field (may be null in test env without git remote)
+    expect(data).toHaveProperty("url");
+  });
+
+  it("serves /api/sprints/:n/issues from cache", async () => {
+    await server.start();
+    const port = getPort(server);
+    const res = await fetch(`http://127.0.0.1:${port}/api/sprints/1/issues`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Adds clickable GitHub links in the web dashboard for issues and sprint milestones.

## Changes

### Backend: `/api/repo` endpoint
- Detects GitHub repo URL from `git remote get-url origin`
- Handles both SSH (`git@github.com:owner/repo.git`) and HTTPS URLs
- Cached after first detection (only runs `git` once)

### Frontend: Clickable links
- **Issue numbers** → link to `github.com/{owner}/{repo}/issues/{N}` (opens in new tab)
- **Sprint label** → links to `github.com/{owner}/{repo}/milestone/{N}` with ↗ indicator
- Links styled in blue with underline on hover, consistent with dark theme
- Falls back to plain text if repo URL not available

### Tests
- `/api/repo` endpoint test
- `/api/sprints/:n/issues` cache endpoint test
- 333 total tests passing