### PR TITLE
feat: add init command for target project scaffolding

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -25,6 +25,7 @@ import {
   parseSprintNumber,
   parseIssueNumber,
 } from "./helpers.js";
+import { initProject } from "./init.js";
 
 /** Register all CLI commands on the given Commander program. */
 export function registerCommands(program: Command): void {
@@ -41,6 +42,7 @@ export function registerCommands(program: Command): void {
   registerResume(program);
   registerMetrics(program);
   registerDriftReport(program);
+  registerInit(program);
 }
 
 // --- plan ---
@@ -654,6 +656,49 @@ function registerDriftReport(program: Command): void {
       } catch (err: unknown) {
         logger.error({ err }, "Drift report failed");
         console.error("❌ Drift report failed:", err instanceof Error ? err.message : err);
+        process.exit(1);
+      }
+    });
+}
+
+// --- init ---
+function registerInit(program: Command): void {
+  program
+    .command("init")
+    .description("Initialize a project with .aiscrum/ roles and config")
+    .option("--path <dir>", "Target project directory", process.cwd())
+    .option("--force", "Overwrite existing files", false)
+    .action(async (opts) => {
+      try {
+        console.log("🚀 Initializing AI Scrum Sprint Runner...\n");
+
+        const result = initProject({
+          targetPath: opts.path,
+          force: opts.force,
+        });
+
+        if (result.created.length > 0) {
+          console.log("  ✅ Created:");
+          for (const f of result.created) {
+            console.log(`     ${f}`);
+          }
+        }
+
+        if (result.skipped.length > 0) {
+          console.log("\n  ⏭️  Skipped (already exist):");
+          for (const f of result.skipped) {
+            console.log(`     ${f}`);
+          }
+        }
+
+        console.log(`\n✅ Initialized! ${result.created.length} files created, ${result.skipped.length} skipped.`);
+
+        if (result.configPath) {
+          console.log(`\n📝 Edit ${result.configPath} to configure your project.`);
+        }
+      } catch (err: unknown) {
+        logger.error({ err }, "Init failed");
+        console.error("❌ Init failed:", err instanceof Error ? err.message : err);
         process.exit(1);
       }
     });

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,0 +1,111 @@
+/**
+ * Init — scaffolds .aiscrum/roles/ and sprint-runner.config.yaml into a target project.
+ *
+ * Copies role templates from the Sprint Runner's own .aiscrum/roles/ directory
+ * and generates a minimal config file for the target project.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { logger } from "../logger.js";
+
+const log = logger.child({ component: "init" });
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/** Path to the Sprint Runner's own .aiscrum/roles/ (shipped with the package). */
+function getTemplateRolesDir(): string {
+  // Navigate from src/cli/ → project root → .aiscrum/roles/
+  return path.resolve(__dirname, "..", "..", ".aiscrum", "roles");
+}
+
+export interface InitOptions {
+  targetPath: string;
+  force?: boolean;
+}
+
+export interface InitResult {
+  created: string[];
+  skipped: string[];
+  configPath: string | null;
+}
+
+const MINIMAL_CONFIG = `# AI Scrum Sprint Runner — Project Configuration
+# See: https://github.com/trsdn/ai-scrum-autonomous-v2
+
+project:
+  name: "my-project"
+  base_branch: "main"
+
+sprint:
+  max_issues: 6
+
+quality_gates:
+  tests: "npm test"
+  lint: "npm run lint"
+  types: "npx tsc --noEmit"
+`;
+
+/**
+ * Initialize a target project with .aiscrum/ structure and config.
+ */
+export function initProject(options: InitOptions): InitResult {
+  const { targetPath, force = false } = options;
+  const result: InitResult = { created: [], skipped: [], configPath: null };
+
+  const targetRolesDir = path.join(targetPath, ".aiscrum", "roles");
+  const templateRolesDir = getTemplateRolesDir();
+
+  if (!fs.existsSync(templateRolesDir)) {
+    throw new Error(
+      `Template roles not found at ${templateRolesDir}. Sprint Runner installation may be corrupted.`,
+    );
+  }
+
+  // Copy role templates
+  copyDirRecursive(templateRolesDir, targetRolesDir, force, result);
+
+  // Generate config if it doesn't exist
+  const configPath = path.join(targetPath, "sprint-runner.config.yaml");
+  if (!fs.existsSync(configPath)) {
+    fs.writeFileSync(configPath, MINIMAL_CONFIG, "utf-8");
+    result.created.push(configPath);
+    result.configPath = configPath;
+    log.info({ configPath }, "Created config file");
+  } else {
+    result.skipped.push(configPath);
+    log.info({ configPath }, "Config file already exists, skipping");
+  }
+
+  return result;
+}
+
+function copyDirRecursive(
+  src: string,
+  dest: string,
+  force: boolean,
+  result: InitResult,
+): void {
+  fs.mkdirSync(dest, { recursive: true });
+
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    // Skip log/ directories — those are runtime artifacts, not templates
+    if (entry.isDirectory() && entry.name === "log") continue;
+
+    if (entry.isDirectory()) {
+      copyDirRecursive(srcPath, destPath, force, result);
+    } else {
+      if (fs.existsSync(destPath) && !force) {
+        result.skipped.push(destPath);
+      } else {
+        fs.copyFileSync(srcPath, destPath);
+        result.created.push(destPath);
+      }
+    }
+  }
+}

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { initProject } from "../../src/cli/init.js";
+
+describe("initProject", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "init-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("scaffolds .aiscrum/roles/ into target directory", () => {
+    const result = initProject({ targetPath: tmpDir });
+
+    expect(fs.existsSync(path.join(tmpDir, ".aiscrum", "roles"))).toBe(true);
+    expect(result.created.length).toBeGreaterThan(0);
+  });
+
+  it("creates all role directories", () => {
+    initProject({ targetPath: tmpDir });
+
+    const roles = fs.readdirSync(path.join(tmpDir, ".aiscrum", "roles"));
+    expect(roles).toContain("refiner");
+    expect(roles).toContain("planner");
+    expect(roles).toContain("reviewer");
+    expect(roles).toContain("researcher");
+    expect(roles).toContain("general");
+    expect(roles).toContain("retro");
+  });
+
+  it("creates copilot-instructions.md for each role", () => {
+    initProject({ targetPath: tmpDir });
+
+    for (const role of ["refiner", "planner", "reviewer", "researcher", "general", "retro"]) {
+      const instructionsPath = path.join(tmpDir, ".aiscrum", "roles", role, "copilot-instructions.md");
+      expect(fs.existsSync(instructionsPath), `${role} instructions missing`).toBe(true);
+    }
+  });
+
+  it("creates sprint-runner.config.yaml", () => {
+    const result = initProject({ targetPath: tmpDir });
+
+    const configPath = path.join(tmpDir, "sprint-runner.config.yaml");
+    expect(fs.existsSync(configPath)).toBe(true);
+    expect(result.configPath).toBe(configPath);
+
+    const content = fs.readFileSync(configPath, "utf-8");
+    expect(content).toContain("project:");
+    expect(content).toContain("sprint:");
+  });
+
+  it("skips existing files without --force", () => {
+    // First init
+    initProject({ targetPath: tmpDir });
+    // Second init
+    const result = initProject({ targetPath: tmpDir });
+
+    expect(result.skipped.length).toBeGreaterThan(0);
+    expect(result.created.length).toBe(0);
+  });
+
+  it("overwrites existing files with --force", () => {
+    // First init
+    initProject({ targetPath: tmpDir });
+    // Second init with force
+    const result = initProject({ targetPath: tmpDir, force: true });
+
+    // Config is always skipped (even with force, only role files are overwritten)
+    // Role files should be re-created
+    expect(result.created.length).toBeGreaterThan(0);
+  });
+
+  it("does not copy log/ directories", () => {
+    initProject({ targetPath: tmpDir });
+
+    const rolesDir = path.join(tmpDir, ".aiscrum", "roles");
+    const allDirs: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (entry.isDirectory()) {
+          allDirs.push(entry.name);
+          walk(path.join(dir, entry.name));
+        }
+      }
+    };
+    walk(rolesDir);
+
+    expect(allDirs).not.toContain("log");
+  });
+
+  it("copies skill files into role directories", () => {
+    initProject({ targetPath: tmpDir });
+
+    // Refiner should have skills
+    const refinerSkills = path.join(tmpDir, ".aiscrum", "roles", "refiner", "skills");
+    expect(fs.existsSync(refinerSkills)).toBe(true);
+    const skillDirs = fs.readdirSync(refinerSkills);
+    expect(skillDirs.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `sprint-runner init` CLI command that scaffolds the `.aiscrum/` structure into any target project, enabling the Sprint Runner to work as a tool against external repos.

### Usage

```bash
# Initialize current directory
sprint-runner init

# Initialize a different project
sprint-runner init --path /path/to/my-project

# Overwrite existing files
sprint-runner init --force
```

### What Gets Created

```
target-project/
├── .aiscrum/roles/
│   ├── refiner/          # copilot-instructions.md + skills/
│   ├── planner/
│   ├── reviewer/
│   ├── researcher/
│   ├── general/
│   └── retro/
└── sprint-runner.config.yaml   # Minimal starter config
```

### Changes

- **`src/cli/init.ts`** (new): `initProject()` copies role templates from the Sprint Runner package, generates config, skips existing files
- **`src/cli/commands.ts`**: Registers `init` command with `--path` and `--force` options
- **`tests/cli/init.test.ts`**: 8 tests (scaffolding, all roles, config, skip existing, force overwrite, no log/ copy, skill files)

### Architecture

The Sprint Runner is the **engine** (TypeScript code, dashboard, ACP). Agent configs (`.aiscrum/roles/`) live in the **target project** — project-specific and improvable by the retro agent. The `init` command bridges the two by copying starter templates.

532 tests passing (49 files).