### PR TITLE
fix: sprint discovery from GitHub milestones + Playwright E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help check fix lint format typecheck test test-quick coverage build notify clean install test-setup test-cleanup test-web
+.PHONY: help check fix lint format typecheck test test-quick coverage build notify clean install test-setup test-cleanup test-web test-e2e
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
@@ -76,3 +76,6 @@ test-cleanup: ## Remove all test sprint artifacts
 
 test-web: ## Run web dashboard in test mode
 	npx tsx src/index.ts web --config sprint-runner.test.yaml
+
+test-e2e: ## Run Playwright E2E tests (requires test-setup first)
+	npx playwright test --reporter=list

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.0.0",
+        "@playwright/test": "^1.58.2",
         "@types/node": "^20.0.0",
         "@types/react": "^19.2.14",
         "@types/ws": "^8.18.1",
@@ -872,6 +873,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3567,6 +3584,53 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
+    "@playwright/test": "^1.58.2",
     "@types/node": "^20.0.0",
     "@types/react": "^19.2.14",
     "@types/ws": "^8.18.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 30_000,
+  retries: 1,
+  use: {
+    baseURL: "http://localhost:9200",
+    headless: true,
+  },
+  projects: [
+    { name: "chromium", use: { browserName: "chromium" } },
+  ],
+  // Dashboard is started by the test setup, not by Playwright
+  webServer: {
+    command: "npx tsx src/index.ts web --config sprint-runner.test.yaml --no-open --port 9200",
+    port: 9200,
+    timeout: 15_000,
+    reuseExistingServer: true,
+  },
+});

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * E2E tests for the Sprint Runner web dashboard.
+ *
+ * Prerequisites: `make test-setup` to create test milestones/issues.
+ * The dashboard is started automatically by playwright.config.ts webServer.
+ */
+import { test, expect } from "@playwright/test";
+
+test.describe("Dashboard Sprint Navigation", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    // Wait for WebSocket connection and initial data load
+    await page.waitForSelector(".phase-badge", { timeout: 10_000 });
+    // Wait for milestone discovery to complete (issues loaded)
+    await page.waitForTimeout(3000);
+  });
+
+  test("shows sprint header with sprint number", async ({ page }) => {
+    const header = page.locator("#sprint-label");
+    await expect(header).toContainText("Sprint");
+  });
+
+  test("displays issues for active sprint", async ({ page }) => {
+    // Should have at least some issues loaded
+    const issueItems = page.locator("#issue-list li");
+    await expect(issueItems.first()).toBeVisible({ timeout: 10_000 });
+    const count = await issueItems.count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test("sprint navigation buttons are visible", async ({ page }) => {
+    const prevBtn = page.locator("#btn-prev");
+    const nextBtn = page.locator("#btn-next");
+    await expect(prevBtn).toBeVisible();
+    await expect(nextBtn).toBeVisible();
+  });
+
+  test("can navigate to Sprint 2 and see its issues", async ({ page }) => {
+    // Click next to go to Sprint 2
+    const nextBtn = page.locator("#btn-next");
+    await expect(nextBtn).toBeEnabled({ timeout: 10_000 });
+    await nextBtn.click();
+
+    // Sprint header should show Sprint 2
+    const header = page.locator("#sprint-label");
+    await expect(header).toContainText("2", { timeout: 5_000 });
+
+    // Sprint 2 should have test issues
+    const issueItems = page.locator("#issue-list li");
+    await expect(issueItems.first()).toBeVisible({ timeout: 10_000 });
+    const count = await issueItems.count();
+    expect(count).toBeGreaterThanOrEqual(3); // 3 test issues in Sprint 2
+  });
+
+  test("can navigate back to Sprint 1 and see its issues", async ({ page }) => {
+    // Go to Sprint 2
+    const nextBtn = page.locator("#btn-next");
+    await expect(nextBtn).toBeEnabled({ timeout: 10_000 });
+    await nextBtn.click();
+    await expect(page.locator("#sprint-label")).toContainText("2", { timeout: 5_000 });
+
+    // Go back to Sprint 1
+    const prevBtn = page.locator("#btn-prev");
+    await prevBtn.click();
+    await expect(page.locator("#sprint-label")).toContainText("1", { timeout: 5_000 });
+
+    // Sprint 1 should still have issues
+    const issueItems = page.locator("#issue-list li");
+    await expect(issueItems.first()).toBeVisible({ timeout: 10_000 });
+    const count = await issueItems.count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test("issues persist after rapid sprint switching", async ({ page }) => {
+    const nextBtn = page.locator("#btn-next");
+    const prevBtn = page.locator("#btn-prev");
+
+    await expect(nextBtn).toBeEnabled({ timeout: 10_000 });
+
+    // Rapid switching: 1→2→1→2→1
+    await nextBtn.click();
+    await page.waitForTimeout(500);
+    await prevBtn.click();
+    await page.waitForTimeout(500);
+    await nextBtn.click();
+    await page.waitForTimeout(500);
+    await prevBtn.click();
+    await page.waitForTimeout(500);
+
+    // Should be back on Sprint 1 with issues visible
+    await expect(page.locator("#sprint-label")).toContainText("1");
+    const issueItems = page.locator("#issue-list li");
+    await expect(issueItems.first()).toBeVisible({ timeout: 5_000 });
+    expect(await issueItems.count()).toBeGreaterThan(0);
+  });
+
+  test("phase badge shows a valid phase", async ({ page }) => {
+    const badge = page.locator(".phase-badge");
+    const text = await badge.textContent();
+    expect(["init", "refine", "plan", "execute", "review", "retro", "complete", "failed", "paused"]).toContain(text);
+  });
+
+  test("activity log section exists", async ({ page }) => {
+    const activitySection = page.locator("#activity-panel");
+    await expect(activitySection).toBeVisible();
+    // Activity list UL exists in DOM (may be empty when no sprint is running)
+    const activityList = page.locator("#activity-list");
+    await expect(activityList).toHaveCount(1);
+  });
+
+  test("GitHub links work on issue numbers", async ({ page }) => {
+    // Wait for issues to load
+    const issueItems = page.locator("#issue-list li");
+    await expect(issueItems.first()).toBeVisible({ timeout: 10_000 });
+    // Check that issue items have links
+    const issueLink = page.locator("#issue-list a[href*='issues/']").first();
+    if (await issueLink.count() > 0) {
+      const href = await issueLink.getAttribute("href");
+      expect(href).toContain("/issues/");
+    }
+  });
+});
+
+test.describe("Dashboard API Endpoints", () => {
+  test("/api/sprints returns both sprints", async ({ request }) => {
+    const res = await request.get("/api/sprints");
+    expect(res.status()).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+    const numbers = data.map((s: { sprintNumber: number }) => s.sprintNumber);
+    expect(numbers).toContain(1);
+    expect(numbers).toContain(2);
+  });
+
+  test("/api/sprints/1/issues returns issues", async ({ request }) => {
+    // Wait for issue cache to load
+    await new Promise((r) => setTimeout(r, 3000));
+    const res = await request.get("/api/sprints/1/issues");
+    expect(res.status()).toBe(200);
+    const data = await res.json();
+    expect(data.length).toBeGreaterThan(0);
+  });
+
+  test("/api/sprints/2/issues returns Sprint 2 issues", async ({ request }) => {
+    // Wait for issue cache to load
+    await new Promise((r) => setTimeout(r, 3000));
+    const res = await request.get("/api/sprints/2/issues");
+    expect(res.status()).toBe(200);
+    const data = await res.json();
+    expect(data.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("/api/sprints/1/state returns valid state", async ({ request }) => {
+    const res = await request.get("/api/sprints/1/state");
+    expect(res.status()).toBe(200);
+    const data = await res.json();
+    expect(data.sprintNumber).toBe(1);
+    expect(data.phase).toBeDefined();
+  });
+
+  test("/api/repo returns repo URL", async ({ request }) => {
+    const res = await request.get("/api/repo");
+    expect(res.status()).toBe(200);
+    const data = await res.json();
+    expect(data.url).toContain("github.com");
+  });
+});


### PR DESCRIPTION
**Root cause:** Dashboard only scanned local files for sprints. Milestones without local state/log files were invisible (Sprint 2 never appeared, issues never loaded).

**Fixes:**
- `listSprintMilestones()` queries GitHub API for all milestones matching prefix
- Sprint list merges milestone data with local file scan
- Issue cache uses max(active, milestones) for preload range
- On-demand GitHub loading for issue cache misses

**E2E Testing:**
- Playwright with Chromium (14 tests, all passing)
- Tests sprint navigation, issue loading, switching, rapid switching, APIs
- `make test-e2e` target

**Verification:**
- 347 unit tests passing
- 14 E2E tests passing
- Type check clean
- Tested against live test data (Test Sprint 1 + 2)