### PR TITLE
feat: add test setup and cleanup scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help check fix lint format typecheck test test-quick coverage build notify clean install
+.PHONY: help check fix lint format typecheck test test-quick coverage build notify clean install test-setup test-cleanup test-web
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
@@ -65,3 +65,14 @@ notify: ## Send notification (MSG="your message")
 clean: ## Remove build artifacts
 	rm -rf dist/
 	rm -rf coverage/ .vitest/
+
+# === Test Sprint Runner ===
+
+test-setup: ## Create test issues and milestones
+	./scripts/test-setup.sh
+
+test-cleanup: ## Remove all test sprint artifacts
+	./scripts/test-cleanup.sh
+
+test-web: ## Run web dashboard in test mode
+	npx tsx src/index.ts web --config sprint-runner.test.yaml

--- a/scripts/test-cleanup.sh
+++ b/scripts/test-cleanup.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# scripts/test-cleanup.sh — Remove all test sprint artifacts
+#
+# Usage: ./scripts/test-cleanup.sh [--keep-issues]
+#
+# Removes:
+#   - All "Test Sprint N" milestones (closed first, then deleted)
+#   - All issues labeled "test-run" (closed)
+#   - All test-sprint/* remote branches
+#   - All test-sprint-*-state.json and test-sprint-*-log.md files
+#   - Sprint worktrees for test issues
+#
+# Use --keep-issues to only clean milestones, branches, and files
+# but leave the test issues open for re-use.
+
+set -euo pipefail
+
+KEEP_ISSUES=false
+if [[ "${1:-}" == "--keep-issues" ]]; then
+  KEEP_ISSUES=true
+fi
+
+PREFIX="test-sprint"
+LABEL="test-run"
+
+echo "🧹 Test Cleanup: Removing all test sprint artifacts"
+echo ""
+
+# --- 1. Close and delete test milestones ---
+echo "📋 Cleaning milestones..."
+milestone_count=0
+while IFS=$'\t' read -r num title state; do
+  [[ -z "$num" ]] && continue
+  if [[ "$title" == "Test Sprint"* ]]; then
+    # Close if open
+    if [[ "$state" == "open" ]]; then
+      gh api -X PATCH "repos/{owner}/{repo}/milestones/${num}" -f state=closed >/dev/null 2>&1 || true
+    fi
+    # Delete
+    gh api -X DELETE "repos/{owner}/{repo}/milestones/${num}" >/dev/null 2>&1 || true
+    echo "  ❌ Deleted milestone: ${title}"
+    ((milestone_count++)) || true
+  fi
+done < <(gh api "repos/{owner}/{repo}/milestones?state=all" --paginate -q '.[] | [.number, .title, .state] | @tsv' 2>/dev/null || echo "")
+
+if [[ $milestone_count -eq 0 ]]; then
+  echo "  (none found)"
+fi
+
+# --- 2. Close test issues ---
+if [[ "$KEEP_ISSUES" == false ]]; then
+  echo ""
+  echo "🎫 Closing test issues (label: ${LABEL})..."
+  issue_count=0
+  while read -r num; do
+    [[ -z "$num" ]] && continue
+    gh issue close "$num" -c "Closed by test cleanup script" 2>/dev/null || true
+    echo "  ❌ Closed issue #${num}"
+    ((issue_count++)) || true
+  done < <(gh issue list --label "${LABEL}" --state open --json number -q '.[].number' 2>/dev/null || echo "")
+
+  if [[ $issue_count -eq 0 ]]; then
+    echo "  (none found)"
+  fi
+else
+  echo ""
+  echo "🎫 Keeping test issues (--keep-issues flag)"
+fi
+
+# --- 3. Delete test branches (remote) ---
+echo ""
+echo "🌿 Cleaning remote branches..."
+branch_count=0
+while read -r branch; do
+  [[ -z "$branch" ]] && continue
+  branch_name="${branch#origin/}"
+  if [[ "$branch_name" == "${PREFIX}/"* ]]; then
+    git push origin --delete "$branch_name" 2>/dev/null || true
+    echo "  ❌ Deleted branch: ${branch_name}"
+    ((branch_count++)) || true
+  fi
+done < <(git branch -r --list "origin/${PREFIX}/*" 2>/dev/null || echo "")
+
+if [[ $branch_count -eq 0 ]]; then
+  echo "  (none found)"
+fi
+
+# Clean local branches too
+while read -r branch; do
+  [[ -z "$branch" ]] && continue
+  branch_name=$(echo "$branch" | sed 's/^[* ]*//')
+  if [[ "$branch_name" == "${PREFIX}/"* ]]; then
+    git branch -D "$branch_name" 2>/dev/null || true
+    echo "  ❌ Deleted local branch: ${branch_name}"
+  fi
+done < <(git branch --list "${PREFIX}/*" 2>/dev/null || echo "")
+
+# --- 4. Delete state and log files ---
+echo ""
+echo "📄 Cleaning state and log files..."
+file_count=0
+sprints_dir="docs/sprints"
+
+if [[ -d "$sprints_dir" ]]; then
+  for f in "${sprints_dir}"/${PREFIX}-*-state.json "${sprints_dir}"/${PREFIX}-*-log.md; do
+    if [[ -f "$f" ]]; then
+      rm "$f"
+      echo "  ❌ Deleted: ${f}"
+      ((file_count++)) || true
+    fi
+  done
+fi
+
+if [[ $file_count -eq 0 ]]; then
+  echo "  (none found)"
+fi
+
+# --- 5. Clean worktrees ---
+echo ""
+echo "🌲 Cleaning worktrees..."
+worktree_base="../sprint-worktrees"
+wt_count=0
+if [[ -d "$worktree_base" ]]; then
+  for wt in "${worktree_base}"/issue-*; do
+    if [[ -d "$wt" ]]; then
+      git worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"
+      echo "  ❌ Removed worktree: ${wt}"
+      ((wt_count++)) || true
+    fi
+  done
+fi
+
+if [[ $wt_count -eq 0 ]]; then
+  echo "  (none found)"
+fi
+
+echo ""
+echo "✅ Cleanup complete!"
+echo ""
+echo "▶ Re-create test data:"
+echo "   ./scripts/test-setup.sh"

--- a/scripts/test-setup.sh
+++ b/scripts/test-setup.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# scripts/test-setup.sh — Create test issues and milestones for sprint runner testing
+#
+# Usage: ./scripts/test-setup.sh [--sprints N] [--issues-per-sprint N]
+#
+# Creates:
+#   - "Test Sprint 1", "Test Sprint 2", ... milestones
+#   - Dummy issues assigned to each milestone with realistic acceptance criteria
+#   - Labels issues as status:ready
+#
+# All artifacts use the "Test Sprint" prefix so they're fully isolated
+# from production sprints.
+
+set -euo pipefail
+
+SPRINTS=${1:-2}
+ISSUES_PER_SPRINT=${2:-3}
+LABEL="test-run"
+PREFIX="Test Sprint"
+
+echo "🧪 Test Setup: Creating ${SPRINTS} sprints with ${ISSUES_PER_SPRINT} issues each"
+echo ""
+
+# Ensure test-run label exists
+if ! gh label list --json name -q '.[].name' | grep -q "^${LABEL}$"; then
+  gh label create "${LABEL}" --color "D4C5F9" --description "Test run issue — auto-created, safe to delete" 2>/dev/null || true
+  echo "📌 Created label: ${LABEL}"
+fi
+
+# Test issue definitions — realistic but clearly test content
+ISSUES=(
+  "test: Add input validation to config loader|## Acceptance Criteria\n\n- [ ] Validate that \`max_issues\` is between 1 and 50\n- [ ] Validate that \`session_timeout_ms\` is positive\n- [ ] Return clear error message on invalid config\n- [ ] Add unit tests for validation edge cases"
+  "test: Add retry count to sprint log output|## Acceptance Criteria\n\n- [ ] Sprint log includes retry count per issue\n- [ ] Format: \`Retries: N\` in huddle entry\n- [ ] Zero retries shows \`Retries: 0\`\n- [ ] Add test covering retry count display"
+  "test: Improve error message for missing milestone|## Acceptance Criteria\n\n- [ ] Error message includes the milestone name that was not found\n- [ ] Suggests creating the milestone with correct naming\n- [ ] Error is logged at warn level, not error\n- [ ] Add test for error message format"
+  "test: Add elapsed time to quality gate output|## Acceptance Criteria\n\n- [ ] Quality gate result includes \`elapsed_ms\` field\n- [ ] Each individual check has its own duration\n- [ ] Total duration is sum of all checks\n- [ ] Add tests for timing data"
+  "test: Export sprint metrics as JSON|## Acceptance Criteria\n\n- [ ] \`sprint-runner metrics --sprint N --json\` outputs JSON\n- [ ] JSON includes: velocity, first_pass_rate, avg_duration_ms\n- [ ] JSON output is valid and parseable\n- [ ] Add test for JSON output format"
+  "test: Add issue title to branch name|## Acceptance Criteria\n\n- [ ] Branch pattern supports \`{title}\` placeholder\n- [ ] Title is slugified (lowercase, hyphens, max 40 chars)\n- [ ] Special characters are stripped\n- [ ] Add tests for title slugification"
+)
+
+CREATED_ISSUES=()
+
+for sprint_num in $(seq 1 "$SPRINTS"); do
+  milestone="${PREFIX} ${sprint_num}"
+
+  # Create milestone if it doesn't exist
+  if gh api "repos/{owner}/{repo}/milestones" --paginate -q ".[].title" 2>/dev/null | grep -qF "$milestone"; then
+    echo "📋 Milestone already exists: ${milestone}"
+  else
+    gh api "repos/{owner}/{repo}/milestones" -f "title=${milestone}" -f "description=Test sprint for runner validation" >/dev/null
+    echo "📋 Created milestone: ${milestone}"
+  fi
+
+  # Create issues for this sprint
+  start_idx=$(( (sprint_num - 1) * ISSUES_PER_SPRINT ))
+  for i in $(seq 0 $((ISSUES_PER_SPRINT - 1))); do
+    idx=$(( (start_idx + i) % ${#ISSUES[@]} ))
+    IFS='|' read -r title body <<< "${ISSUES[$idx]}"
+
+    # Add sprint context to title to make each unique
+    full_title="${title} (S${sprint_num})"
+
+    # Check if issue already exists
+    if gh issue list --label "${LABEL}" --json title -q '.[].title' | grep -qF "$full_title"; then
+      echo "  ⏭  Issue already exists: ${full_title}"
+      issue_num=$(gh issue list --label "${LABEL}" --json number,title -q ".[] | select(.title==\"${full_title}\") | .number")
+    else
+      issue_num=$(gh issue create \
+        --title "$full_title" \
+        --body "$(echo -e "$body")" \
+        --label "${LABEL}" \
+        --label "status:ready" \
+        --milestone "${milestone}" \
+        2>/dev/null | grep -o '[0-9]*$')
+      echo "  ✅ Created issue #${issue_num}: ${full_title}"
+    fi
+    CREATED_ISSUES+=("$issue_num")
+  done
+done
+
+echo ""
+echo "✅ Test setup complete!"
+echo "   ${#CREATED_ISSUES[@]} issues across ${SPRINTS} sprints"
+echo ""
+echo "▶ Start test run:"
+echo "   npx tsx src/index.ts web --config sprint-runner.test.yaml"
+echo ""
+echo "🧹 Clean up when done:"
+echo "   ./scripts/test-cleanup.sh"


### PR DESCRIPTION
## What

Scripts for repeatable test sprint setup and teardown.

### `make test-setup` (scripts/test-setup.sh)
- Creates 2 test milestones: "Test Sprint 1", "Test Sprint 2"
- Creates 6 test issues with realistic acceptance criteria
- Labels all with `test-run` for easy identification
- Assigns to milestones, marks `status:ready`
- Idempotent — detects existing issues/milestones

### `make test-cleanup` (scripts/test-cleanup.sh)
- Deletes all "Test Sprint" milestones
- Closes all `test-run` labeled issues
- Deletes `test-sprint/*` branches (local + remote)
- Removes `test-sprint-*-state.json` and `test-sprint-*-log.md`
- Cleans sprint worktrees
- Supports `--keep-issues` flag

### `make test-web`
- Shortcut: `npx tsx src/index.ts web --config sprint-runner.test.yaml`

## Workflow

```bash
make test-setup     # Create 2 sprints × 3 issues
make test-web       # Launch dashboard in test mode
# ... test the app ...
make test-cleanup   # Nuke everything, clean slate
```

## Testing

Both scripts tested end-to-end. All 345 tests pass.