### PR TITLE
feat: detect file overlap between issues and sequence conflicting ones

### DIFF
--- a/tests/ceremonies/dep-graph.test.ts
+++ b/tests/ceremonies/dep-graph.test.ts
@@ -3,12 +3,14 @@ import {
   buildExecutionGroups,
   detectCircularDependencies,
   validateDependencies,
+  splitByFileOverlap,
 } from "../../src/ceremonies/dep-graph.js";
 import type { SprintIssue } from "../../src/types.js";
 
 function makeIssue(
   number: number,
   depends_on: number[] = [],
+  expectedFiles: string[] = [],
 ): SprintIssue {
   return {
     number,
@@ -16,7 +18,7 @@ function makeIssue(
     ice_score: 10,
     depends_on,
     acceptanceCriteria: "",
-    expectedFiles: [],
+    expectedFiles,
     points: 1,
   };
 }
@@ -147,5 +149,112 @@ describe("validateDependencies", () => {
     expect(result.missingRefs).toEqual([
       { issue: 2, missingDep: 50 },
     ]);
+  });
+});
+
+describe("splitByFileOverlap", () => {
+  it("returns single group when no files overlap", () => {
+    const issues = [
+      makeIssue(1, [], ["src/a.ts"]),
+      makeIssue(2, [], ["src/b.ts"]),
+      makeIssue(3, [], ["src/c.ts"]),
+    ];
+    const issueMap = new Map(issues.map((i) => [i.number, i]));
+    const result = splitByFileOverlap([1, 2, 3], issueMap);
+    expect(result).toEqual([[1, 2, 3]]);
+  });
+
+  it("splits overlapping issues into separate sub-groups", () => {
+    const issues = [
+      makeIssue(1, [], ["src/shared.ts", "src/a.ts"]),
+      makeIssue(2, [], ["src/shared.ts", "src/b.ts"]),
+      makeIssue(3, [], ["src/c.ts"]),
+    ];
+    const issueMap = new Map(issues.map((i) => [i.number, i]));
+    const result = splitByFileOverlap([1, 2, 3], issueMap);
+
+    // Issue 1 and 2 overlap on shared.ts → different sub-groups
+    // Issue 3 has no overlap → in first sub-group
+    expect(result.length).toBe(2);
+    expect(result[0]).toContain(1);
+    expect(result[0]).toContain(3);
+    expect(result[1]).toContain(2);
+  });
+
+  it("handles single issue", () => {
+    const issues = [makeIssue(1, [], ["src/a.ts"])];
+    const issueMap = new Map(issues.map((i) => [i.number, i]));
+    expect(splitByFileOverlap([1], issueMap)).toEqual([[1]]);
+  });
+
+  it("handles issues with no expectedFiles", () => {
+    const issues = [
+      makeIssue(1, [], []),
+      makeIssue(2, [], []),
+    ];
+    const issueMap = new Map(issues.map((i) => [i.number, i]));
+    const result = splitByFileOverlap([1, 2], issueMap);
+    expect(result).toEqual([[1, 2]]);
+  });
+
+  it("handles three-way file overlap", () => {
+    const issues = [
+      makeIssue(1, [], ["src/shared.ts"]),
+      makeIssue(2, [], ["src/shared.ts"]),
+      makeIssue(3, [], ["src/shared.ts"]),
+    ];
+    const issueMap = new Map(issues.map((i) => [i.number, i]));
+    const result = splitByFileOverlap([1, 2, 3], issueMap);
+
+    // All three conflict with each other → 3 separate sub-groups
+    expect(result.length).toBe(3);
+    expect(result[0]).toEqual([1]);
+    expect(result[1]).toEqual([2]);
+    expect(result[2]).toEqual([3]);
+  });
+});
+
+describe("buildExecutionGroups with file overlap", () => {
+  it("splits same-level issues with file overlap into sequential groups", () => {
+    const issues = [
+      makeIssue(1, [], ["src/api.ts"]),
+      makeIssue(2, [], ["src/api.ts"]),
+      makeIssue(3, [], ["src/dashboard.ts"]),
+    ];
+    const groups = buildExecutionGroups(issues);
+
+    // Issue 1 and 2 overlap on api.ts → separate groups
+    // Issue 3 has no overlap → grouped with issue 1
+    expect(groups.length).toBe(2);
+    expect(groups[0].issues).toContain(1);
+    expect(groups[0].issues).toContain(3);
+    expect(groups[1].issues).toContain(2);
+  });
+
+  it("preserves dependency ordering alongside file overlap splitting", () => {
+    const issues = [
+      makeIssue(1, [], ["src/a.ts"]),
+      makeIssue(2, [], ["src/a.ts"]),
+      makeIssue(3, [1], ["src/b.ts"]),
+    ];
+    const groups = buildExecutionGroups(issues);
+
+    // Level 0: issues 1, 2 (overlap on a.ts → split)
+    // Level 1: issue 3 (depends on 1)
+    expect(groups.length).toBe(3);
+    expect(groups[0].issues).toEqual([1]);
+    expect(groups[1].issues).toEqual([2]);
+    expect(groups[2].issues).toEqual([3]);
+  });
+
+  it("keeps non-overlapping same-level issues in one group", () => {
+    const issues = [
+      makeIssue(1, [], ["src/a.ts"]),
+      makeIssue(2, [], ["src/b.ts"]),
+      makeIssue(3, [], ["src/c.ts"]),
+    ];
+    const groups = buildExecutionGroups(issues);
+    expect(groups.length).toBe(1);
+    expect(groups[0].issues).toEqual([1, 2, 3]);
   });
 });


### PR DESCRIPTION
Closes #213

## Problem
When multiple issues execute in parallel, they may modify the same files, causing merge conflicts.

## Solution
Added `splitByFileOverlap()` in `dep-graph.ts` using greedy graph coloring:
1. Build a conflict graph from shared `expectedFiles`
2. Color the graph — issues that share files get different colors
3. Each color becomes a sequential sub-group within the same dependency level

`buildExecutionGroups()` now calls this after topological sort, so overlapping issues are automatically sequenced while non-overlapping ones still run in parallel.

## Tests
- 8 new tests covering: no overlap, pairwise overlap, three-way conflict, single issue, no files, dependency + overlap combo
- 542/542 tests pass