### PR TITLE
fix: rebase feature branch on latest main before pre-merge verification

### DIFF
--- a/tests/ceremonies/parallel-dispatcher.test.ts
+++ b/tests/ceremonies/parallel-dispatcher.test.ts
@@ -490,11 +490,14 @@ describe("runParallelExecution", () => {
       { group: 0, issues: [1] },
     ]);
     vi.mocked(executeIssue).mockResolvedValueOnce(makeResult(1));
-    // execFile fails on test command (first call after fetch + merge)
+    // execFile: rebase calls (fetch, rebase, push) then pre-merge (fetch, merge, npm test fails)
     mockExecFileAsync
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // git fetch
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // git merge
-      .mockRejectedValueOnce(new Error("test failure"));  // npm test
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git fetch
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git rebase
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git push
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // pre-merge: git fetch
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // pre-merge: git merge
+      .mockRejectedValueOnce(new Error("test failure"));  // pre-merge: npm test
 
     const result = await runParallelExecution(mockClient, makeConfig(), makePlan(issues));
 
@@ -512,12 +515,15 @@ describe("runParallelExecution", () => {
       { group: 0, issues: [1] },
     ]);
     vi.mocked(executeIssue).mockResolvedValueOnce(makeResult(1));
-    // execFile: fetch ok, merge ok, tests ok, typecheck fails
+    // execFile: rebase calls (fetch, rebase, push) then pre-merge (fetch, merge, tests ok, typecheck fails)
     mockExecFileAsync
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // git fetch
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // git merge
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // npm test
-      .mockRejectedValueOnce(new Error("type error"));    // tsc --noEmit
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git fetch
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git rebase
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git push
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // pre-merge: git fetch
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // pre-merge: git merge
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // pre-merge: npm test
+      .mockRejectedValueOnce(new Error("type error"));    // pre-merge: tsc --noEmit
 
     const result = await runParallelExecution(mockClient, makeConfig(), makePlan(issues));
 
@@ -552,9 +558,12 @@ describe("runParallelExecution", () => {
     ]);
     vi.mocked(executeIssue).mockResolvedValueOnce(makeResult(1));
     mockExecFileAsync
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // git fetch
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // git merge
-      .mockRejectedValueOnce(new Error("test failure"));  // npm test
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git fetch
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git rebase
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git push
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // pre-merge: git fetch
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // pre-merge: git merge
+      .mockRejectedValueOnce(new Error("test failure"));  // pre-merge: npm test
 
     await runParallelExecution(mockClient, makeConfig(), makePlan(issues));
 


### PR DESCRIPTION
## Problem

After earlier issues in the same execution group merge to main, subsequent branches are based on stale main. This caused pre-merge verification failures due to merge conflicts (observed in E2E Run 3 — issue #54 dark mode CSS failed because #51/#52 had already changed main).

## Solution

Added a rebase step before pre-merge verification:
1. Fetch latest main
2. Rebase feature branch on origin/main
3. Force-push with lease

If rebase fails (conflicts), it gracefully aborts and lets pre-merge verification catch the issue naturally.

## Changes

- `src/ceremonies/parallel-dispatcher.ts`: Added rebase-on-latest-main before `runPreMergeVerification()`
- `tests/ceremonies/parallel-dispatcher.test.ts`: Updated 3 test mock sequences to account for the 3 new execFile calls (fetch, rebase, push)

## Testing

- All 570 tests pass
- 17/17 parallel-dispatcher tests pass