### PR TITLE
chore(process): Enforce worker file-scope boundaries in execution prompt (#185)

### DIFF
--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -14,6 +14,14 @@ You are the **Worker Agent** for the AI-Scrum autonomous sprint runner.
 - **Worktree path**: {{WORKTREE_PATH}}
 - **Max diff lines**: {{MAX_DIFF_LINES}}
 
+## Files in Scope
+
+These are the only files you should modify for this issue:
+
+{{FILES_IN_SCOPE}}
+
+> ⚠️ Modifying files outside this list will trigger a scope-drift failure in the quality gate.
+
 ## Your Task
 
 Implement issue #{{ISSUE_NUMBER}} following the AI-Scrum Definition of Done, then create a PR for review.
@@ -75,6 +83,18 @@ npm run typecheck   # Must show 0 errors
 npm run test        # Must show 0 failures
 git diff --stat     # Must be within diff limit
 ```
+
+### 5.5. Pre-Commit Scope Check
+
+Before committing, verify you haven't modified out-of-scope files:
+
+```bash
+git diff --name-only   # Compare against Files in Scope list above
+```
+
+If any files are outside the scope list, either:
+- Remove the change (`git checkout -- <file>`) if it's not essential
+- Document why it's necessary in the PR description
 
 ### 6. Commit and Push
 

--- a/src/ceremonies/execution.ts
+++ b/src/ceremonies/execution.ts
@@ -366,6 +366,9 @@ function buildPromptVars(ctx: ExecutionContext): Record<string, string> {
     BASE_BRANCH: config.baseBranch,
     WORKTREE_PATH: worktreePath,
     MAX_DIFF_LINES: String(buildQualityGateConfig(config).maxDiffLines),
+    FILES_IN_SCOPE: issue.expectedFiles.length > 0
+      ? issue.expectedFiles.map(f => `- \`${f}\``).join("\n")
+      : "_No file restrictions — use your best judgment._",
   };
 }
 


### PR DESCRIPTION
Closes #185

## Summary

This PR adds explicit file-scope boundaries to the worker execution prompt to help workers stay within planned file changes.

## Changes

1. **Prompt variable** — Added `FILES_IN_SCOPE` to `buildPromptVars()` in `execution.ts`
   - Formats `issue.expectedFiles` as markdown bullet list
   - Falls back to "No file restrictions" when empty

2. **Worker prompt** — Added "Files in scope" section to `worker.md`
   - Displays after Context block
   - Warns about scope-drift quality gate failure

3. **Pre-commit check** — Added step 5.5 before "Commit and Push"
   - Instructs worker to verify `git diff --name-only` against scope list
   - Provides guidance on handling out-of-scope changes

## Test Coverage

Added 3 tests in `execution.test.ts`:
- ✅ Verifies FILES_IN_SCOPE appears with expectedFiles list
- ✅ Verifies fallback text when expectedFiles is empty
- ✅ Verifies bullet list formatting (markdown backticks, newlines)

## Definition of Done

- [x] Code implemented — addresses all acceptance criteria
- [x] Lint clean — 0 errors (21 warnings in existing code)
- [x] Type clean — 0 errors
- [x] Tests written — 3 tests added
- [x] Tests pass — 500/500 tests pass
- [x] Diff size — 84 lines changed (max 300)
- [x] No unrelated changes — only execution.ts, worker.md, execution.test.ts, package-lock.json (npm install)