### PR TITLE
fix: make scope-drift non-blocking and improve file matching

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -50,7 +50,8 @@ export function calculateSprintMetrics(result: SprintResult): SprintMetrics {
   const firstPassCount = results.filter((r) => r.retryCount === 0).length;
   const firstPassRate = percent(firstPassCount, planned);
   const driftIncidents = results.filter((r) =>
-    r.qualityDetails.checks.some((c) => c.name === "scope_drift" && !c.passed),
+    r.qualityDetails.checks.some((c) =>
+      (c.name === "scope_drift" || c.name === "scope-drift") && c.detail?.includes("unplanned")),
   ).length;
 
   return {

--- a/tests/enforcement/quality-gate.test.ts
+++ b/tests/enforcement/quality-gate.test.ts
@@ -277,7 +277,7 @@ describe("runQualityGate", () => {
     expect(scopeDrift?.detail).toContain("within expected scope");
   });
 
-  it("should fail scope-drift when unplanned files exist", async () => {
+  it("should warn but not block on scope-drift when unplanned files exist", async () => {
     mockGlob.mockResolvedValue(["foo.test.ts"] as never);
     mockExecSuccess();
 
@@ -288,11 +288,12 @@ describe("runQualityGate", () => {
       "main",
     );
 
-    expect(result.passed).toBe(false);
+    // Scope drift is non-blocking — the overall gate should still pass
+    expect(result.passed).toBe(true);
     const scopeDrift = result.checks.find((c) => c.name === "scope-drift");
     expect(scopeDrift).toBeDefined();
-    expect(scopeDrift?.passed).toBe(false);
-    expect(scopeDrift?.detail).toContain("out-of-scope");
+    expect(scopeDrift?.passed).toBe(true);
+    expect(scopeDrift?.detail).toContain("unplanned files");
   });
 
   it("should not add scope-drift check when expectedFiles is not set", async () => {

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -97,22 +97,22 @@ describe("calculateSprintMetrics", () => {
       makeIssue({
         issueNumber: 1,
         qualityDetails: {
-          passed: false,
-          checks: [{ name: "scope_drift", passed: false, detail: "drift", category: "diff" }],
+          passed: true,
+          checks: [{ name: "scope-drift", passed: true, detail: "⚠️ 2 unplanned files (non-blocking): index.html, src/footer.ts", category: "diff" }],
         },
       }),
       makeIssue({
         issueNumber: 2,
         qualityDetails: {
           passed: true,
-          checks: [{ name: "scope_drift", passed: true, detail: "ok", category: "diff" }],
+          checks: [{ name: "scope-drift", passed: true, detail: "All 3 changed files within expected scope", category: "diff" }],
         },
       }),
       makeIssue({
         issueNumber: 3,
         qualityDetails: {
-          passed: false,
-          checks: [{ name: "scope_drift", passed: false, detail: "drift", category: "diff" }],
+          passed: true,
+          checks: [{ name: "scope-drift", passed: true, detail: "⚠️ 1 unplanned files (non-blocking): style.css", category: "diff" }],
         },
       }),
     ]);


### PR DESCRIPTION
## Problem

Scope-drift QG check was **blocking** issues based on the sprint planner's `expectedFiles` predictions — which are frequently wrong. In E2E Run 8, the footer bugfix (#146) was blocked because the planner predicted `src/footer.ts` but the agent correctly edited `index.html`.

## Root Cause

1. Sprint planner guesses `expectedFiles` without deep codebase analysis
2. QG used `f.includes(ef)` substring matching — both imprecise and error-prone
3. The item planner (which actually reads the codebase) lists files in its structured plan, but these weren't fed back into `expectedFiles`

## Changes

### 1. Scope-drift is now non-blocking (informational warning)
- `scope-drift.passed` is always `true` — it never fails the gate
- Unplanned files are still detected and logged with a ⚠️ warning
- Tests, lint, types, and build remain the real quality gates

### 2. Fixed file matching logic
- Old: `f.includes(ef)` — substring match (broken: 'component' matches 'components-old')
- New: `f === ef || f.endsWith('/'+ef) || ef.endsWith('/'+f)` — path-aware

### 3. Extract files from implementation plan
- The item planner generates a structured JSON plan with `file` fields per step
- These files are now merged into `expectedFiles` before QG runs
- Much more accurate than sprint planner predictions

### 4. Fix drift metrics counting
- Since `scope-drift.passed` is always true, metrics now count based on `detail.includes('unplanned')`

## Testing
- 570/570 tests pass
- Types clean
- 2 pre-existing lint errors (unrelated)