### PR TITLE
refactor: decouple refinement from sprint cycle

### DIFF
--- a/src/ceremonies/planning.ts
+++ b/src/ceremonies/planning.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { AcpClient } from "../acp/client.js";
-import type { SprintConfig, SprintPlan, RefinedIssue } from "../types.js";
+import type { SprintConfig, SprintPlan } from "../types.js";
 import { SprintPlanSchema } from "../types.js";
 import type { SprintEventBus } from "../events.js";
 import { listIssues } from "../github/issues.js";
@@ -20,7 +20,6 @@ import { resolveSessionConfig } from "../acp/session-config.js";
 export async function runSprintPlanning(
   client: AcpClient,
   config: SprintConfig,
-  refinedIssues?: RefinedIssue[],
   eventBus?: SprintEventBus,
 ): Promise<SprintPlan> {
   const log = logger.child({ ceremony: "planning" });
@@ -48,9 +47,6 @@ export async function runSprintPlanning(
     SPRINT_NUMBER: String(config.sprintNumber),
     MAX_ISSUES: String(config.maxIssuesPerSprint),
     VELOCITY_DATA: sanitizePromptInput(velocityStr),
-    PREVIOUS_SPRINT_SUMMARY: refinedIssues
-      ? sanitizePromptInput(JSON.stringify(refinedIssues))
-      : "No previous refinement data",
     BASE_BRANCH: config.baseBranch,
   });
 

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -204,7 +204,7 @@ function registerRefine(program: Command): void {
 function registerFullCycle(program: Command): void {
   program
     .command("full-cycle")
-    .description("Run a full sprint cycle: refine → plan → execute → review → retro")
+    .description("Run a full sprint cycle: plan → execute → review → retro")
     .requiredOption("--sprint <number>", "Sprint number", parseSprintNumber)
     .action(async (opts) => {
       try {
@@ -214,31 +214,26 @@ function registerFullCycle(program: Command): void {
 
         const client = await createConnectedClient(config);
         try {
-          // Step 1: Refine
-          console.log("\n🔄 Phase 1/5: Refinement...");
-          const refined = await runRefinement(client, sprintConfig);
-          console.log(`  Refined ${refined.length} issues`);
-
-          // Step 2: Plan
-          console.log("\n🔄 Phase 2/5: Planning...");
-          const plan = await runSprintPlanning(client, sprintConfig, refined);
+          // Step 1: Plan
+          console.log("\n🔄 Phase 1/4: Planning...");
+          const plan = await runSprintPlanning(client, sprintConfig);
           console.log(`  Planned ${plan.sprint_issues.length} issues (${plan.estimated_points} points)`);
 
-          // Step 3: Execute all issues (with parallel dispatch, merge, pre-merge verification)
-          console.log("\n🔄 Phase 3/5: Execution...");
+          // Step 2: Execute all issues (with parallel dispatch, merge, pre-merge verification)
+          console.log("\n🔄 Phase 2/4: Execution...");
           const sprintResult = await runParallelExecution(client, sprintConfig, plan);
           const results = sprintResult.results;
           for (const r of results) {
             console.log(`  ${r.status === "completed" ? "✅" : "❌"} #${r.issueNumber} — ${r.status}`);
           }
 
-          // Step 4: Review
-          console.log("\n🔄 Phase 4/5: Review...");
+          // Step 3: Review
+          console.log("\n🔄 Phase 3/4: Review...");
           const review = await runSprintReview(client, sprintConfig, sprintResult);
           console.log(`  ${review.demoItems.length} demo items, ${review.openItems.length} open items`);
 
-          // Step 5: Retro
-          console.log("\n🔄 Phase 5/5: Retrospective...");
+          // Step 4: Retro
+          console.log("\n🔄 Phase 4/4: Retrospective...");
           const retro = await runSprintRetro(client, sprintConfig, sprintResult, review);
           console.log(`  ${retro.wentWell.length} went well, ${retro.wentBadly.length} went badly`);
           console.log(`  ${retro.improvements.length} improvements identified`);

--- a/src/dashboard/frontend/src/components/Header.tsx
+++ b/src/dashboard/frontend/src/components/Header.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useDashboardStore } from "../store";
 import "./Header.css";
 
-const PHASES = ["refine", "plan", "execute", "review", "retro", "complete"];
+const PHASES = ["plan", "execute", "review", "retro", "complete"];
 
 export function Header() {
   const state = useDashboardStore((s) => s.state);

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -291,7 +291,7 @@ function handleSprintEvent(
         state: {
           ...store.state,
           sprintNumber: (p?.sprintNumber as number) ?? store.state.sprintNumber,
-          phase: "refine",
+          phase: "plan",
           startedAt: new Date().toISOString(),
         },
         activeSprintNumber: (p?.sprintNumber as number) ?? store.activeSprintNumber,

--- a/src/dashboard/public/app.js
+++ b/src/dashboard/public/app.js
@@ -239,7 +239,7 @@
         }
         activities = [];
         state.sprintNumber = payload.sprintNumber;
-        state.phase = "refine";
+        state.phase = "plan";
         state.startedAt = new Date();
         activeSprintNumber = payload.sprintNumber;
         viewingSprintNumber = payload.sprintNumber;
@@ -413,7 +413,7 @@
     updatePhaseStepper(state.phase);
   }
 
-  const PHASE_ORDER = ["refine", "plan", "execute", "review", "retro", "complete"];
+  const PHASE_ORDER = ["plan", "execute", "review", "retro", "complete"];
 
   function updatePhaseStepper(currentPhase) {
     const stepper = document.getElementById("phase-stepper");

--- a/src/dashboard/public/index.html
+++ b/src/dashboard/public/index.html
@@ -36,8 +36,6 @@
 
   <!-- Phase Stepper (sprint progress) -->
   <nav id="phase-stepper" class="phase-stepper">
-    <span class="step" data-phase="refine">Refine</span>
-    <span class="step-arrow">→</span>
     <span class="step" data-phase="plan">Plan</span>
     <span class="step-arrow">→</span>
     <span class="step" data-phase="execute">Execute</span>

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,7 +1,6 @@
 import * as fs from "node:fs";
 import { AcpClient } from "./acp/client.js";
 import { resolveSessionConfig } from "./acp/session-config.js";
-import { runRefinement } from "./ceremonies/refinement.js";
 import { runSprintPlanning } from "./ceremonies/planning.js";
 import { runParallelExecution } from "./ceremonies/parallel-dispatcher.js";
 import { runSprintReview } from "./ceremonies/review.js";
@@ -29,12 +28,10 @@ import type {
   SprintResult,
   ReviewResult,
   RetroResult,
-  RefinedIssue,
 } from "./types.js";
 
 export type SprintPhase =
   | "init"
-  | "refine"
   | "plan"
   | "execute"
   | "review"
@@ -181,16 +178,11 @@ export class SprintRunner {
       createSprintLog(this.config.sprintNumber, `${this.config.sprintPrefix} cycle started`, 0, undefined, this.config.sprintPrefix, this.config.sprintSlug);
       await this.client.connect();
 
-      // 2. refine
-      await this.checkPaused();
-      this.transition("refine", undefined, "Refinement Agent");
-      const refined = await this.runRefine();
-
-      // 3. plan
+      // 2. plan
       await this.checkPaused();
       const plannerModel = (await resolveSessionConfig(this.config, "planner")).model;
       this.transition("plan", plannerModel, "Planning Agent");
-      const plan = await this.runPlan(refined);
+      const plan = await this.runPlan();
 
       // Broadcast planned issues so dashboard can update
       this.events.emitTyped("sprint:planned", {
@@ -203,7 +195,7 @@ export class SprintRunner {
       // Warn about issues missing acceptance criteria
       this.warnMissingAcceptanceCriteria(plan);
 
-      // 4. execute
+      // 3. execute
       if (this.hitlMode) {
         this.log.info("HITL mode — pausing before execution for stakeholder review");
         this.events.emitTyped("log", { level: "info", message: "⏸ HITL: Pausing before execution — review the plan and resume in dashboard to continue" });
@@ -214,18 +206,18 @@ export class SprintRunner {
       this.transition("execute", workerModel, "Worker Agent");
       const result = await this.runExecute(plan);
 
-      // 5. review
+      // 4. review
       await this.checkPaused();
       const reviewerModel = (await resolveSessionConfig(this.config, "reviewer")).model;
       this.transition("review", reviewerModel, "Review Agent");
       const review = await this.runReview(result);
 
-      // 6. retro
+      // 5. retro
       await this.checkPaused();
       this.transition("retro", undefined, "Retro Agent");
       const retro = await this.runRetro(result, review);
 
-      // 7. complete
+      // 6. complete
       this.state.retro = retro;
       this.transition("complete");
       await this.client.disconnect();
@@ -319,18 +311,10 @@ export class SprintRunner {
 
     return results;
   }
-  /** Run the refinement phase */
-  async runRefine(): Promise<RefinedIssue[]> {
-    this.log.info("Running refinement");
-    const refined = await runRefinement(this.client, this.config, this.events);
-    this.log.info({ count: refined.length }, "Refinement complete");
-    return refined;
-  }
-
   /** Run the sprint planning phase */
-  async runPlan(refinedIssues?: RefinedIssue[]): Promise<SprintPlan> {
+  async runPlan(): Promise<SprintPlan> {
     this.log.info("Running sprint planning");
-    const plan = await runSprintPlanning(this.client, this.config, refinedIssues, this.events);
+    const plan = await runSprintPlanning(this.client, this.config, this.events);
     this.state.plan = plan;
     this.persistState();
     this.log.info(

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -15,7 +15,6 @@ const SprintStateSchema = z
     sprintNumber: z.number(),
     phase: z.enum([
       "init",
-      "refine",
       "plan",
       "execute",
       "review",

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -97,7 +97,7 @@ test.describe("Dashboard Sprint Navigation", () => {
   test("phase badge shows a valid phase", async ({ page }) => {
     const badge = page.locator(".phase-badge");
     const text = await badge.textContent();
-    expect(["init", "refine", "plan", "execute", "review", "retro", "complete", "failed", "paused"]).toContain(text);
+    expect(["init", "plan", "execute", "review", "retro", "complete", "failed", "paused"]).toContain(text);
   });
 
   test("activity log section exists", async ({ page }) => {

--- a/tests/integration/sprint-cycle.test.ts
+++ b/tests/integration/sprint-cycle.test.ts
@@ -15,12 +15,6 @@ vi.mock("../../src/acp/client.js", () => ({
   })),
 }));
 
-vi.mock("../../src/ceremonies/refinement.js", () => ({
-  runRefinement: vi.fn().mockResolvedValue([
-    { number: 1, title: "Issue 1", ice_score: 8 },
-  ]),
-}));
-
 vi.mock("../../src/ceremonies/planning.js", () => ({
   runSprintPlanning: vi.fn().mockResolvedValue({
     sprintNumber: 1,
@@ -108,7 +102,7 @@ describe("sprint cycle integration", () => {
     const runner = new SprintRunner(config, events);
     await runner.fullCycle();
 
-    expect(phaseChanges).toEqual(["init", "refine", "plan", "execute", "review", "retro", "complete"]);
+    expect(phaseChanges).toEqual(["init", "plan", "execute", "review", "retro", "complete"]);
   });
 
   it("fullCycle emits sprint:start and sprint:complete", { timeout: 15000 }, async () => {
@@ -154,8 +148,8 @@ describe("sprint cycle integration", () => {
   });
 
   it("fullCycle on error emits sprint:error", { timeout: 15000 }, async () => {
-    const { runRefinement } = await import("../../src/ceremonies/refinement.js");
-    vi.mocked(runRefinement).mockRejectedValueOnce(new Error("Refinement exploded"));
+    const { runSprintPlanning } = await import("../../src/ceremonies/planning.js");
+    vi.mocked(runSprintPlanning).mockRejectedValueOnce(new Error("Planning exploded"));
 
     const events = new SprintEventBus();
     const errors: string[] = [];
@@ -165,6 +159,6 @@ describe("sprint cycle integration", () => {
     await runner.fullCycle();
 
     expect(errors).toHaveLength(1);
-    expect(errors[0]).toBe("Refinement exploded");
+    expect(errors[0]).toBe("Planning exploded");
   });
 });

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -7,7 +7,6 @@ import type {
   SprintResult,
   ReviewResult,
   RetroResult,
-  RefinedIssue,
 } from "../src/types.js";
 import { SprintEventBus } from "../src/events.js";
 import { getNextOpenMilestone, closeMilestone } from "../src/github/milestones.js";
@@ -22,13 +21,6 @@ vi.mock("../src/acp/client.js", () => ({
     connect: vi.fn().mockResolvedValue(undefined),
     disconnect: vi.fn().mockResolvedValue(undefined),
   })),
-}));
-
-vi.mock("../src/ceremonies/refinement.js", () => ({
-  runRefinement: vi.fn().mockResolvedValue([
-    { number: 1, title: "Issue 1", ice_score: 8 },
-    { number: 2, title: "Issue 2", ice_score: 5 },
-  ] satisfies RefinedIssue[]),
 }));
 
 vi.mock("../src/ceremonies/planning.js", () => ({
@@ -329,8 +321,8 @@ describe("SprintRunner", { timeout: 15000 }, () => {
     });
 
     it("sets failed phase on error", async () => {
-      const { runRefinement } = await import("../src/ceremonies/refinement.js");
-      vi.mocked(runRefinement).mockRejectedValueOnce(new Error("ACP timeout"));
+      const { runSprintPlanning } = await import("../src/ceremonies/planning.js");
+      vi.mocked(runSprintPlanning).mockRejectedValueOnce(new Error("ACP timeout"));
 
       const runner = new SprintRunner(config);
       const finalState = await runner.fullCycle();
@@ -350,8 +342,8 @@ describe("SprintRunner", { timeout: 15000 }, () => {
           }) as any,
       );
 
-      const { runRefinement } = await import("../src/ceremonies/refinement.js");
-      vi.mocked(runRefinement).mockRejectedValueOnce(new Error("fail"));
+      const { runSprintPlanning } = await import("../src/ceremonies/planning.js");
+      vi.mocked(runSprintPlanning).mockRejectedValueOnce(new Error("fail"));
 
       const runner = new SprintRunner(config);
       await runner.fullCycle();
@@ -361,17 +353,6 @@ describe("SprintRunner", { timeout: 15000 }, () => {
   });
 
   describe("individual phase methods", () => {
-    it("runRefine returns refined issues", async () => {
-      const runner = new SprintRunner(config);
-      // Connect first since phases need the client
-      await (runner as any).client.connect();
-
-      const refined = await runner.runRefine();
-      expect(refined).toHaveLength(2);
-      expect(refined[0]!.number).toBe(1);
-      expect(refined[1]!.ice_score).toBe(5);
-    });
-
     it("runPlan stores plan in state", async () => {
       const runner = new SprintRunner(config);
       await (runner as any).client.connect();
@@ -520,8 +501,8 @@ describe("SprintRunner", { timeout: 15000 }, () => {
 
   describe("error handling", () => {
     it("handles non-Error throws", async () => {
-      const { runRefinement } = await import("../src/ceremonies/refinement.js");
-      vi.mocked(runRefinement).mockRejectedValueOnce("string error");
+      const { runSprintPlanning } = await import("../src/ceremonies/planning.js");
+      vi.mocked(runSprintPlanning).mockRejectedValueOnce("string error");
 
       const runner = new SprintRunner(config);
       const finalState = await runner.fullCycle();
@@ -531,8 +512,8 @@ describe("SprintRunner", { timeout: 15000 }, () => {
     });
 
     it("persists state on failure", async () => {
-      const { runRefinement } = await import("../src/ceremonies/refinement.js");
-      vi.mocked(runRefinement).mockRejectedValueOnce(new Error("boom"));
+      const { runSprintPlanning } = await import("../src/ceremonies/planning.js");
+      vi.mocked(runSprintPlanning).mockRejectedValueOnce(new Error("boom"));
 
       const runner = new SprintRunner(config);
       await runner.fullCycle();
@@ -555,8 +536,8 @@ describe("SprintRunner", { timeout: 15000 }, () => {
           }) as any,
       );
 
-      const { runRefinement } = await import("../src/ceremonies/refinement.js");
-      vi.mocked(runRefinement).mockRejectedValueOnce(new Error("boom"));
+      const { runSprintPlanning } = await import("../src/ceremonies/planning.js");
+      vi.mocked(runSprintPlanning).mockRejectedValueOnce(new Error("boom"));
 
       const runner = new SprintRunner(config);
       const finalState = await runner.fullCycle();
@@ -588,12 +569,14 @@ describe("sprintLoop", { timeout: 30000 }, () => {
         }) as any,
     );
 
-    // Restore runRefinement — "error handling" tests add mockRejectedValueOnce
-    const { runRefinement } = await import("../src/ceremonies/refinement.js");
-    vi.mocked(runRefinement).mockResolvedValue([
-      { number: 1, title: "Issue 1", ice_score: 8 },
-      { number: 2, title: "Issue 2", ice_score: 5 },
-    ] as any);
+    // Restore runSprintPlanning — "error handling" tests add mockRejectedValueOnce
+    const { runSprintPlanning } = await import("../src/ceremonies/planning.js");
+    vi.mocked(runSprintPlanning).mockResolvedValue({
+      sprintNumber: 1,
+      sprint_issues: [{ number: 1, title: "Issue 1", estimate: 3 }],
+      estimated_points: 3,
+      rationale: "test",
+    } as any);
   });
 
   it("runs multiple sprints until no milestones remain", async () => {
@@ -674,8 +657,8 @@ describe("sprintLoop", { timeout: 30000 }, () => {
       .mockResolvedValueOnce(makeMilestone(2));
     vi.mocked(closeMilestone).mockResolvedValue(undefined);
 
-    const { runRefinement } = await import("../src/ceremonies/refinement.js");
-    vi.mocked(runRefinement).mockRejectedValueOnce(new Error("ACP down"));
+    const { runSprintPlanning } = await import("../src/ceremonies/planning.js");
+    vi.mocked(runSprintPlanning).mockRejectedValueOnce(new Error("ACP down"));
 
     const bus = new SprintEventBus();
     const results = await SprintRunner.sprintLoop(


### PR DESCRIPTION
## Summary

Decouples the refinement ceremony from the automatic sprint cycle. Refinement is now a standalone on-demand activity.

**Before:** `init → refine → plan → execute → review → retro → complete`
**After:** `init → plan → execute → review → retro → complete`

## Changes

- Removed refine step from `SprintRunner.run()` and `full-cycle` CLI command
- Removed `refinedIssues` parameter from `runSprintPlanning()` (planner reads backlog directly)
- Removed `PREVIOUS_SPRINT_SUMMARY` template variable from planning prompt
- Removed `'refine'` from `SprintPhase` type and state schema
- Updated dashboard phase steppers (HTML, React, legacy JS)
- Standalone `sprint-runner refine` CLI command preserved for on-demand use

## Rationale

Refinement is a collaborative backlog grooming activity, not an automatic sprint step. Running it at every sprint start:
1. Delays sprint start unnecessarily when backlog is already refined
2. Happens without stakeholder input
3. Conflates backlog grooming with sprint planning

## Testing

- 570/570 tests pass (removed 1 obsolete `runRefine` test)
- Type check clean
- Unit, integration, and E2E test expectations updated

Closes #312