### PR TITLE
test(docs): add retry count to sprint log output (#151)

### DIFF
--- a/src/ceremonies/execution.ts
+++ b/src/ceremonies/execution.ts
@@ -395,6 +395,7 @@ export async function executeIssue(
       cleanupWarning,
       errorMessage,
       prStats,
+      retryCount,
     };
 
     const comment = formatHuddleComment(huddleEntry);

--- a/src/documentation/huddle.ts
+++ b/src/documentation/huddle.ts
@@ -90,6 +90,7 @@ export function formatSprintLogEntry(entry: HuddleEntry): string {
     `- **Duration**: ${duration}`,
     `- **Quality**: ${qualityStatus}`,
     `- **Files changed**: ${entry.filesChanged.length}`,
+    `- **Retries**: ${entry.retryCount}`,
   ];
 
   if (entry.prStats) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,6 +131,7 @@ export interface HuddleEntry {
   cleanupWarning?: string;
   errorMessage?: string;
   prStats?: { prNumber: number; additions: number; deletions: number; changedFiles: number };
+  retryCount: number;
 }
 
 // --- Ceremonies ---

--- a/tests/documentation/huddle.test.ts
+++ b/tests/documentation/huddle.test.ts
@@ -20,6 +20,7 @@ function makeEntry(overrides: Partial<HuddleEntry> = {}): HuddleEntry {
     duration_ms: 125_000,
     filesChanged: ["src/login.ts", "tests/login.test.ts"],
     timestamp: new Date("2025-01-15T10:30:00Z"),
+    retryCount: 0,
     ...overrides,
   };
 }
@@ -85,5 +86,15 @@ describe("formatSprintLogEntry", () => {
     expect(result).toContain("- **Status**: failed");
     expect(result).toContain("- **Quality**: FAILED");
     expect(result).toContain("❌ types: 5 type errors");
+  });
+
+  it("includes retry count in sprint log entry", () => {
+    const entryWithRetries = makeEntry({ retryCount: 2 });
+    const resultWithRetries = formatSprintLogEntry(entryWithRetries);
+    expect(resultWithRetries).toContain("- **Retries**: 2");
+
+    const entryNoRetries = makeEntry({ retryCount: 0 });
+    const resultNoRetries = formatSprintLogEntry(entryNoRetries);
+    expect(resultNoRetries).toContain("- **Retries**: 0");
   });
 });


### PR DESCRIPTION
Closes #151

## Summary

Adds retry count to sprint log output to provide visibility into how many times each issue execution was retried due to quality gate failures.

## Changes

- **types.ts**: Added `retryCount` field to `HuddleEntry` interface
- **execution.ts**: Wire `retryCount` from execution flow to huddle entry
- **huddle.ts**: Display retry count in `formatSprintLogEntry()` output
- **huddle.test.ts**: Added test coverage for retry count display

## Test Coverage

Added new test case `includes retry count in sprint log entry` that verifies:
- ✅ Sprint log shows retry count of 0 (first-pass success)
- ✅ Sprint log shows retry count > 0 (retried issues)
- ✅ All existing tests still pass (356/356)

## Quality Gates

- [x] **Code implemented** — retry count field added and displayed
- [x] **Lint clean** — 0 errors
- [x] **Type clean** — 0 errors  
- [x] **Tests written** — 1 new test with 2 scenarios
- [x] **Tests pass** — 356/356 tests passing
- [x] **Diff size** — 14 lines (well under 300)
- [x] **No unrelated changes** — only modified 4 relevant files

## Example Output

Sprint log entries now include:
```markdown
- **Status**: completed
- **Duration**: 2m 5s
- **Quality**: PASSED
- **Files changed**: 2
- **Retries**: 0
```