### PR TITLE
fix: dashboard stability — activity scoping, timer, markdown, phase stepper

### DIFF
--- a/src/dashboard/public/index.html
+++ b/src/dashboard/public/index.html
@@ -28,6 +28,21 @@
     </div>
   </header>
 
+  <!-- Phase Stepper -->
+  <nav id="phase-stepper" class="phase-stepper">
+    <span class="step" data-phase="refine">Refine</span>
+    <span class="step-arrow">→</span>
+    <span class="step" data-phase="plan">Plan</span>
+    <span class="step-arrow">→</span>
+    <span class="step" data-phase="execute">Execute</span>
+    <span class="step-arrow">→</span>
+    <span class="step" data-phase="review">Review</span>
+    <span class="step-arrow">→</span>
+    <span class="step" data-phase="retro">Retro</span>
+    <span class="step-arrow">→</span>
+    <span class="step" data-phase="complete">Done</span>
+  </nav>
+
   <!-- Main content -->
   <main>
     <!-- Left panel: Issues -->

--- a/src/dashboard/public/style.css
+++ b/src/dashboard/public/style.css
@@ -591,3 +591,67 @@ main.chat-open {
 main.session-open {
   grid-template-columns: 280px 1fr 380px;
 }
+
+/* --- Phase Stepper --- */
+.phase-stepper {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 16px;
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+}
+.step {
+  padding: 3px 10px;
+  border-radius: 12px;
+  background: var(--bg-hover);
+  color: var(--text-dim);
+  font-weight: 500;
+  transition: all 0.2s;
+}
+.step-arrow { color: var(--text-dim); font-size: 10px; }
+.step-done { background: var(--green); color: #000; }
+.step-active { background: var(--blue); color: #000; animation: pulse 1.5s infinite; }
+.step-failed { background: var(--red); color: #000; }
+@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.7; } }
+
+/* --- Failure Styling --- */
+.issue-fail-reason {
+  display: block;
+  font-size: 11px;
+  color: var(--red);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+}
+.activity-failed .activity-detail {
+  color: var(--red);
+  font-weight: 600;
+}
+
+/* --- Markdown in Session Viewer --- */
+.md-code-block {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px;
+  margin: 4px 0;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  overflow-x: auto;
+  white-space: pre;
+}
+.md-inline-code {
+  background: var(--bg-hover);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+.md-h1 { font-size: 16px; font-weight: 700; margin: 8px 0 4px; color: var(--text); }
+.md-h2 { font-size: 14px; font-weight: 600; margin: 6px 0 3px; color: var(--text); }
+.md-h3 { font-size: 13px; font-weight: 600; margin: 4px 0 2px; color: var(--text-dim); }
+.md-li { padding-left: 12px; }


### PR DESCRIPTION
## Dashboard Stability & Process Visibility

6 focused fixes addressing UX complaints:

### 1. Activity log sprint scoping
Activities from Sprint 1 no longer leak into Sprint 2. On `sprint:start`, old activities are saved to cache and cleared.

### 2. Timer freeze on complete
Elapsed timer freezes with ✓ when sprint completes. No more counting after finish. Final value persists on switch-back.

### 3. ACP session viewer markdown
Session output now renders markdown (code blocks, bold, headers, bullet lists) instead of plain text. Uses inline parser with XSS escaping.

### 4. Failure prominence
Failed issues show error reason directly in the issue list. Activity log failure entries styled in red with detailed reason.

### 5. Phase stepper
New horizontal phase indicator: Refine → Plan → Execute → Review → Retro → Done. Current phase pulses blue, completed phases green, failed phases red.

### 6. Session viewer speed
Refresh interval reduced 5s → 2s. Auto-opens newest active session when panel is visible.

## Tests
361 tests passing, type check clean, lint clean