### PR TITLE
chore(ci): allow coverage badge step to fail without blocking CI (#109)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Update Coverage Badge
         if: github.ref == 'refs/heads/main'
+        continue-on-error: true
         uses: schneegans/dynamic-badges-action@v1.7.0
         with:
           auth: ${{ secrets.GIST_SECRET }}


### PR DESCRIPTION
## Closes #109

## Summary
Adds `continue-on-error: true` to the "Update Coverage Badge" step in the CI workflow to prevent 401 Unauthorized errors from blocking CI when the gist configuration is incomplete.

## Changes
- Modified `.github/workflows/ci.yml` to allow the coverage badge update step to fail gracefully
- CI will now show green status when tests/lint/types pass, even if badge upload fails

## Test Coverage
- No unit tests needed (CI configuration change)
- Verification will be done by observing CI behavior on main branch after merge

## Definition of Done
- [x] Code implemented — single-line change addresses acceptance criteria
- [x] Lint clean — 0 errors
- [x] Type clean — 0 errors  
- [x] Tests pass — 347 passed, 0 failed
- [x] Diff size — 1 line (within 300 line limit)
- [x] No unrelated changes — only CI workflow file modified
- [x] Conventional commit format used

## Impact
- ✅ CI accurately reflects code quality (green when tests pass)
- ✅ PRs with passing tests will show green CI, enabling auto-merge
- ⚠️ Coverage badge will not update until gistID and GIST_SECRET are properly configured (deferred work)