### PR TITLE
fix: remove file-level conflict detection from dep-graph (#257)

### DIFF
--- a/src/ceremonies/dep-graph.ts
+++ b/src/ceremonies/dep-graph.ts
@@ -79,10 +79,9 @@ export function validateDependencies(issues: SprintIssue[]): ValidationResult {
 
 /**
  * Build execution groups via topological sort.
- * Issues with no dependencies come first; parallel-safe issues
- * at the same dependency level are grouped together.
- * Issues within the same level that share expectedFiles are
- * split into sequential sub-groups to avoid merge conflicts.
+ * Issues with no dependencies come first; issues
+ * at the same dependency level are grouped together for parallel execution.
+ * Rebase-before-merge handles any file-level conflicts at merge time.
  * Throws on circular dependencies.
  */
 export function buildExecutionGroups(issues: SprintIssue[]): ExecutionGroup[] {
@@ -105,7 +104,7 @@ export function buildExecutionGroups(issues: SprintIssue[]): ExecutionGroup[] {
     );
   }
 
-  // Compute depth (longest path from root) for each node via BFS/memoisation
+  // Compute depth (longest path from root) for each node via memoisation
   const depth = new Map<number, number>();
 
   function getDepth(node: number): number {
@@ -124,7 +123,7 @@ export function buildExecutionGroups(issues: SprintIssue[]): ExecutionGroup[] {
     getDepth(issue.number);
   }
 
-  // Group by depth level
+  // Group by depth level — all issues at the same level run in parallel
   const levelGroups = new Map<number, number[]>();
   for (const issue of issues) {
     const d = depth.get(issue.number)!;
@@ -132,82 +131,14 @@ export function buildExecutionGroups(issues: SprintIssue[]): ExecutionGroup[] {
     levelGroups.get(d)!.push(issue.number);
   }
 
-  const issueMap = new Map(issues.map((i) => [i.number, i]));
   const sortedLevels = Array.from(levelGroups.keys()).sort((a, b) => a - b);
 
-  // Split each level by file overlap — overlapping issues become sequential sub-groups
   const result: ExecutionGroup[] = [];
   let groupIdx = 0;
   for (const level of sortedLevels) {
     const levelIssues = levelGroups.get(level)!.sort((a, b) => a - b);
-    const subGroups = splitByFileOverlap(levelIssues, issueMap);
-    for (const sg of subGroups) {
-      result.push({ group: groupIdx++, issues: sg });
-    }
+    result.push({ group: groupIdx++, issues: levelIssues });
   }
 
   return result;
-}
-
-/**
- * Split a set of issue numbers into sub-groups where issues within each
- * sub-group have no overlapping expectedFiles. Uses greedy graph coloring:
- * issues that share files cannot be in the same group.
- */
-export function splitByFileOverlap(
-  issueNumbers: number[],
-  issueMap: Map<number, SprintIssue>,
-): number[][] {
-  if (issueNumbers.length <= 1) return [issueNumbers];
-
-  // Build file → issues index
-  const fileToIssues = new Map<string, number[]>();
-  for (const num of issueNumbers) {
-    const issue = issueMap.get(num);
-    if (!issue) continue;
-    for (const file of issue.expectedFiles) {
-      if (!fileToIssues.has(file)) fileToIssues.set(file, []);
-      fileToIssues.get(file)!.push(num);
-    }
-  }
-
-  // Build conflict adjacency (issues that share at least one file)
-  const conflicts = new Map<number, Set<number>>();
-  for (const num of issueNumbers) {
-    conflicts.set(num, new Set());
-  }
-  for (const [, issueNums] of fileToIssues) {
-    if (issueNums.length < 2) continue;
-    for (let i = 0; i < issueNums.length; i++) {
-      for (let j = i + 1; j < issueNums.length; j++) {
-        conflicts.get(issueNums[i])!.add(issueNums[j]);
-        conflicts.get(issueNums[j])!.add(issueNums[i]);
-      }
-    }
-  }
-
-  // Check if any conflicts exist at all
-  const hasConflicts = Array.from(conflicts.values()).some((s) => s.size > 0);
-  if (!hasConflicts) return [issueNumbers];
-
-  // Greedy coloring — assign each issue to the earliest compatible sub-group
-  const subGroups: number[][] = [];
-  const assignment = new Map<number, number>();
-
-  for (const num of issueNumbers) {
-    const neighborColors = new Set(
-      Array.from(conflicts.get(num) ?? [])
-        .filter((n) => assignment.has(n))
-        .map((n) => assignment.get(n)!),
-    );
-
-    let color = 0;
-    while (neighborColors.has(color)) color++;
-
-    if (color >= subGroups.length) subGroups.push([]);
-    subGroups[color].push(num);
-    assignment.set(num, color);
-  }
-
-  return subGroups;
 }


### PR DESCRIPTION
## Summary

Remove `splitByFileOverlap()` from the dependency graph. The `expectedFiles` predictions from the sprint planner have a ~40% miss rate, making file-level conflict detection unreliable. The rebase-before-merge pipeline (PR #248) handles file conflicts reliably at merge time.

### Changes
- **dep-graph.ts**: Remove `splitByFileOverlap()` function. `buildExecutionGroups()` now groups all same-level issues into a single group (capped by `maxParallelSessions`).
- **dep-graph.test.ts**: Remove 5 `splitByFileOverlap` tests, update 2 file-overlap execution group tests to expect single groups.
- **ADR.md**: Add ADR-010 documenting the decision (supersedes part of ADR-007).

### Impact
- **More parallelism**: Issues at the same dependency level always run concurrently (was artificially serialized when expectedFiles overlapped)
- **Simpler code**: -99 lines of graph-coloring logic
- **564 tests pass**, types clean

Closes #257