### PR TITLE
feat: dashboard overhaul + remove challenger from pipeline

### DIFF
--- a/src/dashboard/public/index.html
+++ b/src/dashboard/public/index.html
@@ -30,19 +30,11 @@
       <button id="btn-pause" class="btn btn-warn" title="Pause sprint" style="display:none">⏸ Pause</button>
       <button id="btn-resume" class="btn btn-primary" title="Resume sprint" style="display:none">▶ Resume</button>
       <button id="btn-stop" class="btn btn-danger" title="Stop sprint" style="display:none">⏹ Stop</button>
-      <button id="btn-sessions" class="btn" title="View ACP Sessions">🔍 Sessions</button>
       <button id="btn-chat" class="btn" title="Open Agent Chat">💬 Chat</button>
     </div>
   </header>
 
-  <!-- Navigation Tabs -->
-  <nav id="tab-nav" class="tab-nav">
-    <button class="tab-btn tab-active" data-tab="sprint">🏃 Sprint</button>
-    <button class="tab-btn" data-tab="backlog">📋 Backlog</button>
-    <button class="tab-btn" data-tab="ideas">💡 Ideas</button>
-  </nav>
-
-  <!-- Phase Stepper -->
+  <!-- Phase Stepper (sprint progress) -->
   <nav id="phase-stepper" class="phase-stepper">
     <span class="step" data-phase="refine">Refine</span>
     <span class="step-arrow">→</span>
@@ -57,6 +49,13 @@
     <span class="step" data-phase="complete">Done</span>
   </nav>
 
+  <!-- Navigation Tabs -->
+  <nav id="tab-nav" class="tab-nav">
+    <button class="tab-btn tab-active" data-tab="sprint">🏃 Sprint</button>
+    <button class="tab-btn" data-tab="backlog">📋 Backlog</button>
+    <button class="tab-btn" data-tab="ideas">💡 Ideas</button>
+  </nav>
+
   <!-- Main content -->
   <main>
     <!-- Sprint Tab (default) -->
@@ -67,7 +66,7 @@
         <ul id="issue-list"></ul>
       </section>
 
-      <!-- Right panel: Activity + Log -->
+      <!-- Center panel: Activity + Log -->
       <section id="activity-panel" class="panel">
         <h2>Activity</h2>
         <ul id="activity-list"></ul>
@@ -105,6 +104,26 @@
       </section>
     </div>
 
+    <!-- Session panel (always visible on right side) -->
+    <section id="session-panel" class="panel session-panel">
+      <div class="session-header">
+        <h2>ACP Sessions</h2>
+      </div>
+      <ul id="session-list" class="session-list"></ul>
+      <div id="session-viewer" class="session-viewer" style="display:none">
+        <div class="session-viewer-header">
+          <button id="btn-back-sessions" class="btn btn-small">← Back</button>
+          <span id="session-viewer-title"></span>
+          <button id="btn-stop-session" class="btn btn-small btn-danger" title="Stop session">⏹ Stop</button>
+        </div>
+        <pre id="session-output" class="session-output"></pre>
+        <div id="session-input-bar" class="session-input-bar">
+          <input id="session-message-input" type="text" placeholder="Send message to session…" autocomplete="off" />
+          <button id="btn-send-session" class="btn btn-small">Send</button>
+        </div>
+      </div>
+    </section>
+
     <!-- Chat panel (slide-out) -->
     <section id="chat-panel" class="panel chat-panel" style="display:none">
       <div class="chat-header">
@@ -126,27 +145,6 @@
       <div class="chat-input-row">
         <textarea id="chat-input" placeholder="Type a message…" rows="2"></textarea>
         <button id="btn-send" class="btn btn-primary btn-small" disabled>Send</button>
-      </div>
-    </section>
-
-    <!-- Session viewer panel (slide-out) -->
-    <section id="session-panel" class="panel session-panel" style="display:none">
-      <div class="session-header">
-        <h2>ACP Sessions</h2>
-        <button id="btn-close-sessions" class="btn btn-small" title="Close panel">✕</button>
-      </div>
-      <ul id="session-list" class="session-list"></ul>
-      <div id="session-viewer" class="session-viewer" style="display:none">
-        <div class="session-viewer-header">
-          <button id="btn-back-sessions" class="btn btn-small">← Back</button>
-          <span id="session-viewer-title"></span>
-          <button id="btn-stop-session" class="btn btn-small btn-danger" title="Stop session">⏹ Stop</button>
-        </div>
-        <pre id="session-output" class="session-output"></pre>
-        <div id="session-input-bar" class="session-input-bar">
-          <input id="session-message-input" type="text" placeholder="Send message to session…" autocomplete="off" />
-          <button id="btn-send-session" class="btn btn-small">Send</button>
-        </div>
       </div>
     </section>
   </main>

--- a/src/dashboard/public/style.css
+++ b/src/dashboard/public/style.css
@@ -144,11 +144,11 @@ header {
 
 .btn-primary:hover { background: #2ea043; }
 
-/* Main layout */
+/* Main layout — 3 columns: issues | activity | sessions */
 main {
   flex: 1;
   display: grid;
-  grid-template-columns: 320px 1fr;
+  grid-template-columns: 280px 1fr 340px;
   overflow: hidden;
 }
 
@@ -227,9 +227,10 @@ main {
   display: flex;
   align-items: flex-start;
   gap: 8px;
-  padding: 6px 0;
+  padding: 8px 8px;
   font-size: 13px;
   border-bottom: 1px solid var(--border);
+  line-height: 1.5;
 }
 
 #activity-list li:last-child { border-bottom: none; }
@@ -251,7 +252,8 @@ main {
 .activity-detail {
   color: var(--text-dim);
   font-size: 12px;
-  margin-top: 2px;
+  margin-top: 4px;
+  word-break: break-word;
 }
 
 .activity-elapsed {
@@ -449,7 +451,7 @@ footer {
 
 /* Adjust main grid when chat is open */
 main.chat-open {
-  grid-template-columns: 280px 1fr 380px;
+  grid-template-columns: 240px 1fr 300px 380px;
 }
 
 /* GitHub links */
@@ -468,10 +470,13 @@ main.chat-open {
   color: var(--blue);
 }
 
-/* Session viewer panel */
+/* Session viewer panel (always visible) */
 .session-panel {
   flex-direction: column;
   overflow: hidden;
+  display: flex;
+  border-left: 1px solid var(--border);
+  border-right: none;
 }
 
 .session-header {
@@ -550,6 +555,27 @@ main.chat-open {
   font-style: italic;
 }
 
+.session-group-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 8px 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  border-top: 1px solid var(--border);
+  margin-top: 4px;
+  list-style: none;
+}
+
+.session-group-icon { font-size: 12px; }
+
+.session-indented {
+  padding-left: 24px;
+}
+
 /* Session output viewer */
 .session-viewer {
   flex-direction: column;
@@ -620,10 +646,12 @@ main.chat-open {
   background: #b71c1c;
 }
 
-/* Grid adjustment when session panel is open */
-main.session-open {
-  grid-template-columns: 280px 1fr 380px;
+/* Grid adjustment when chat is open — 4 columns */
+main.chat-open {
+  grid-template-columns: 240px 1fr 300px 380px;
 }
+
+/* Grid adjustment — session-open no longer needed (always visible) */
 
 /* --- Phase Stepper --- */
 .phase-stepper {
@@ -689,6 +717,27 @@ main.session-open {
 .md-h2 { font-size: 14px; font-weight: 600; margin: 6px 0 3px; color: var(--text); }
 .md-h3 { font-size: 13px; font-weight: 600; margin: 4px 0 2px; color: var(--text-dim); }
 .md-li { padding-left: 12px; }
+.md-hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 8px 0;
+}
+.md-table {
+  border-collapse: collapse;
+  margin: 8px 0;
+  font-size: 12px;
+  width: 100%;
+}
+.md-table th, .md-table td {
+  border: 1px solid var(--border);
+  padding: 4px 8px;
+  text-align: left;
+}
+.md-table th {
+  background: var(--bg-hover);
+  font-weight: 600;
+}
+.md-table tr:hover { background: var(--bg-hover); }
 
 /* Session control status messages */
 .session-status-msg {
@@ -703,6 +752,14 @@ main.session-open {
 .session-status-warn { color: #ff9800; background: rgba(255, 152, 0, 0.1); }
 .session-status-err { color: #d32f2f; background: rgba(211, 47, 47, 0.1); }
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+
+.session-history-marker {
+  text-align: center;
+  color: var(--text-dim);
+  font-size: 11px;
+  padding: 4px 0;
+  font-style: italic;
+}
 
 /* Mode toggle */
 .mode-toggle {


### PR DESCRIPTION
## Summary

Major dashboard UI improvements and removal of challenger from the issue-level execution pipeline.

## Issues Addressed

### Dashboard UI
| Issue | Change |
|-------|--------|
| #209 | Session panel always visible (3-column layout) |
| #210 | Activity section spacing improved |
| #211 | Session history replayed on subscribe with History/Live separator |
| #212 | Sessions grouped by issue with indented workers |
| #220 | Enhanced markdown rendering (italic, tables, HR, numbered lists, checkboxes) |
| #221 | Phase stepper moved above tabs |

### Pipeline
| Issue | Change |
|-------|--------|
| #217 | Challenger removed from issue-level execution |

## Technical Details

**Layout change:** 3-column grid: Issues (280px) | Activity (1fr) | Sessions (340px). Sessions button removed from header. Chat panel adds a 4th column when opened.

**Session hierarchy:** Sessions grouped by `issueNumber`. Ungrouped sessions (ceremonies) shown first, then issue groups with indented workers.

**Markdown:** Enhanced renderer handles italic (\*text\*), tables, horizontal rules, numbered lists, and checkboxes. Table detection scans for pipe-separated header + separator pattern.

**Session history:** Server already buffered output (`session.output[]`). Client now handles `isHistory: true` flag — replays full history with visual separator before live output.

**Challenger removal:** `runChallengerPhase()` removed from execution.ts. Module kept at `src/enforcement/challenger.ts` for potential sprint-level use.

## Testing
- 532 tests passing (49 files)
- Type check clean
- No behavioral changes to existing tests

Closes #209, #210, #211, #212, #217, #220, #221