### PR TITLE
feat(dashboard): add Decisions tab (#258)

### DIFF
--- a/src/dashboard/public/index.html
+++ b/src/dashboard/public/index.html
@@ -54,6 +54,7 @@
     <button class="tab-btn tab-active" data-tab="sprint">🏃 Sprint</button>
     <button class="tab-btn" data-tab="backlog">📋 Backlog</button>
     <button class="tab-btn" data-tab="blocked">🚫 Blocked</button>
+    <button class="tab-btn" data-tab="decisions">⚖️ Decisions <span id="decisions-badge" class="tab-badge" style="display:none">0</span></button>
     <button class="tab-btn" data-tab="ideas">💡 Ideas</button>
   </nav>
 
@@ -102,6 +103,20 @@
         <p class="tab-description">Issues blocked during execution. Add comments to provide guidance, then unblock to retry.</p>
         <ul id="blocked-list" class="backlog-list"></ul>
         <div id="blocked-empty" class="empty-state" style="display:none">No blocked issues. 🎉</div>
+      </section>
+    </div>
+
+    <!-- Decisions Tab -->
+    <div id="tab-decisions" class="tab-content" style="display:none">
+      <section class="panel panel-full">
+        <div class="backlog-header">
+          <h2>⚖️ Human Decisions Needed</h2>
+          <span id="decisions-count" class="badge">0 pending</span>
+          <button id="btn-refresh-decisions" class="btn btn-small">🔄 Refresh</button>
+        </div>
+        <p class="tab-description">Issues requiring stakeholder input. Review each item and <strong>Approve</strong>, <strong>Reject</strong>, or <strong>Comment</strong>.</p>
+        <ul id="decisions-list" class="backlog-list"></ul>
+        <div id="decisions-empty" class="empty-state" style="display:none">No pending decisions. 🎉</div>
       </section>
     </div>
 

--- a/src/dashboard/public/style.css
+++ b/src/dashboard/public/style.css
@@ -832,6 +832,15 @@ main.chat-open {
   border-radius: 10px;
   font-size: 12px;
 }
+.tab-badge {
+  background: var(--accent);
+  color: #fff;
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-size: 11px;
+  margin-left: 4px;
+  vertical-align: middle;
+}
 .tab-description {
   color: var(--text-dim);
   font-size: 13px;
@@ -925,6 +934,23 @@ main.chat-open {
   border-left: 3px solid var(--red, #e74c3c);
 }
 .blocked-item .btn { margin-left: 4px; }
+.decision-item {
+  border-left: 3px solid var(--accent, #3498db);
+}
+.decision-item .btn { margin-left: 4px; }
+.decision-labels { display: inline-flex; gap: 4px; margin-left: 8px; }
+.label-tag {
+  background: var(--bg-hover);
+  color: var(--text-dim);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+.decision-date {
+  color: var(--text-dim);
+  font-size: 11px;
+  margin-left: 8px;
+}
 
 /* Backlog action buttons */
 .backlog-actions {


### PR DESCRIPTION
## Summary
Adds a **Decisions** tab to the dashboard for managing issues with the `human-decision-needed` label.

## Changes
- **HTML**: New Decisions tab button with badge counter + tab content pane
- **CSS**: Tab badge, decision item styling, label tags
- **Server**: `/api/decisions` REST endpoint + 3 WebSocket action handlers (approve/reject/comment)
- **Client**: `loadDecisions()` function with approve/reject/comment buttons, real-time badge refresh

## Actions
- **Approve**: Removes `human-decision-needed` label, adds `status:refined`
- **Reject**: Closes the issue (with confirmation dialog)
- **Comment**: Adds a comment to the issue

## Verification
- `npx tsc --noEmit` — clean
- `npx vitest run` — 564/564 tests pass

Closes #258