### PR TITLE
test(dashboard): improve ws-server test reliability and prevent timeouts (#159)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["tests/**/*.test.ts"],
+    testTimeout: 10000, // 10s default for integration tests with network operations
     coverage: {
       provider: "v8",
       reporter: ["json-summary"],


### PR DESCRIPTION
## Summary

Fixes flaky ws-server.test.ts that blocked PR #158 for issue #152 in Sprint 1. Improves test reliability through explicit timeouts, proper cleanup, and reduced race conditions.

## Changes

### 1. Test Timeout Configuration
- Added 10s default test timeout in vitest.config.ts (up from implicit 5s)
- Added 15s per-test timeout for WebSocket integration tests
- Provides headroom for CI load and async milestone discovery

### 2. WebSocket Cleanup Improvements
- All WebSocket tests now use `ws.terminate()` in timeout handlers
- Added `resolved` flags to prevent race conditions
- Added 50ms delay in `afterEach` to ensure server cleanup completes
- Prevents port conflicts between tests

### 3. Test Helper Function
- Extracted `connectAndCollectMessages()` helper for simple message collection
- Reduces duplication in initial state connection test
- Handles cleanup automatically

### 4. Timeout Management
- All Promise timeouts properly clear timers on success
- Proper error handling prevents hanging tests
- 3s internal timeout for fast failure, 15s Vitest timeout for CI headroom

## Test Coverage

- All existing 23 tests pass
- Verified with 10 consecutive test runs (10/10 passed)
- Full test suite: 355/355 tests passing

## Definition of Done

- [x] Code implemented — all WebSocket tests improved
- [x] Lint clean — 0 errors
- [x] Type clean — 0 errors
- [x] Tests pass — 355/355 passing
- [x] Diff size — 174 lines (140 insertions, 34 deletions) ✓ under 300
- [x] No unrelated changes — only test files modified
- [x] 10 consecutive test runs passed

Closes #159