### PR TITLE
fix: show Worker Agent type in issue activity (#44)

### DIFF
--- a/src/dashboard/public/app.js
+++ b/src/dashboard/public/app.js
@@ -176,7 +176,7 @@
       case "issue:start":
         updateIssueStatus(payload.issue.number, "in-progress");
         const issueLabel = `#${payload.issue.number} ${payload.issue.title}`;
-        const model = payload.model ? `Agent: ${payload.model}` : null;
+        const model = payload.model ? `Worker Agent (${payload.model})` : "Worker Agent";
         addActivity("issue", issueLabel, model, "active");
         break;
 
@@ -204,8 +204,11 @@
       case "sprint:error":
         state.phase = "failed";
         renderHeader();
-        addActivity("sprint", "Sprint error", payload.error, "failed");
-        showNotification("Sprint Error", payload.error, true);
+        const errMsg = typeof payload.error === 'string' && payload.error.length > 200
+          ? payload.error.substring(0, 200) + '…'
+          : payload.error;
+        addActivity("sprint", "Sprint error", errMsg, "failed");
+        showNotification("Sprint Error", errMsg, true);
         break;
 
       case "log":


### PR DESCRIPTION
## Changes

- Issue start activity now shows **Worker Agent (model)** instead of just `Agent: model`
- Sprint error messages truncated to 200 chars in activity panel to prevent UI overflow with long JSON errors

## Testing

All 340 tests pass.

Closes #44