### PR TITLE
feat: dashboard ceremony controls, dual-mode, backlog/ideas views

### DIFF
--- a/src/dashboard/public/index.html
+++ b/src/dashboard/public/index.html
@@ -22,11 +22,25 @@
     <div class="header-right">
       <span id="issue-count" class="issue-count">0/0 done</span>
       <span id="elapsed" class="elapsed">0m 00s</span>
+      <select id="mode-toggle" class="mode-toggle" title="Execution mode">
+        <option value="autonomous">🤖 Autonomous</option>
+        <option value="hitl">👤 Human-in-the-Loop</option>
+      </select>
       <button id="btn-start" class="btn btn-primary" title="Start sprint">▶ Start</button>
+      <button id="btn-pause" class="btn btn-warn" title="Pause sprint" style="display:none">⏸ Pause</button>
+      <button id="btn-resume" class="btn btn-primary" title="Resume sprint" style="display:none">▶ Resume</button>
+      <button id="btn-stop" class="btn btn-danger" title="Stop sprint" style="display:none">⏹ Stop</button>
       <button id="btn-sessions" class="btn" title="View ACP Sessions">🔍 Sessions</button>
       <button id="btn-chat" class="btn" title="Open Agent Chat">💬 Chat</button>
     </div>
   </header>
+
+  <!-- Navigation Tabs -->
+  <nav id="tab-nav" class="tab-nav">
+    <button class="tab-btn tab-active" data-tab="sprint">🏃 Sprint</button>
+    <button class="tab-btn" data-tab="backlog">📋 Backlog</button>
+    <button class="tab-btn" data-tab="ideas">💡 Ideas</button>
+  </nav>
 
   <!-- Phase Stepper -->
   <nav id="phase-stepper" class="phase-stepper">
@@ -45,19 +59,50 @@
 
   <!-- Main content -->
   <main>
-    <!-- Left panel: Issues -->
-    <section id="issues-panel" class="panel">
-      <h2>Issues</h2>
-      <ul id="issue-list"></ul>
-    </section>
+    <!-- Sprint Tab (default) -->
+    <div id="tab-sprint" class="tab-content tab-visible">
+      <!-- Left panel: Issues -->
+      <section id="issues-panel" class="panel">
+        <h2>Issues</h2>
+        <ul id="issue-list"></ul>
+      </section>
 
-    <!-- Right panel: Activity + Log -->
-    <section id="activity-panel" class="panel">
-      <h2>Activity</h2>
-      <ul id="activity-list"></ul>
-      <h2>Log</h2>
-      <div id="log-panel"></div>
-    </section>
+      <!-- Right panel: Activity + Log -->
+      <section id="activity-panel" class="panel">
+        <h2>Activity</h2>
+        <ul id="activity-list"></ul>
+        <h2>Log</h2>
+        <div id="log-panel"></div>
+      </section>
+    </div>
+
+    <!-- Backlog Tab -->
+    <div id="tab-backlog" class="tab-content" style="display:none">
+      <section class="panel panel-full">
+        <div class="backlog-header">
+          <h2>📋 Backlog</h2>
+          <span id="backlog-count" class="badge">0 issues</span>
+          <button id="btn-refresh-backlog" class="btn btn-small">🔄 Refresh</button>
+        </div>
+        <p class="tab-description">Refined issues ready for sprint planning. These have acceptance criteria and are not assigned to a sprint.</p>
+        <ul id="backlog-list" class="backlog-list"></ul>
+        <div id="backlog-empty" class="empty-state" style="display:none">No refined issues in backlog. Refine ideas first.</div>
+      </section>
+    </div>
+
+    <!-- Ideas Tab -->
+    <div id="tab-ideas" class="tab-content" style="display:none">
+      <section class="panel panel-full">
+        <div class="backlog-header">
+          <h2>💡 Ideas</h2>
+          <span id="ideas-count" class="badge">0 ideas</span>
+          <button id="btn-refresh-ideas" class="btn btn-small">🔄 Refresh</button>
+        </div>
+        <p class="tab-description">Raw ideas awaiting refinement. Label issues with <code>type:idea</code> to see them here.</p>
+        <ul id="ideas-list" class="backlog-list"></ul>
+        <div id="ideas-empty" class="empty-state" style="display:none">No ideas found. Create issues with the <code>type:idea</code> label.</div>
+      </section>
+    </div>
 
     <!-- Chat panel (slide-out) -->
     <section id="chat-panel" class="panel chat-panel" style="display:none">

--- a/src/dashboard/public/style.css
+++ b/src/dashboard/public/style.css
@@ -703,3 +703,145 @@ main.session-open {
 .session-status-warn { color: #ff9800; background: rgba(255, 152, 0, 0.1); }
 .session-status-err { color: #d32f2f; background: rgba(211, 47, 47, 0.1); }
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+
+/* Mode toggle */
+.mode-toggle {
+  background: var(--bg-hover);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.mode-toggle:focus { outline: 2px solid var(--blue); }
+
+/* Warn/Danger button variants */
+.btn-warn {
+  background: var(--yellow);
+  color: #000;
+}
+.btn-warn:hover { opacity: 0.85; }
+.btn-danger {
+  background: var(--red);
+  color: #fff;
+}
+.btn-danger:hover { opacity: 0.85; }
+
+/* Tab navigation */
+.tab-nav {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  padding: 0 16px;
+  background: var(--bg-panel);
+}
+.tab-btn {
+  padding: 8px 16px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 13px;
+  font-family: var(--font);
+  transition: color 0.15s, border-color 0.15s;
+}
+.tab-btn:hover { color: var(--text); }
+.tab-btn.tab-active {
+  color: var(--blue);
+  border-bottom-color: var(--blue);
+}
+
+/* Tab content */
+.tab-content { display: none; }
+.tab-visible { display: flex !important; }
+
+/* Panel full width (for backlog/ideas) */
+.panel-full {
+  flex: 1;
+  padding: 16px;
+}
+.backlog-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+.badge {
+  background: var(--bg-hover);
+  color: var(--text-dim);
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 12px;
+}
+.tab-description {
+  color: var(--text-dim);
+  font-size: 13px;
+  margin-bottom: 12px;
+}
+.tab-description code {
+  background: var(--bg-hover);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+/* Backlog/Ideas list */
+.backlog-list {
+  list-style: none;
+}
+.backlog-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+}
+.backlog-item:hover { background: var(--bg-hover); }
+.backlog-number {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--blue);
+  flex-shrink: 0;
+  min-width: 50px;
+}
+.backlog-title {
+  flex: 1;
+  font-size: 14px;
+}
+.backlog-labels {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.label-tag {
+  background: var(--bg-hover);
+  color: var(--text-dim);
+  padding: 2px 6px;
+  border-radius: 10px;
+  font-size: 11px;
+}
+.idea-body {
+  color: var(--text-dim);
+  font-size: 12px;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 300px;
+}
+.empty-state {
+  padding: 40px 20px;
+  text-align: center;
+  color: var(--text-dim);
+  font-style: italic;
+}
+.empty-state code {
+  background: var(--bg-hover);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}


### PR DESCRIPTION
Closes #183 (partial — first iteration)

## What's new

### Sprint Controls
- **⏸ Pause** button — pauses sprint between phases (wires to `runner.pause()`)
- **▶ Resume** button — resumes paused sprint
- **⏹ Stop** button — stops sprint with confirmation dialog
- Buttons auto-show/hide based on phase: idle shows Start, running shows Pause+Stop, paused shows Resume+Stop

### Dual Execution Mode
- **🤖 Autonomous** (default) — runs all phases end-to-end
- **👤 Human-in-the-Loop** — auto-pauses at each phase transition, user clicks Resume to proceed
- Mode toggle dropdown in header, synced to server

### Navigation Tabs
- **Sprint** tab — existing sprint execution view
- **Backlog** tab — shows `status:refined` issues from GitHub (ready for sprint planning)
- **Ideas** tab — shows `type:idea` issues awaiting refinement
- Lazy-loaded from new API endpoints

### API Endpoints
- `/api/backlog` — refined issues with labels
- `/api/ideas` — idea issues with body preview

## Verification
- 497 tests passing (46 files)
- Types clean
- Lint clean (0 errors)