### PR TITLE
fix: elapsed timer no longer resets on sprint switch

### DIFF
--- a/src/dashboard/public/app.js
+++ b/src/dashboard/public/app.js
@@ -9,6 +9,7 @@
   let issues = [];
   let activities = [];
   let elapsedTimer = null;
+  let elapsedTimerStartedAt = null; // Track which startedAt the timer is running for
   let availableSprints = [];
   let activeSprintNumber = 0; // The sprint actually running
   let viewingSprintNumber = 0; // The sprint being displayed
@@ -259,15 +260,21 @@
     // Update nav button states
     updateNavButtons();
 
-    // Elapsed timer
-    if (elapsedTimer) clearInterval(elapsedTimer);
-    if (state.startedAt && state.phase !== "complete" && state.phase !== "failed" && state.phase !== "init") {
-      updateElapsed();
-      elapsedTimer = setInterval(updateElapsed, 1000);
-    } else if (state.startedAt) {
-      updateElapsed();
-    } else {
-      elapsedEl.textContent = "0m 00s";
+    // Elapsed timer — only restart if startedAt changed
+    const currentStartedAt = state.startedAt ? new Date(state.startedAt).getTime() : null;
+    if (currentStartedAt !== elapsedTimerStartedAt) {
+      if (elapsedTimer) clearInterval(elapsedTimer);
+      elapsedTimer = null;
+      elapsedTimerStartedAt = currentStartedAt;
+
+      if (state.startedAt && state.phase !== "complete" && state.phase !== "failed" && state.phase !== "init") {
+        updateElapsed();
+        elapsedTimer = setInterval(updateElapsed, 1000);
+      } else if (state.startedAt) {
+        updateElapsed();
+      } else {
+        elapsedEl.textContent = "0m 00s";
+      }
     }
 
     // Toggle start button — only on active sprint


### PR DESCRIPTION
**Problem:** The elapsed timer in the sprint header reloads/resets when switching between sprints and back.

**Root cause:** `renderHeader()` unconditionally clears and restarts the timer interval on every call. Sprint switching triggers multiple `renderHeader()` calls, each killing and restarting the timer.

**Fix:** Track which `startedAt` value the timer is currently running for (`elapsedTimerStartedAt`). Only restart the timer interval when the timestamp actually changes. Same sprint → timer keeps ticking smoothly.

347 unit tests passing, type check clean.