### PR TITLE
feat: idea refinement chat from Ideas tab

### DIFF
--- a/docs/sprints/sprint-2-log.md
+++ b/docs/sprints/sprint-2-log.md
@@ -1,15 +1,44 @@
-### ✅ #9 — Add ntfy topic validation in escalation handler
+# Sprint 2 Log — 2026-02-28
+
+**Goal**: All 5 eligible issues are type:chore process improvements from Sprint 1 retrospective — no priority:critical/high or type:bug issues exist. No dependencies between issues, so all run in a single parallel group. 2 additional open issues (#182, #183) were excluded because they lack type:* labels and need backlog grooming. Sprint 1 velocity (6 done / 8 planned) sets capacity baseline; 5 issues with 20% buffer fits comfortably.
+**Planned**: 5 issues
+
+## Huddles
+### ✅ #186 — chore(process): Reduce max_issues config from 8 to 6 based on Sprint 1 velocity
 
 - **Status**: completed
-- **Duration**: 4m 8s
+- **Duration**: 5m 34s
 - **Quality**: PASSED
-- **Files changed**: 2
+- **Files changed**: 3
+- **Retries**: 0
+- **PR**: #undefined (+3 −3)
 
 **Quality Checks**:
-  - ✅ tests-exist: Found 27 test file(s)
+  - ✅ tests-exist: Found 46 test file(s)
   - ✅ tests-pass: Tests passed
   - ✅ lint-clean: Lint clean
   - ✅ types-clean: Types clean
-  - ✅ diff-size: 66 lines changed (max 300)
+  - ✅ build-pass: Build succeeded
+  - ✅ scope-drift: All 3 changed files within expected scope
+  - ✅ diff-size: 6 lines changed (max 300)
 
-_2026-02-26T21:23:59.376Z_
+_2026-02-28T08:11:01.350Z_
+### ✅ #185 — chore(process): Enforce worker file-scope boundaries in execution prompt
+
+- **Status**: completed
+- **Duration**: 11m 21s
+- **Quality**: PASSED
+- **Files changed**: 3
+- **Retries**: 0
+- **PR**: #undefined (+79 −1)
+
+**Quality Checks**:
+  - ✅ tests-exist: Found 46 test file(s)
+  - ✅ tests-pass: Tests passed
+  - ✅ lint-clean: Lint clean
+  - ✅ types-clean: Types clean
+  - ✅ build-pass: Build succeeded
+  - ✅ scope-drift: All 3 changed files within expected scope
+  - ✅ diff-size: 80 lines changed (max 300)
+
+_2026-02-28T08:16:48.500Z_

--- a/src/dashboard/chat-manager.ts
+++ b/src/dashboard/chat-manager.ts
@@ -13,7 +13,7 @@ import { logger } from "../logger.js";
 
 const log = logger.child({ component: "chat-manager" });
 
-export type ChatRole = "researcher" | "planner" | "reviewer" | "general";
+export type ChatRole = "researcher" | "planner" | "reviewer" | "refiner" | "general";
 
 export interface ChatSession {
   id: string;
@@ -49,6 +49,16 @@ Flag blocking issues clearly and explain why they matter.`,
   general: `You are a General Assistant for the AI Scrum Sprint Runner project.
 You can help with any task: coding, debugging, documentation, architecture, or answering questions.
 You have access to the full codebase and development tools.`,
+
+  refiner: `You are a Refinement Agent for the AI Scrum Sprint Runner project.
+Your role is to help transform raw ideas into well-defined, actionable GitHub issues.
+Guide the user through refinement by asking clarifying questions about:
+- The problem being solved and its value
+- Scope boundaries (what's in, what's out)
+- Testable acceptance criteria
+- Dependencies and risks
+At the end, produce a refined issue description with a clear title, summary, acceptance criteria list, and suggested labels.
+Keep the conversation focused and productive.`,
 };
 
 export interface ChatManagerOptions {

--- a/src/dashboard/public/index.html
+++ b/src/dashboard/public/index.html
@@ -114,6 +114,7 @@
             <option value="researcher">Researcher</option>
             <option value="planner">Planner</option>
             <option value="reviewer">Reviewer</option>
+            <option value="refiner">Refiner</option>
           </select>
           <button id="btn-new-chat" class="btn btn-small">+ New</button>
           <button id="btn-close-chat" class="btn btn-small" title="Close panel">✕</button>

--- a/src/dashboard/public/style.css
+++ b/src/dashboard/public/style.css
@@ -845,3 +845,20 @@ main.session-open {
   font-family: var(--font-mono);
   font-size: 12px;
 }
+
+/* Refine button on idea items */
+.btn-refine {
+  flex-shrink: 0;
+  margin-left: auto;
+  background: var(--blue);
+  color: #fff;
+  border: none;
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.idea-item:hover .btn-refine { opacity: 1; }
+.btn-refine:hover { filter: brightness(1.15); }


### PR DESCRIPTION
## Summary
Add ability to refine ideas directly from the dashboard Ideas tab via an AI-guided chat session.

### Changes
- **chat-manager.ts**: New `refiner` ChatRole with system prompt focused on clarifying questions, scope boundaries, and acceptance criteria
- **index.html**: Added `Refiner` option to chat role dropdown
- **app.js**: 
  - `pendingIdeaContext` state for passing idea data to chat
  - `refineIdea(idea)` function: opens chat panel, creates refiner session
  - `handleChatCreated` auto-sends idea context as first message when role is refiner
  - `💬 Refine` button rendered on each idea item
- **style.css**: Refine button styling (appears on hover, blue accent)

### UX Flow
1. User clicks Ideas tab → sees idea list
2. Hovers an idea → `💬 Refine` button appears
3. Clicks Refine → chat panel opens with refiner agent
4. Agent auto-receives idea context and starts asking clarifying questions
5. User refines through conversation → gets structured issue with acceptance criteria

### Verification
- 505 tests pass (46 files)
- Types clean
- Manual smoke test: server starts, ideas load with Refine button, refiner in dropdown