### PR TITLE
test(config): add input validation for URLs and empty strings (#150)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,29 +8,29 @@ import { z } from "zod";
 // --- Zod Schemas ---
 
 const NameValueSchema = z.object({
-  name: z.string(),
-  value: z.string(),
+  name: z.string().min(1),
+  value: z.string().min(1),
 });
 
 const McpServerStdioSchema = z.object({
   type: z.literal("stdio"),
-  name: z.string(),
-  command: z.string(),
+  name: z.string().min(1),
+  command: z.string().min(1),
   args: z.array(z.string()).default([]),
   env: z.array(NameValueSchema).optional(),
 });
 
 const McpServerHttpSchema = z.object({
   type: z.literal("http"),
-  name: z.string(),
-  url: z.string(),
+  name: z.string().min(1),
+  url: z.string().url(),
   headers: z.array(NameValueSchema).optional(),
 });
 
 const McpServerSseSchema = z.object({
   type: z.literal("sse"),
-  name: z.string(),
-  url: z.string(),
+  name: z.string().min(1),
+  url: z.string().url(),
   headers: z.array(NameValueSchema).optional(),
 });
 
@@ -47,12 +47,12 @@ const PhaseConfigSchema = z.object({
 });
 
 const ProjectSchema = z.object({
-  name: z.string(),
-  base_branch: z.string().default("main"),
+  name: z.string().min(1),
+  base_branch: z.string().min(1).default("main"),
 });
 
 const CopilotSchema = z.object({
-  executable: z.string().default("copilot"),
+  executable: z.string().min(1).default("copilot"),
   max_parallel_sessions: z.number().int().min(1).max(20).default(4),
   session_timeout_ms: z.number().int().min(0).default(600000),
   auto_approve_tools: z.boolean().default(true),
@@ -63,7 +63,7 @@ const CopilotSchema = z.object({
 });
 
 const SprintSchema = z.object({
-  prefix: z.string().default("Sprint"),
+  prefix: z.string().min(1).default("Sprint"),
   max_issues: z.number().int().min(1).default(8),
   max_drift_incidents: z.number().int().min(0).default(2),
   max_retries: z.number().int().min(0).default(2),
@@ -95,9 +95,10 @@ const EscalationSchema = z.object({
 });
 
 const GitSchema = z.object({
-  worktree_base: z.string().default("../sprint-worktrees"),
+  worktree_base: z.string().min(1).default("../sprint-worktrees"),
   branch_pattern: z
     .string()
+    .min(1)
     .default("{prefix}/{sprint}/issue-{issue}"),
   auto_merge: z.boolean().default(true),
   squash_merge: z.boolean().default(true),

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -121,6 +121,71 @@ copilot:
     const file = writeTmpConfig(invalid);
     expect(() => loadConfig(file)).toThrow();
   });
+
+  it("throws on invalid URL for HTTP MCP server", () => {
+    const invalid = `
+project:
+  name: "test"
+copilot:
+  mcp_servers:
+    - type: "http"
+      name: "test"
+      url: "not-a-url"
+`;
+    const file = writeTmpConfig(invalid);
+    expect(() => loadConfig(file)).toThrow();
+  });
+
+  it("throws on invalid URL for SSE MCP server", () => {
+    const invalid = `
+project:
+  name: "test"
+copilot:
+  mcp_servers:
+    - type: "sse"
+      name: "test"
+      url: "invalid"
+`;
+    const file = writeTmpConfig(invalid);
+    expect(() => loadConfig(file)).toThrow();
+  });
+
+  it("throws on empty project name", () => {
+    const invalid = `
+project:
+  name: ""
+`;
+    const file = writeTmpConfig(invalid);
+    expect(() => loadConfig(file)).toThrow();
+  });
+
+  it("throws on empty MCP server name", () => {
+    const invalid = `
+project:
+  name: "test"
+copilot:
+  mcp_servers:
+    - type: "stdio"
+      name: ""
+      command: "npx"
+`;
+    const file = writeTmpConfig(invalid);
+    expect(() => loadConfig(file)).toThrow();
+  });
+
+  it("throws on empty MCP server command", () => {
+    const invalid = `
+project:
+  name: "test"
+copilot:
+  mcp_servers:
+    - type: "stdio"
+      name: "test"
+      command: ""
+`;
+    const file = writeTmpConfig(invalid);
+    expect(() => loadConfig(file)).toThrow();
+  });
 });
 
 describe("substituteEnvVars", () => {


### PR DESCRIPTION
Closes #150

## Summary

Add stricter Zod validators to the config loader to prevent invalid configuration values from passing validation.

## Changes

### Validation Added

1. **URL validation** - HTTP and SSE MCP servers now require valid URLs ()
2. **Empty string validation** - Required string fields now reject empty strings ():
   - `project.name`
   - `project.base_branch`
   - MCP server `name` and `command` fields
   - `copilot.executable`
   - `sprint.prefix`
   - `git.worktree_base` and `git.branch_pattern`

### Test Coverage

Added 5 new test cases that verify invalid configs are rejected:
- Invalid HTTP URL
- Invalid SSE URL
- Empty project name
- Empty MCP server name
- Empty MCP server command

All 18 config tests passing (13 existing + 5 new).

## Definition of Done

- [x] Code implemented - addresses all validation gaps
- [x] Lint clean - 0 errors (only pre-existing warnings)
- [x] Type clean - 0 errors
- [x] Tests written - 5 new test cases (TDD approach)
- [x] Tests pass - 18/18 config tests pass, 359/360 full suite (1 pre-existing failure)
- [x] Diff size - 79 lines (well under 300 limit)
- [x] No unrelated changes - only config.ts and config.test.ts modified

## Testing

```bash
# TDD approach - tests written first (red phase)
npm run test tests/config.test.ts  # 5 tests failed as expected

# Implementation added (green phase)
npm run test tests/config.test.ts  # All 18 tests pass
npm run lint                        # 0 errors
npm run typecheck                   # 0 errors
```