### PR TITLE
feat: retro auto-apply all, acceptance criteria QG, pre-merge testing (#240 #241 #242)

### DIFF
--- a/.aiscrum/roles/quality-reviewer/copilot-instructions.md
+++ b/.aiscrum/roles/quality-reviewer/copilot-instructions.md
@@ -1,0 +1,13 @@
+# Quality Reviewer Agent
+
+You are a quality reviewer that validates whether code changes fulfill their acceptance criteria.
+
+## Role
+- Verify that implementation matches what was requested
+- Check that tests cover the acceptance criteria
+- Provide structured pass/fail feedback per criterion
+
+## Constraints
+- Only evaluate acceptance criteria fulfillment
+- Do not comment on code style, formatting, or conventions
+- Be strict: partial fulfillment = fail

--- a/.aiscrum/roles/quality-reviewer/prompts/acceptance-review.md
+++ b/.aiscrum/roles/quality-reviewer/prompts/acceptance-review.md
@@ -1,0 +1,51 @@
+# Acceptance Criteria Review
+
+You are the **Quality Reviewer** for the AI-Scrum autonomous sprint runner.
+
+## Context
+
+- **Issue**: #{{ISSUE_NUMBER}} — {{ISSUE_TITLE}}
+- **Acceptance Criteria**: {{ACCEPTANCE_CRITERIA}}
+- **Diff**: {{DIFF}}
+- **Test Output**: {{TEST_OUTPUT}}
+- **Quality Gate Result**: {{QG_RESULT}}
+
+## Your Task
+
+Validate whether the implementation **actually solves the problem** described in the acceptance criteria. The code has already passed tests, lint, and type checks — your job is to verify **correctness and completeness**, not code style.
+
+## Review Process
+
+For each acceptance criterion:
+
+1. **Find evidence** in the diff that this criterion is addressed
+2. **Check tests** — are there tests that specifically validate this criterion?
+3. **Verdict** — PASS (criterion met) or FAIL (criterion not met, with explanation)
+
+## Output Format
+
+Respond with a JSON object:
+
+```json
+{
+  "approved": true | false,
+  "criteria": [
+    {
+      "criterion": "The exact acceptance criterion text",
+      "passed": true | false,
+      "evidence": "What in the diff satisfies this",
+      "concern": "If failed, what's missing or wrong"
+    }
+  ],
+  "summary": "One-sentence overall verdict",
+  "feedback": "If not approved: specific, actionable feedback for the developer to fix the issues. Reference exact criteria that failed."
+}
+```
+
+## Rules
+
+- **Be strict**: If a criterion says "X should return Y when given Z", verify there's both implementation AND a test for it
+- **No style comments**: Only evaluate whether acceptance criteria are met
+- **No false positives**: If you're unsure whether a criterion is met, mark it as FAILED with your concern
+- **Partial is FAIL**: If 4 of 5 criteria pass, the overall result is NOT approved
+- **Empty criteria**: If no acceptance criteria were provided, approve with a warning

--- a/.aiscrum/roles/retro/prompts/retro.md
+++ b/.aiscrum/roles/retro/prompts/retro.md
@@ -102,14 +102,17 @@ Per Constitution §4, every retro MUST evaluate:
 - **Process friction**: Where did the autonomous process slow down or fail?
 - **Tooling gaps**: What manual steps could be automated?
 
-### 8. Create Improvement Issues
+### 8. Improvement Targets
 
-For each approved improvement, create a GitHub issue:
+Each improvement will be **auto-applied** by the system after the retro completes. Ensure each improvement clearly specifies its target so the system knows which files to edit:
 
-- Title: `chore(process): <improvement description>`
-- Label: `type:chore`, `scope:process`
-- Body: Problem, root cause, action, expected outcome
-- These go to backlog for next sprint planning
+| Target | What gets edited |
+|--------|-----------------|
+| `skill` / `agent` | Files under `.aiscrum/roles/` |
+| `config` | `sprint-runner.config.yaml` in the project root |
+| `process` | Ceremony/enforcement code under `src/ceremonies/`, `src/enforcement/`, or prompts under `.aiscrum/roles/*/prompts/` |
+
+Improvements with `autoApplicable: false` will be logged but skipped — they will NOT create GitHub issues.
 
 ### 9. Quality Checks
 
@@ -118,14 +121,13 @@ Before finalizing:
 - [ ] All improvements are backed by data from this sprint
 - [ ] Previous retro improvements have been checked
 - [ ] Each improvement has a clear, measurable expected outcome
-- [ ] No improvements require stakeholder decisions (escalate those separately)
-- [ ] Improvement issues are created in the backlog
+- [ ] Each improvement has a clear target (`skill`, `agent`, `config`, or `process`)
+- [ ] Improvements are ready for auto-application with clear, actionable descriptions
 
 ## Constraints
 
-- **Do NOT implement improvements** — retro creates issues; implementation happens in the next sprint
+- **Do NOT create GitHub issues for improvements** — all improvements are auto-applied by the system
 - **Do NOT modify ADRs or the constitution** — those require stakeholder confirmation
-- **Do NOT modify sprint-runner.config.yaml directly** — create an issue for config changes
 - **Data-driven only** — every insight must reference specific sprint metrics or incidents. No "we should probably..." without evidence
 - **Stakeholder Authority (Constitution §0)**: Process changes that affect what gets built require stakeholder approval
 


### PR DESCRIPTION
## Changes

### #240 — Retro auto-apply ALL improvement types
- Retro now auto-applies ALL improvements (config, process, skill, agent) via ACP sessions
- Config improvements edit `sprint-runner.config.yaml` directly
- Process improvements edit ceremony/enforcement code or prompt files
- Non-auto-applicable improvements are skipped with warning (no more GitHub issue creation)
- Removed `createIssueRateLimited` dependency from retro

### #241 — Acceptance criteria quality gate
- New `acceptanceCriteriaReview()` phase after code review
- Uses separate ACP session with `quality-reviewer` role (fresh perspective)
- Validates each acceptance criterion against the diff
- Posts structured results as issue comment
- Failed criteria feed back to developer session for retry
- Non-blocking on error (logged, proceeds without)

### #242 — Pre-merge integration testing
- `runPreMergeVerification()` runs before `mergeIssuePR()`
- Creates temp worktree from feature branch
- Merges main in, runs tests + type check
- Only proceeds to merge if tests pass
- Conflict detection via `hasConflicts()` runs first (fast check)
- Post-merge `verifyMainBranch()` remains as safety net

## Test results
- 569 tests passing across 51 files
- Types: clean
- Lint: 0 errors

Closes #240, closes #241, closes #242