### PR TITLE
fix: robustness improvements — sanitization, circuit breaker, state management, Zod schemas

### DIFF
--- a/src/ceremonies/refinement.ts
+++ b/src/ceremonies/refinement.ts
@@ -5,7 +5,7 @@ import type { SprintConfig, RefinedIssue } from "../types.js";
 import type { SprintEventBus } from "../tui/events.js";
 import { listIssues } from "../github/issues.js";
 import { logger } from "../logger.js";
-import { substitutePrompt, extractJson } from "./helpers.js";
+import { substitutePrompt, extractJson, sanitizePromptInput } from "./helpers.js";
 import { readVelocity } from "../documentation/velocity.js";
 import { resolveSessionConfig } from "../acp/session-config.js";
 
@@ -49,7 +49,7 @@ export async function runRefinement(
     REPO_OWNER: "",
     REPO_NAME: path.basename(config.projectPath),
     SPRINT_NUMBER: String(config.sprintNumber),
-    VELOCITY_DATA: velocityStr,
+    VELOCITY_DATA: sanitizePromptInput(velocityStr),
     BASE_BRANCH: config.baseBranch,
   });
 

--- a/src/ceremonies/review.ts
+++ b/src/ceremonies/review.ts
@@ -6,7 +6,7 @@ import type { SprintEventBus } from "../tui/events.js";
 import { calculateSprintMetrics, topFailedGates } from "../metrics.js";
 import { readVelocity } from "../documentation/velocity.js";
 import { logger } from "../logger.js";
-import { substitutePrompt, extractJson } from "./helpers.js";
+import { substitutePrompt, extractJson, sanitizePromptInput } from "./helpers.js";
 import { resolveSessionConfig } from "../acp/session-config.js";
 
 /**
@@ -48,8 +48,8 @@ export async function runSprintReview(
     REPO_NAME: path.basename(config.projectPath),
     SPRINT_NUMBER: String(config.sprintNumber),
     SPRINT_START_SHA: config.baseBranch,
-    SPRINT_ISSUES: JSON.stringify(issuesSummary),
-    VELOCITY_DATA: velocityStr,
+    SPRINT_ISSUES: sanitizePromptInput(JSON.stringify(issuesSummary)),
+    VELOCITY_DATA: sanitizePromptInput(velocityStr),
     BASE_BRANCH: config.baseBranch,
     METRICS: JSON.stringify(metrics),
     FAILED_GATES: failedGates,

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -1,0 +1,76 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { SprintConfig } from "./types.js";
+import type { SprintState } from "./runner.js";
+
+// Re-export types needed by consumers
+export type { SprintState };
+
+export const STATE_VERSION = "1";
+
+export function getStatePath(config: SprintConfig): string {
+  return path.join(
+    config.projectPath,
+    "docs",
+    "sprints",
+    `${config.sprintSlug}-${config.sprintNumber}-state.json`,
+  );
+}
+
+export function saveState(state: SprintState, filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmpPath = filePath + ".tmp";
+  const data = JSON.stringify({ ...state, version: STATE_VERSION }, null, 2);
+  fs.writeFileSync(tmpPath, data, "utf-8");
+  const fd = fs.openSync(tmpPath, "r");
+  fs.fsyncSync(fd);
+  fs.closeSync(fd);
+  fs.renameSync(tmpPath, filePath);
+}
+
+export function loadState(filePath: string): SprintState {
+  const raw = fs.readFileSync(filePath, "utf-8");
+  const parsed = JSON.parse(raw) as SprintState;
+  if (parsed.version && parsed.version !== STATE_VERSION) {
+    throw new Error(
+      `Incompatible sprint state version: got '${parsed.version}', expected '${STATE_VERSION}'. Delete the state file and restart.`,
+    );
+  }
+  parsed.startedAt = new Date(parsed.startedAt);
+  return parsed;
+}
+
+// --- Lock file ---
+
+export function acquireLock(config: SprintConfig): void {
+  const lockPath = getStatePath(config) + ".lock";
+  const pid = process.pid;
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  try {
+    // Try exclusive create — fails if file exists
+    fs.writeFileSync(lockPath, String(pid), { flag: "wx" });
+  } catch {
+    // Check if the holding process is alive
+    let existingPid: number | null = null;
+    try {
+      existingPid = parseInt(fs.readFileSync(lockPath, "utf-8"), 10);
+      process.kill(existingPid, 0); // Check if alive — throws if not
+      throw new Error(
+        `Sprint ${config.sprintNumber} is already running (PID ${existingPid}). Lock: ${lockPath}`,
+      );
+    } catch (e) {
+      if (e instanceof Error && e.message.includes("already running")) throw e;
+      // Stale lock — process is dead, take over
+      fs.writeFileSync(lockPath, String(pid));
+    }
+  }
+}
+
+export function releaseLock(config: SprintConfig): void {
+  const lockPath = getStatePath(config) + ".lock";
+  try {
+    fs.unlinkSync(lockPath);
+  } catch {
+    // Already removed
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,52 @@
 // Shared type definitions for the Sprint Runner
 
+import { z } from "zod";
+
+// --- Zod Response Schemas (for validating ACP responses) ---
+
+export const SprintPlanSchema = z.object({
+  sprintNumber: z.coerce.number(),
+  sprint_issues: z
+    .array(
+      z.object({
+        number: z.coerce.number(),
+        title: z.string().default(""),
+        ice_score: z.number().default(0),
+        depends_on: z.array(z.coerce.number()).default([]),
+        acceptanceCriteria: z.string().default(""),
+        expectedFiles: z.array(z.string()).default([]),
+        points: z.number().default(0),
+      }),
+    )
+    .min(1),
+  execution_groups: z.array(z.array(z.coerce.number())).optional(),
+  estimated_points: z.number().default(0),
+  rationale: z.string().default(""),
+});
+
+export const ReviewResultSchema = z.object({
+  summary: z.string().default("No summary provided"),
+  demoItems: z.array(z.string()).default([]),
+  velocityUpdate: z.string().default(""),
+  openItems: z.array(z.string()).default([]),
+});
+
+export const RetroResultSchema = z.object({
+  wentWell: z.array(z.string()).default([]),
+  wentBadly: z.array(z.string()).default([]),
+  improvements: z
+    .array(
+      z.object({
+        title: z.string(),
+        description: z.string(),
+        autoApplicable: z.boolean().default(false),
+        target: z.enum(["config", "agent", "skill", "process"]).default("process"),
+      }),
+    )
+    .default([]),
+  previousImprovementsChecked: z.boolean().default(false),
+});
+
 // --- Sprint Planning ---
 
 export interface SprintIssue {


### PR DESCRIPTION
## Changes

### Prompt input sanitization (#9, #10)
- All ceremony prompts now wrap user-derived content in `sanitizePromptInput()`
- Retro config filtered to sprint-relevant keys only (no MCP/ntfy leak)

### State management extraction (#11, #12)
- New `src/state-manager.ts` with `saveState`, `loadState`, `getStatePath`
- Instance locking via PID-based lockfile (stale lock detection)
- Runner delegates to state-manager; public API preserved via re-exports

### ACP circuit breaker (#13)
- Track consecutive failures; after 3 failures → 60s cooldown
- Prevents cascading timeouts when ACP is down

### Zod response schemas (#14, #15)
- `SprintPlanSchema`, `ReviewResultSchema`, `RetroResultSchema` in types.ts
- Planning uses `SprintPlanSchema.parse()` for validation + string→number coercion
- Replaces manual `sprint_issues` array check

**Tests:** 361 passing | **Lint:** 0 errors | **Types:** clean