### PR TITLE
fix: derive REPO_OWNER and REPO_NAME from git remote

### DIFF
--- a/src/ceremonies/execution.ts
+++ b/src/ceremonies/execution.ts
@@ -619,8 +619,8 @@ function buildPromptVars(ctx: ExecutionContext): Record<string, string> {
   const { config, issue, branch, worktreePath } = ctx;
   return {
     PROJECT_NAME: path.basename(config.projectPath),
-    REPO_OWNER: "",
-    REPO_NAME: path.basename(config.projectPath),
+    REPO_OWNER: config.repoOwner,
+    REPO_NAME: config.repoName,
     SPRINT_NUMBER: String(config.sprintNumber),
     ISSUE_NUMBER: String(issue.number),
     ISSUE_TITLE: issue.title,

--- a/src/ceremonies/planning.ts
+++ b/src/ceremonies/planning.ts
@@ -42,8 +42,8 @@ export async function runSprintPlanning(
 
   const prompt = substitutePrompt(template, {
     PROJECT_NAME: path.basename(config.projectPath),
-    REPO_OWNER: "",
-    REPO_NAME: path.basename(config.projectPath),
+    REPO_OWNER: config.repoOwner,
+    REPO_NAME: config.repoName,
     SPRINT_NUMBER: String(config.sprintNumber),
     MAX_ISSUES: String(config.maxIssuesPerSprint),
     VELOCITY_DATA: sanitizePromptInput(velocityStr),

--- a/src/ceremonies/refinement.ts
+++ b/src/ceremonies/refinement.ts
@@ -46,8 +46,8 @@ export async function runRefinement(
 
   const prompt = substitutePrompt(template, {
     PROJECT_NAME: path.basename(config.projectPath),
-    REPO_OWNER: "",
-    REPO_NAME: path.basename(config.projectPath),
+    REPO_OWNER: config.repoOwner,
+    REPO_NAME: config.repoName,
     SPRINT_NUMBER: String(config.sprintNumber),
     VELOCITY_DATA: sanitizePromptInput(velocityStr),
     BASE_BRANCH: config.baseBranch,

--- a/src/ceremonies/retro.ts
+++ b/src/ceremonies/retro.ts
@@ -87,8 +87,8 @@ export async function runSprintRetro(
 
   const prompt = substitutePrompt(template, {
     PROJECT_NAME: path.basename(config.projectPath),
-    REPO_OWNER: "",
-    REPO_NAME: path.basename(config.projectPath),
+    REPO_OWNER: config.repoOwner,
+    REPO_NAME: config.repoName,
     SPRINT_NUMBER: String(config.sprintNumber),
     SPRINT_REVIEW_DATA: sanitizePromptInput(JSON.stringify({ review, metrics })),
     VELOCITY_DATA: velocityStr,

--- a/src/ceremonies/review.ts
+++ b/src/ceremonies/review.ts
@@ -111,8 +111,8 @@ export async function runSprintReview(
 
   const prompt = substitutePrompt(template, {
     PROJECT_NAME: path.basename(config.projectPath),
-    REPO_OWNER: "",
-    REPO_NAME: path.basename(config.projectPath),
+    REPO_OWNER: config.repoOwner,
+    REPO_NAME: config.repoName,
     SPRINT_NUMBER: String(config.sprintNumber),
     SPRINT_START_SHA: config.baseBranch,
     SPRINT_ISSUES: sanitizePromptInput(JSON.stringify(issuesSummary)),

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -2,20 +2,37 @@
  * Shared CLI helper functions — config builders, client factory, argument parsers.
  */
 
+import { execFileSync } from "node:child_process";
 import { InvalidArgumentError } from "commander";
 import { loadConfig, type ConfigFile, prefixToSlug } from "../config.js";
 import { AcpClient } from "../acp/client.js";
 import type { SprintConfig } from "../types.js";
 
+/** Parse owner/name from a git remote URL (HTTPS or SSH). */
+function parseGitRemote(cwd: string): { owner: string; name: string } {
+  try {
+    const url = execFileSync("git", ["remote", "get-url", "origin"], { cwd, encoding: "utf-8" }).trim();
+    // HTTPS: https://github.com/owner/repo.git
+    // SSH:   git@github.com:owner/repo.git
+    const match = url.match(/[/:]([\w.-]+)\/([\w.-]+?)(?:\.git)?$/);
+    if (match) return { owner: match[1]!, name: match[2]! };
+  } catch { /* ignore — return empty */ }
+  return { owner: "", name: "" };
+}
+
 /** Build a SprintConfig from the parsed config file and a sprint number. */
 export function buildSprintConfig(config: ConfigFile, sprintNumber: number): SprintConfig {
   const prefix = config.sprint.prefix;
   const slug = prefixToSlug(prefix);
+  const cwd = process.cwd();
+  const remote = parseGitRemote(cwd);
   return {
     sprintNumber,
     sprintPrefix: prefix,
     sprintSlug: slug,
-    projectPath: process.cwd(),
+    projectPath: cwd,
+    repoOwner: remote.owner,
+    repoName: remote.name || config.project.name,
     baseBranch: config.project.base_branch,
     worktreeBase: config.git.worktree_base,
     branchPattern: config.git.branch_pattern,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -84,6 +84,10 @@ export interface SprintConfig extends GitConfig, SessionConfig, ExecutionLimits 
   sprintPrefix: string;
   sprintSlug: string;
   projectPath: string;
+  /** GitHub repository owner (org or user), derived from git remote. */
+  repoOwner: string;
+  /** GitHub repository name, derived from git remote. */
+  repoName: string;
   /** Quality gate settings from YAML config. Falls back to hardcoded defaults when absent. */
   qualityGate?: QualityGateSettings;
   /** ntfy push notification settings. */


### PR DESCRIPTION
Parses owner/name from `git remote get-url origin` (HTTPS + SSH) and passes them to all ceremony prompt templates. Previously `REPO_OWNER` was always `""` and `REPO_NAME` used `path.basename()`.

Closes #315

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>