### PR TITLE
fix: use temporary worktree for pre-merge rebase

### DIFF
--- a/tests/ceremonies/parallel-dispatcher.test.ts
+++ b/tests/ceremonies/parallel-dispatcher.test.ts
@@ -476,7 +476,6 @@ describe("runParallelExecution", () => {
     const result = await runParallelExecution(mockClient, makeConfig(), makePlan(issues));
 
     expect(mergeIssuePR).not.toHaveBeenCalled();
-    expect(createWorktree).not.toHaveBeenCalled();
     const issue1 = result.results.find((r) => r.issueNumber === 1)!;
     expect(issue1.status).toBe("failed");
     expect(issue1.qualityGatePassed).toBe(false);


### PR DESCRIPTION
Fixes the rebase step failing with 'cannot rebase: You have unstaged changes' by creating a temporary worktree instead of rebasing in the main project directory.

- 570 tests pass
- Observed in E2E Run 4: rebase always fell back gracefully but never actually executed