### PR TITLE
feat: interactive ACP session control from dashboard

### DIFF
--- a/src/dashboard/public/index.html
+++ b/src/dashboard/public/index.html
@@ -93,8 +93,13 @@
         <div class="session-viewer-header">
           <button id="btn-back-sessions" class="btn btn-small">← Back</button>
           <span id="session-viewer-title"></span>
+          <button id="btn-stop-session" class="btn btn-small btn-danger" title="Stop session">⏹ Stop</button>
         </div>
         <pre id="session-output" class="session-output"></pre>
+        <div id="session-input-bar" class="session-input-bar">
+          <input id="session-message-input" type="text" placeholder="Send message to session…" autocomplete="off" />
+          <button id="btn-send-session" class="btn btn-small">Send</button>
+        </div>
       </div>
     </section>
   </main>

--- a/src/dashboard/public/style.css
+++ b/src/dashboard/public/style.css
@@ -587,6 +587,39 @@ main.chat-open {
   margin: 0;
 }
 
+.session-input-bar {
+  display: flex;
+  gap: 6px;
+  padding: 8px 0 0;
+}
+
+.session-input-bar input {
+  flex: 1;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 10px;
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 13px;
+}
+
+.session-input-bar input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.session-viewer-header .btn-danger {
+  margin-left: auto;
+  background: #d32f2f;
+  color: #fff;
+  border: none;
+}
+
+.session-viewer-header .btn-danger:hover {
+  background: #b71c1c;
+}
+
 /* Grid adjustment when session panel is open */
 main.session-open {
   grid-template-columns: 280px 1fr 380px;
@@ -655,3 +688,17 @@ main.session-open {
 .md-h2 { font-size: 14px; font-weight: 600; margin: 6px 0 3px; color: var(--text); }
 .md-h3 { font-size: 13px; font-weight: 600; margin: 4px 0 2px; color: var(--text-dim); }
 .md-li { padding-left: 12px; }
+
+/* Session control status messages */
+.session-status-msg {
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--accent);
+  background: rgba(79, 140, 255, 0.1);
+  border-radius: 4px;
+  margin-top: 4px;
+  animation: fadeIn 0.2s ease;
+}
+.session-status-warn { color: #ff9800; background: rgba(255, 152, 0, 0.1); }
+.session-status-err { color: #d32f2f; background: rgba(211, 47, 47, 0.1); }
+@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }

--- a/src/dashboard/session-control.ts
+++ b/src/dashboard/session-control.ts
@@ -1,0 +1,71 @@
+import { logger } from "../logger.js";
+
+export interface SessionMessage {
+  type: "user-message" | "stop";
+  content?: string;
+  timestamp: Date;
+}
+
+/**
+ * Per-session message queue for interactive dashboard control.
+ * The dashboard sends messages, execution picks them up between prompts.
+ */
+export class SessionController {
+  private queues = new Map<string, SessionMessage[]>();
+  private stopSignals = new Set<string>();
+  private log = logger.child({ module: "session-control" });
+
+  /** Queue a user message for delivery to a running ACP session. */
+  enqueue(sessionId: string, message: string): void {
+    if (!this.queues.has(sessionId)) {
+      this.queues.set(sessionId, []);
+    }
+    this.queues.get(sessionId)!.push({
+      type: "user-message",
+      content: message,
+      timestamp: new Date(),
+    });
+    this.log.info({ sessionId, queueSize: this.queues.get(sessionId)!.length }, "message queued");
+  }
+
+  /** Drain all pending messages for a session. Returns empty array if none. */
+  drain(sessionId: string): SessionMessage[] {
+    const messages = this.queues.get(sessionId) ?? [];
+    this.queues.delete(sessionId);
+    return messages;
+  }
+
+  /** Check if there are pending messages for a session. */
+  hasPending(sessionId: string): boolean {
+    return (this.queues.get(sessionId)?.length ?? 0) > 0;
+  }
+
+  /** Signal a session to stop. */
+  requestStop(sessionId: string): void {
+    this.stopSignals.add(sessionId);
+    this.log.warn({ sessionId }, "stop requested");
+  }
+
+  /** Check and clear stop signal. Returns true if session should stop. */
+  shouldStop(sessionId: string): boolean {
+    if (this.stopSignals.has(sessionId)) {
+      this.stopSignals.delete(sessionId);
+      return true;
+    }
+    return false;
+  }
+
+  /** Clean up a session's queue and signals. */
+  cleanup(sessionId: string): void {
+    this.queues.delete(sessionId);
+    this.stopSignals.delete(sessionId);
+  }
+
+  /** Get list of sessions with pending messages. */
+  getActiveSessions(): string[] {
+    return [...this.queues.keys()].filter(id => this.hasPending(id));
+  }
+}
+
+// Singleton for cross-module access
+export const sessionController = new SessionController();

--- a/tests/dashboard/session-control.test.ts
+++ b/tests/dashboard/session-control.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/logger.js", () => {
+  const noop = vi.fn();
+  return { logger: { child: () => ({ info: noop, warn: noop, error: noop, debug: noop }) } };
+});
+
+import { SessionController } from "../../src/dashboard/session-control.js";
+
+describe("SessionController", () => {
+  let ctrl: SessionController;
+
+  beforeEach(() => {
+    ctrl = new SessionController();
+  });
+
+  it("enqueue and drain messages", () => {
+    ctrl.enqueue("s1", "hello");
+    ctrl.enqueue("s1", "world");
+    expect(ctrl.hasPending("s1")).toBe(true);
+
+    const msgs = ctrl.drain("s1");
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]!.content).toBe("hello");
+    expect(msgs[1]!.content).toBe("world");
+    expect(msgs[0]!.type).toBe("user-message");
+    expect(ctrl.hasPending("s1")).toBe(false);
+  });
+
+  it("drain returns empty for unknown session", () => {
+    expect(ctrl.drain("unknown")).toEqual([]);
+  });
+
+  it("stop signal lifecycle", () => {
+    expect(ctrl.shouldStop("s1")).toBe(false);
+    ctrl.requestStop("s1");
+    expect(ctrl.shouldStop("s1")).toBe(true);
+    expect(ctrl.shouldStop("s1")).toBe(false); // cleared after check
+  });
+
+  it("cleanup removes queue and stop signal", () => {
+    ctrl.enqueue("s1", "test");
+    ctrl.requestStop("s1");
+    ctrl.cleanup("s1");
+    expect(ctrl.hasPending("s1")).toBe(false);
+    expect(ctrl.shouldStop("s1")).toBe(false);
+  });
+
+  it("getActiveSessions returns sessions with pending messages", () => {
+    ctrl.enqueue("s1", "a");
+    ctrl.enqueue("s2", "b");
+    expect(ctrl.getActiveSessions()).toContain("s1");
+    expect(ctrl.getActiveSessions()).toContain("s2");
+    ctrl.drain("s1");
+    expect(ctrl.getActiveSessions()).not.toContain("s1");
+  });
+});


### PR DESCRIPTION
Closes #55

## Changes

### SessionController (new: `src/dashboard/session-control.ts`)
- Per-session message queue for interactive dashboard control
- Stop signal management with cleanup
- Singleton pattern for cross-module access (`sessionController`)

### Execution integration (`src/ceremonies/execution.ts`)
- After main worker prompt completes, checks for queued messages
- Sends queued messages as follow-up prompts to the same ACP session
- Checks for stop signals and exits gracefully
- User messages visible in session output stream

### WebSocket server (`src/dashboard/ws-server.ts`)
- New message types: `session:send-message`, `session:stop`
- New response type: `session:status` (message-queued, stop-requested, error)
- Validates session is active before accepting messages

### Dashboard UI
- **Message input bar** at bottom of session viewer — type + Enter to send
- **Stop button** (⏹) in session viewer header with confirmation dialog
- **Visual feedback**: status messages for queued/stop/error states
- **CSS**: input styling, danger button, animated status messages

### Safety
- Confirmation dialog before stopping session (per AC)
- Stop signal is advisory — session finishes current action before exiting
- Messages only accepted for active (non-ended) sessions

### Verification
- 477 tests pass ✅ (5 new for SessionController)
- Types clean ✅
- Lint: 0 errors ✅