### PR TITLE
fix: filter backlog issues by label in sprint planning

### DIFF
--- a/sprint-runner.test.yaml
+++ b/sprint-runner.test.yaml
@@ -38,6 +38,7 @@ sprint:
   max_retries: 1
   enable_challenger: false
   auto_revert_drift: false
+  backlog_labels: ["test-run"]
 
 quality_gates:
   require_tests: true

--- a/src/ceremonies/planning.ts
+++ b/src/ceremonies/planning.ts
@@ -26,9 +26,13 @@ export async function runSprintPlanning(
   const velocity = readVelocity();
   const velocityStr = JSON.stringify(velocity);
 
-  // List available backlog issues
-  const backlog = await listIssues({ state: "open" });
-  log.info({ count: backlog.length }, "Loaded backlog issues");
+  // List available backlog issues (filtered by backlog_labels if configured)
+  const listOpts: { state: string; labels?: string[] } = { state: "open" };
+  if (config.backlogLabels.length > 0) {
+    listOpts.labels = config.backlogLabels;
+  }
+  const backlog = await listIssues(listOpts);
+  log.info({ count: backlog.length, labels: config.backlogLabels }, "Loaded backlog issues");
 
   // Read prompt template
   const templatePath = path.join(config.projectPath, "prompts", "planning.md");

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,6 +69,7 @@ const SprintSchema = z.object({
   max_retries: z.number().int().min(0).default(2),
   enable_challenger: z.boolean().default(true),
   auto_revert_drift: z.boolean().default(false),
+  backlog_labels: z.array(z.string()).default([]),
 });
 
 const QualityGatesSchema = z.object({

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ function buildSprintConfig(config: ConfigFile, sprintNumber: number): SprintConf
     maxRetries: config.sprint.max_retries,
     enableChallenger: config.sprint.enable_challenger,
     autoRevertDrift: config.sprint.auto_revert_drift,
+    backlogLabels: config.sprint.backlog_labels,
     autoMerge: config.git.auto_merge,
     squashMerge: config.git.squash_merge,
     deleteBranchAfterMerge: config.git.delete_branch_after_merge,

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,6 +210,7 @@ export interface SprintConfig {
   maxRetries: number;
   enableChallenger: boolean;
   autoRevertDrift: boolean;
+  backlogLabels: string[];
   autoMerge: boolean;
   squashMerge: boolean;
   deleteBranchAfterMerge: boolean;

--- a/tests/ceremonies/ceremony-coverage.test.ts
+++ b/tests/ceremonies/ceremony-coverage.test.ts
@@ -98,6 +98,7 @@ const config: SprintConfig = {
   maxRetries: 2,
   enableChallenger: true,
   autoRevertDrift: false,
+  backlogLabels: [],
   autoMerge: true,
   squashMerge: true,
   deleteBranchAfterMerge: true,

--- a/tests/ceremonies/execution.test.ts
+++ b/tests/ceremonies/execution.test.ts
@@ -106,6 +106,7 @@ function makeConfig(overrides: Partial<SprintConfig> = {}): SprintConfig {
     maxRetries: 2,
     enableChallenger: false,
     autoRevertDrift: false,
+  backlogLabels: [],
     autoMerge: true,
     squashMerge: true,
     deleteBranchAfterMerge: true,

--- a/tests/ceremonies/parallel-dispatcher.test.ts
+++ b/tests/ceremonies/parallel-dispatcher.test.ts
@@ -87,6 +87,7 @@ function makeConfig(overrides: Partial<SprintConfig> = {}): SprintConfig {
     maxRetries: 1,
     enableChallenger: false,
     autoRevertDrift: false,
+  backlogLabels: [],
     autoMerge: true,
     squashMerge: true,
     deleteBranchAfterMerge: true,

--- a/tests/ceremonies/planning.test.ts
+++ b/tests/ceremonies/planning.test.ts
@@ -160,6 +160,7 @@ function makeConfig(overrides: Partial<SprintConfig> = {}): SprintConfig {
     maxRetries: 1,
     enableChallenger: false,
     autoRevertDrift: false,
+  backlogLabels: [],
     autoMerge: true,
     squashMerge: true,
     deleteBranchAfterMerge: true,

--- a/tests/enforcement/challenger.test.ts
+++ b/tests/enforcement/challenger.test.ts
@@ -68,6 +68,7 @@ const config: SprintConfig = {
   maxRetries: 2,
   enableChallenger: true,
   autoRevertDrift: false,
+  backlogLabels: [],
   autoMerge: true,
   squashMerge: true,
   deleteBranchAfterMerge: true,

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -162,6 +162,7 @@ function makeConfig(overrides: Partial<SprintConfig> = {}): SprintConfig {
     maxRetries: 2,
     enableChallenger: false,
     autoRevertDrift: false,
+  backlogLabels: [],
     autoMerge: true,
     squashMerge: true,
     deleteBranchAfterMerge: true,

--- a/tests/tui/events.test.ts
+++ b/tests/tui/events.test.ts
@@ -24,6 +24,7 @@ const makeConfig = (): SprintConfig => ({
   maxRetries: 1,
   enableChallenger: false,
   autoRevertDrift: false,
+  backlogLabels: [],
   autoMerge: true,
   squashMerge: true,
   deleteBranchAfterMerge: true,


### PR DESCRIPTION
## Problem

The sprint planner fetched **ALL** open issues (`listIssues({ state: "open" })`) without any label or milestone filtering. This caused test sprints to pick up real issues (#82, #94, #96) instead of only test issues (#98, #99, #100).

## Solution

- Add `backlog_labels` config option to `SprintSchema` (default: `[]` = no filtering)
- When set, `runSprintPlanning()` passes labels to `listIssues()` so only matching issues are visible to the planner
- Test config (`sprint-runner.test.yaml`) now uses `backlog_labels: ["test-run"]` to isolate test issues

## Cleanup

Removed real issues #82, #94, #96 from the Test Sprint 1 milestone (they were incorrectly assigned by a previous unfiltered planning run).

## Changes

- `src/config.ts`: Add `backlog_labels` to SprintSchema
- `src/types.ts`: Add `backlogLabels` to SprintConfig interface
- `src/index.ts`: Map config to SprintConfig
- `src/ceremonies/planning.ts`: Filter backlog by labels when configured
- `sprint-runner.test.yaml`: Add `backlog_labels: ["test-run"]`
- 7 test files: Add `backlogLabels: []` to test fixtures