### PR TITLE
revert: remove per-file license headers

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import { spawn, type ChildProcess } from "node:child_process";
 import {
   ClientSideConnection,

--- a/src/acp/permissions.ts
+++ b/src/acp/permissions.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import type {
   RequestPermissionRequest,
   RequestPermissionResponse,

--- a/src/acp/session-config.ts
+++ b/src/acp/session-config.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 // Resolve MCP servers and instructions for a given ceremony phase.
 // Merges global config with phase-specific overrides.
 

--- a/src/acp/session-pool.ts
+++ b/src/acp/session-pool.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import { type AcpClient } from "./client.js";
 import type { McpServer } from "@agentclientprotocol/sdk";
 import { logger as defaultLogger, type Logger } from "../logger.js";

--- a/src/ceremonies/dep-graph.ts
+++ b/src/ceremonies/dep-graph.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import type { SprintIssue } from "../types.js";
 
 export interface ExecutionGroup {

--- a/src/ceremonies/execution.ts
+++ b/src/ceremonies/execution.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { AcpClient } from "../acp/client.js";

--- a/src/ceremonies/helpers.ts
+++ b/src/ceremonies/helpers.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 /**
  * Shared helpers for sprint ceremony modules.
  */

--- a/src/ceremonies/merge-pipeline.ts
+++ b/src/ceremonies/merge-pipeline.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import type { AcpClient } from "../acp/client.js";
 import type { SprintConfig, IssueResult } from "../types.js";
 import { mergeBranch } from "../git/merge.js";

--- a/src/ceremonies/parallel-dispatcher.ts
+++ b/src/ceremonies/parallel-dispatcher.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import pLimit from "p-limit";
 import type { AcpClient } from "../acp/client.js";
 import type {

--- a/src/ceremonies/planning.ts
+++ b/src/ceremonies/planning.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { AcpClient } from "../acp/client.js";

--- a/src/ceremonies/refinement.ts
+++ b/src/ceremonies/refinement.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { AcpClient } from "../acp/client.js";

--- a/src/ceremonies/retro.ts
+++ b/src/ceremonies/retro.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { AcpClient } from "../acp/client.js";

--- a/src/ceremonies/review.ts
+++ b/src/ceremonies/review.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { AcpClient } from "../acp/client.js";

--- a/src/ceremonies/worker-status.ts
+++ b/src/ceremonies/worker-status.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 export interface WorkerStatus {
   issueNumber: number;
   status: "queued" | "running" | "completed" | "failed";

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 // Config loader: parse sprint-runner.config.yaml with Zod validation
 
 import * as fs from "node:fs";

--- a/src/dashboard/chat-manager.ts
+++ b/src/dashboard/chat-manager.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 /**
  * Chat Manager — manages interactive ACP chat sessions for the web dashboard.
  *

--- a/src/dashboard/issue-cache.ts
+++ b/src/dashboard/issue-cache.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 /**
  * Sprint Issue Cache
  *

--- a/src/dashboard/sprint-history.ts
+++ b/src/dashboard/sprint-history.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 /**
  * Sprint History — Dashboard
  *

--- a/src/dashboard/web-ui.ts
+++ b/src/dashboard/web-ui.ts
@@ -1,3 +1,2 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 // Web UI — re-exports from ws-server for backward compatibility
 export { DashboardWebServer, type DashboardServerOptions, type IssueEntry } from "./ws-server.js";

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 /**
  * Dashboard WebSocket Server
  *

--- a/src/documentation/huddle.ts
+++ b/src/documentation/huddle.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import type { HuddleEntry } from "../types.js";
 
 function statusIcon(status: "completed" | "failed"): string {

--- a/src/documentation/sprint-log.ts
+++ b/src/documentation/sprint-log.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import fs from "node:fs";
 import path from "node:path";
 import { logger } from "../logger.js";

--- a/src/documentation/velocity.ts
+++ b/src/documentation/velocity.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import fs from "node:fs";
 import path from "node:path";
 import { logger } from "../logger.js";

--- a/src/enforcement/challenger.ts
+++ b/src/enforcement/challenger.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import { diffStat } from "../git/diff-analysis.js";
 import { getIssue } from "../github/issues.js";
 import { logger } from "../logger.js";

--- a/src/enforcement/ci-cd.ts
+++ b/src/enforcement/ci-cd.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import { execGh } from "../github/issues.js";
 import { addComment } from "../github/issues.js";
 import { logger } from "../logger.js";

--- a/src/enforcement/code-review.ts
+++ b/src/enforcement/code-review.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 // Automated code review step in the execution pipeline.
 // Runs after quality gate passes. Uses ACP with the reviewer model
 // to analyze the diff for bugs, security issues, and logic errors.

--- a/src/enforcement/drift-control.ts
+++ b/src/enforcement/drift-control.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import { logger } from "../logger.js";
 import type { DriftReport } from "../types.js";
 

--- a/src/enforcement/escalation.ts
+++ b/src/enforcement/escalation.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import { createIssue } from "../github/issues.js";

--- a/src/enforcement/quality-gate.ts
+++ b/src/enforcement/quality-gate.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import { glob } from "glob";

--- a/src/git/diff-analysis.ts
+++ b/src/git/diff-analysis.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import { logger } from "../logger.js";

--- a/src/git/merge.ts
+++ b/src/git/merge.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import { execGh } from "../github/issues.js";

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import { logger } from "../logger.js";

--- a/src/github/issues.ts
+++ b/src/github/issues.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { logger } from "../logger.js";

--- a/src/github/labels.ts
+++ b/src/github/labels.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import { execGh } from "./issues.js";
 import { logger } from "../logger.js";
 

--- a/src/github/milestones.ts
+++ b/src/github/milestones.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import { execGh } from "./issues.js";
 import { logger } from "../logger.js";
 

--- a/src/improvement/auto-improve.ts
+++ b/src/improvement/auto-improve.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 /**
  * Auto-Improvement — Phase 4 (Self-Improvement)
  *

--- a/src/improvement/config-tuner.ts
+++ b/src/improvement/config-tuner.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 /**
  * Config Tuner — Phase 4 (Self-Improvement)
  *

--- a/src/improvement/multi-repo.ts
+++ b/src/improvement/multi-repo.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 // Multi-repo support — Phase 4
 // TODO: Implement cross-repo sprint management
 

--- a/src/improvement/prompt-optimizer.ts
+++ b/src/improvement/prompt-optimizer.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 /**
  * Prompt Optimizer — Phase 4 (Self-Improvement)
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 
 /**
  * Sprint Runner CLI — ACP-powered autonomous sprint engine.

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import pino from "pino";
 import type { Logger, DestinationStream } from "pino";
 import * as fs from "node:fs";

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import type { SprintResult, SprintMetrics } from "./types.js";
 
 /**

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { AcpClient } from "./acp/client.js";

--- a/src/tui/events.ts
+++ b/src/tui/events.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 // Typed event system for SprintRunner → TUI communication.
 
 import { EventEmitter } from "node:events";

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -1,3 +1,2 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 export { App } from "./App.js";
 export { SprintEventBus } from "./events.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 trsdn. MIT License — see LICENSE for details.
 // Shared type definitions for the Sprint Runner
 
 // --- Sprint Planning ---


### PR DESCRIPTION
Removes the one-line copyright headers added in PR #148. Root LICENSE file is sufficient — per-file headers are unnecessary noise.