### PR TITLE
refactor: remove pre-loading from ceremonies, agents fetch via MCP

### DIFF
--- a/.aiscrum/roles/planner/prompts/planning.md
+++ b/.aiscrum/roles/planner/prompts/planning.md
@@ -8,9 +8,15 @@ You are the **Sprint Planning Agent** for the AI-Scrum autonomous sprint runner.
 - **Repository**: {{REPO_OWNER}}/{{REPO_NAME}}
 - **Sprint**: {{SPRINT_NUMBER}}
 - **Max issues per sprint**: {{MAX_ISSUES}}
-- **Velocity data**: {{VELOCITY_DATA}}
-- **Previous sprint summary**: {{PREVIOUS_SPRINT_SUMMARY}}
 - **Base branch**: {{BASE_BRANCH}}
+
+## Data Sources
+
+Fetch these yourself using the tools available:
+
+- **Backlog issues**: `gh issue list --state open --json number,title,body,labels,milestone --limit 100` — filter for issues WITHOUT a milestone and with `status:ready` or `status:refined` labels
+- **Velocity history**: Read `docs/sprints/velocity.md` if it exists
+- **Issue details**: `gh issue view <N> --json title,body,labels` for acceptance criteria
 
 ## Your Task
 

--- a/.aiscrum/roles/refiner/prompts/refinement.md
+++ b/.aiscrum/roles/refiner/prompts/refinement.md
@@ -7,8 +7,15 @@ You are the **Refinement Agent** for the AI-Scrum autonomous sprint runner.
 - **Project**: {{PROJECT_NAME}}
 - **Repository**: {{REPO_OWNER}}/{{REPO_NAME}}
 - **Sprint**: {{SPRINT_NUMBER}} (upcoming)
-- **Velocity data**: {{VELOCITY_DATA}}
 - **Base branch**: {{BASE_BRANCH}}
+
+## Data Sources
+
+Fetch these yourself using the tools available:
+
+- **Idea issues**: `gh issue list --state open --label type:idea --json number,title,body,labels`
+- **Velocity history**: Read `docs/sprints/velocity.md` if it exists
+- **Architecture decisions**: Read `docs/architecture/ADR.md`
 
 ## Your Task
 

--- a/.aiscrum/roles/retro/prompts/retro.md
+++ b/.aiscrum/roles/retro/prompts/retro.md
@@ -8,10 +8,16 @@ You are the **Sprint Retro Agent** for the AI-Scrum autonomous sprint runner.
 - **Repository**: {{REPO_OWNER}}/{{REPO_NAME}}
 - **Sprint**: {{SPRINT_NUMBER}}
 - **Sprint review data**: {{SPRINT_REVIEW_DATA}}
-- **Velocity data**: {{VELOCITY_DATA}}
-- **Previous retro improvements**: {{PREVIOUS_RETRO_IMPROVEMENTS}}
-- **Sprint runner config**: {{SPRINT_RUNNER_CONFIG}}
 - **Failure diagnostics**: {{FAILURE_DIAGNOSTICS}}
+
+## Data Sources
+
+Fetch these yourself using the tools available:
+
+- **Velocity history**: Read `docs/sprints/velocity.md` if it exists
+- **Previous retro**: Read `docs/sprints/sprint-<N-1>-retro.md` where N-1 = previous sprint number
+- **Sprint runner config**: Read `sprint-runner.config.yaml` in the project root
+- **Sprint log**: Read `docs/sprints/sprint-{{SPRINT_NUMBER}}-log.md`
 
 ## Your Task
 

--- a/.aiscrum/roles/reviewer/prompts/review.md
+++ b/.aiscrum/roles/reviewer/prompts/review.md
@@ -9,8 +9,15 @@ You are the **Sprint Review Agent** for the AI-Scrum autonomous sprint runner.
 - **Sprint**: {{SPRINT_NUMBER}}
 - **Sprint start SHA**: {{SPRINT_START_SHA}}
 - **Sprint issues**: {{SPRINT_ISSUES}}
-- **Velocity data**: {{VELOCITY_DATA}}
 - **Base branch**: {{BASE_BRANCH}}
+
+## Data Sources
+
+Fetch these yourself using the tools available:
+
+- **Velocity history**: Read `docs/sprints/velocity.md` if it exists
+- **Sprint logs**: Read `docs/sprints/sprint-{{SPRINT_NUMBER}}-log.md` if it exists
+- **PR details**: `gh pr list --state merged --limit 20 --json number,title,mergedAt`
 
 ## Your Task
 

--- a/src/ceremonies/planning.ts
+++ b/src/ceremonies/planning.ts
@@ -4,18 +4,17 @@ import type { AcpClient } from "../acp/client.js";
 import type { SprintConfig, SprintPlan } from "../types.js";
 import { SprintPlanSchema } from "../types.js";
 import type { SprintEventBus } from "../events.js";
-import { listIssues } from "../github/issues.js";
 import { setLabel } from "../github/labels.js";
 import { setMilestone, getMilestone, createMilestone } from "../github/milestones.js";
 import { createSprintLog } from "../documentation/sprint-log.js";
-import { readVelocity } from "../documentation/velocity.js";
 import { logger } from "../logger.js";
-import { substitutePrompt, extractJson, sanitizePromptInput } from "./helpers.js";
+import { substitutePrompt, extractJson } from "./helpers.js";
 import { resolveSessionConfig } from "../acp/session-config.js";
 
 /**
- * Run the sprint planning ceremony: select and sequence backlog issues
- * into a sprint plan via ACP, then label and milestone them.
+ * Run the sprint planning ceremony: send the planner agent instructions
+ * to select and sequence backlog issues, then label and milestone them.
+ * The agent fetches backlog issues and velocity data itself via MCP tools.
  */
 export async function runSprintPlanning(
   client: AcpClient,
@@ -24,29 +23,16 @@ export async function runSprintPlanning(
 ): Promise<SprintPlan> {
   const log = logger.child({ ceremony: "planning" });
 
-  // Read velocity data
-  const velocity = readVelocity();
-  const velocityStr = JSON.stringify(velocity);
-
-  // List available backlog issues (filtered by backlog_labels if configured)
-  const listOpts: { state: string; labels?: string[] } = { state: "open" };
-  if (config.backlogLabels.length > 0) {
-    listOpts.labels = config.backlogLabels;
-  }
-  const backlog = await listIssues(listOpts);
-  log.info({ count: backlog.length, labels: config.backlogLabels }, "Loaded backlog issues");
-
   // Read prompt template
   const templatePath = path.join(config.projectPath, ".aiscrum", "roles", "planner", "prompts", "planning.md");
   const template = await fs.readFile(templatePath, "utf-8");
 
   const prompt = substitutePrompt(template, {
-    PROJECT_NAME: path.basename(config.projectPath),
+    PROJECT_NAME: config.repoName,
     REPO_OWNER: config.repoOwner,
     REPO_NAME: config.repoName,
     SPRINT_NUMBER: String(config.sprintNumber),
     MAX_ISSUES: String(config.maxIssuesPerSprint),
-    VELOCITY_DATA: sanitizePromptInput(velocityStr),
     BASE_BRANCH: config.baseBranch,
   });
 

--- a/src/ceremonies/refinement.ts
+++ b/src/ceremonies/refinement.ts
@@ -5,8 +5,7 @@ import type { SprintConfig, RefinedIssue } from "../types.js";
 import type { SprintEventBus } from "../events.js";
 import { listIssues } from "../github/issues.js";
 import { logger } from "../logger.js";
-import { substitutePrompt, extractJson, sanitizePromptInput } from "./helpers.js";
-import { readVelocity } from "../documentation/velocity.js";
+import { substitutePrompt, extractJson } from "./helpers.js";
 import { resolveSessionConfig } from "../acp/session-config.js";
 
 interface RefinementResponse {
@@ -36,20 +35,15 @@ export async function runRefinement(
   }
   log.info({ count: ideas.length }, "Loaded idea issues for refinement");
 
-  // Read velocity data for context
-  const velocity = readVelocity();
-  const velocityStr = JSON.stringify(velocity);
-
   // Read prompt template
   const templatePath = path.join(config.projectPath, ".aiscrum", "roles", "refiner", "prompts", "refinement.md");
   const template = await fs.readFile(templatePath, "utf-8");
 
   const prompt = substitutePrompt(template, {
-    PROJECT_NAME: path.basename(config.projectPath),
+    PROJECT_NAME: config.repoName,
     REPO_OWNER: config.repoOwner,
     REPO_NAME: config.repoName,
     SPRINT_NUMBER: String(config.sprintNumber),
-    VELOCITY_DATA: sanitizePromptInput(velocityStr),
     BASE_BRANCH: config.baseBranch,
   });
 

--- a/src/ceremonies/retro.ts
+++ b/src/ceremonies/retro.ts
@@ -10,7 +10,6 @@ import type {
 } from "../types.js";
 import type { SprintEventBus } from "../events.js";
 import { calculateSprintMetrics } from "../metrics.js";
-import { readVelocity } from "../documentation/velocity.js";
 import { logger } from "../logger.js";
 import { substitutePrompt, extractJson, sanitizePromptInput } from "./helpers.js";
 import { resolveSessionConfig } from "../acp/session-config.js";
@@ -33,46 +32,6 @@ export async function runSprintRetro(
   // Calculate metrics
   const metrics = calculateSprintMetrics(result);
 
-  // Read velocity data
-  const velocity = readVelocity();
-  const velocityStr = JSON.stringify(velocity);
-
-  // Load previous retro improvements (best-effort)
-  let previousImprovements = "None available";
-  const prevRetroPath = path.join(
-    config.projectPath,
-    "docs",
-    "sprints",
-    `sprint-${config.sprintNumber - 1}-retro.md`,
-  );
-  try {
-    previousImprovements = await fs.readFile(prevRetroPath, "utf-8");
-  } catch {
-    log.debug("No previous retro file found — using empty context");
-  }
-
-  // Read sprint runner config for context (filtered to sprint-relevant keys)
-  let runnerConfig = "";
-  const configPath = path.join(config.projectPath, "sprint-runner.config.yaml");
-  try {
-    const rawConfig = await fs.readFile(configPath, "utf-8");
-    // Filter to sprint-relevant keys only
-    const lines = rawConfig.split("\n");
-    const relevantKeys = ["sprintPrefix", "qualityGate", "maxParallel", "sessionTimeout", "backlogLabels", "maxRetries"];
-    const filteredLines = lines.filter(line => {
-      const trimmed = line.trim();
-      if (trimmed === "" || trimmed.startsWith("#")) return true;
-      return relevantKeys.some(key => trimmed.startsWith(key));
-    });
-    runnerConfig = filteredLines.join("\n");
-  } catch {
-    log.debug("No sprint runner config found");
-  }
-
-  // Read prompt template
-  const templatePath = path.join(config.projectPath, ".aiscrum", "roles", "retro", "prompts", "retro.md");
-  const template = await fs.readFile(templatePath, "utf-8");
-
   // Build failure diagnostics from sprint results
   const failureDiagnostics = result.results
     .filter((r) => r.status === "failed")
@@ -85,15 +44,16 @@ export async function runSprintRetro(
       retryCount: r.retryCount,
     }));
 
+  // Read prompt template
+  const templatePath = path.join(config.projectPath, ".aiscrum", "roles", "retro", "prompts", "retro.md");
+  const template = await fs.readFile(templatePath, "utf-8");
+
   const prompt = substitutePrompt(template, {
-    PROJECT_NAME: path.basename(config.projectPath),
+    PROJECT_NAME: config.repoName,
     REPO_OWNER: config.repoOwner,
     REPO_NAME: config.repoName,
     SPRINT_NUMBER: String(config.sprintNumber),
     SPRINT_REVIEW_DATA: sanitizePromptInput(JSON.stringify({ review, metrics })),
-    VELOCITY_DATA: velocityStr,
-    PREVIOUS_RETRO_IMPROVEMENTS: sanitizePromptInput(previousImprovements),
-    SPRINT_RUNNER_CONFIG: runnerConfig,
     FAILURE_DIAGNOSTICS: sanitizePromptInput(JSON.stringify(failureDiagnostics)),
   });
 

--- a/src/ceremonies/review.ts
+++ b/src/ceremonies/review.ts
@@ -4,7 +4,6 @@ import type { AcpClient } from "../acp/client.js";
 import type { SprintConfig, SprintResult, ReviewResult, IssueResult } from "../types.js";
 import type { SprintEventBus } from "../events.js";
 import { calculateSprintMetrics, topFailedGates } from "../metrics.js";
-import { readVelocity } from "../documentation/velocity.js";
 import { logger } from "../logger.js";
 import { substitutePrompt, extractJson, sanitizePromptInput } from "./helpers.js";
 import { resolveSessionConfig } from "../acp/session-config.js";
@@ -76,10 +75,6 @@ export async function runSprintReview(
   const failedGates = topFailedGates(result);
   log.info({ metrics }, "Calculated sprint metrics");
 
-  // Read velocity data
-  const velocity = readVelocity();
-  const velocityStr = JSON.stringify(velocity);
-
   // Verify PR merges
   const flaggedPRs = await verifyPRMerges(result.results);
   if (flaggedPRs.length > 0) {
@@ -110,13 +105,12 @@ export async function runSprintReview(
   const template = await fs.readFile(templatePath, "utf-8");
 
   const prompt = substitutePrompt(template, {
-    PROJECT_NAME: path.basename(config.projectPath),
+    PROJECT_NAME: config.repoName,
     REPO_OWNER: config.repoOwner,
     REPO_NAME: config.repoName,
     SPRINT_NUMBER: String(config.sprintNumber),
     SPRINT_START_SHA: config.baseBranch,
     SPRINT_ISSUES: sanitizePromptInput(JSON.stringify(issuesSummary)),
-    VELOCITY_DATA: sanitizePromptInput(velocityStr),
     BASE_BRANCH: config.baseBranch,
     METRICS: JSON.stringify(metrics),
     FAILED_GATES: failedGates,


### PR DESCRIPTION
Removes unnecessary data pre-loading from all ceremonies. Agents now fetch data themselves via MCP tools (gh CLI, file system).

**Removed pre-loading:**
- Planning: backlog issues, velocity data
- Refinement: velocity data  
- Review: velocity data
- Retro: velocity data, previous retro file, sprint runner config

**Kept (runtime-computed data agents can't fetch):**
- Review: sprint metrics, PR verification, issue summaries
- Retro: failure diagnostics, review data

**Updated prompt templates** with `Data Sources` section listing specific commands and file paths.

570/570 tests pass.

Closes #314, #316, #317