### PR TITLE
feat: QG retry reuses session, retro auto-applies, blocked dashboard

### DIFF
--- a/src/dashboard/public/index.html
+++ b/src/dashboard/public/index.html
@@ -53,6 +53,7 @@
   <nav id="tab-nav" class="tab-nav">
     <button class="tab-btn tab-active" data-tab="sprint">🏃 Sprint</button>
     <button class="tab-btn" data-tab="backlog">📋 Backlog</button>
+    <button class="tab-btn" data-tab="blocked">🚫 Blocked</button>
     <button class="tab-btn" data-tab="ideas">💡 Ideas</button>
   </nav>
 
@@ -87,6 +88,20 @@
         <p class="tab-description">Refined issues ready for sprint planning. Click <strong>+ Sprint</strong> to add an issue to the current sprint.</p>
         <ul id="backlog-list" class="backlog-list"></ul>
         <div id="backlog-empty" class="empty-state" style="display:none">No refined issues in backlog. Refine ideas first.</div>
+      </section>
+    </div>
+
+    <!-- Blocked Tab -->
+    <div id="tab-blocked" class="tab-content" style="display:none">
+      <section class="panel panel-full">
+        <div class="backlog-header">
+          <h2>🚫 Blocked Issues</h2>
+          <span id="blocked-count" class="badge">0 blocked</span>
+          <button id="btn-refresh-blocked" class="btn btn-small">🔄 Refresh</button>
+        </div>
+        <p class="tab-description">Issues blocked during execution. Add comments to provide guidance, then unblock to retry.</p>
+        <ul id="blocked-list" class="backlog-list"></ul>
+        <div id="blocked-empty" class="empty-state" style="display:none">No blocked issues. 🎉</div>
       </section>
     </div>
 

--- a/src/dashboard/public/style.css
+++ b/src/dashboard/public/style.css
@@ -920,6 +920,12 @@ main.chat-open {
 .idea-item:hover .btn-refine { opacity: 1; }
 .btn-refine:hover { filter: brightness(1.15); }
 
+/* Blocked item styling */
+.blocked-item {
+  border-left: 3px solid var(--red, #e74c3c);
+}
+.blocked-item .btn { margin-left: 4px; }
+
 /* Backlog action buttons */
 .backlog-actions {
   display: flex;


### PR DESCRIPTION
## Changes

### #227 — Quality gate retry reuses developer session
- `implementPhase()` now returns `{ acpOutputLines, sessionId }` instead of tearing down session
- `handleQualityRetryInSession()` sends QG feedback to the **same** developer session
- `attemptCodeReviewFix()` also reuses the developer session
- Developer session closed in `executeIssue()` finally block after all retries
- New test: verifies no new session created for QG retry

### #228 — Retro auto-applies improvements
- Auto-applicable skill/agent improvements applied via ACP session editing `.aiscrum/roles/` files
- Config improvements create issues with `needs:review` label (safety — requires stakeholder approval)
- Process improvements create issues as before
- New test: verifies ACP session created for skill auto-apply

### #229 — Blocked issues dashboard view
- New `🚫 Blocked` tab in dashboard navigation
- `/api/blocked` endpoint returns `status:blocked` issues
- Comment button: adds comment to blocked issue via `gh issue comment`
- Unblock button: removes `status:blocked` label
- New WS message types: `blocked:comment`, `blocked:unblock`

## Verification
- 544 tests pass (2 new)
- Types clean
- Lint clean

Closes #227, #228, #229