### PR TITLE
docs(types): add @deprecated tag to customInstructions (#27)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -212,6 +212,7 @@ export interface SprintConfig {
   squashMerge: boolean;
   deleteBranchAfterMerge: boolean;
   sessionTimeoutMs: number;
+  /** @deprecated Use globalInstructions or per-phase instructions instead. */
   customInstructions: string;
   autoApproveTools: boolean;
   allowToolPatterns: string[];


### PR DESCRIPTION
Closes #27

## Summary
Added @deprecated JSDoc tag to the `customInstructions` field in `SprintConfig` interface. This field is unused (always set to `""`) and has been superseded by `globalInstructions` and per-phase `instructions`.

## Changes
- Added JSDoc deprecation notice to `src/types.ts`

## Test Coverage
No new tests required - this is a documentation-only change with no runtime impact.

## Definition of Done
- [x] Code implemented - JSDoc tag added
- [x] Lint clean - 0 errors
- [x] Type clean - 0 errors  
- [x] Tests pass - 0 failures
- [x] Diff size - 1 line (well within 300 limit)
- [x] No unrelated changes - only modified relevant file