### PR TITLE
fix(dashboard): backlog sprint button feedback

### DIFF
--- a/src/dashboard/frontend/src/components/TabList.css
+++ b/src/dashboard/frontend/src/components/TabList.css
@@ -98,3 +98,8 @@
   color: #000;
 }
 .btn-success:hover { filter: brightness(1.1); }
+
+.btn-pending {
+  opacity: 0.6;
+  cursor: wait;
+}

--- a/src/dashboard/frontend/src/components/Tabs.tsx
+++ b/src/dashboard/frontend/src/components/Tabs.tsx
@@ -8,29 +8,44 @@ export function BacklogTab() {
   const [loading, setLoading] = useState(true);
   const send = useDashboardStore((s) => s.send);
   const repoUrl = useDashboardStore((s) => s.repoUrl);
+  const sprintNumber = useDashboardStore((s) => s.activeSprintNumber);
+  const backlogPending = useDashboardStore((s) => s.backlogPending);
+  const backlogPlanned = useDashboardStore((s) => s.backlogPlanned);
 
   const fetchItems = () => {
     setLoading(true);
     fetch("/api/backlog")
       .then((r) => r.json())
-      .then((d) => setItems(Array.isArray(d) ? d : []))
+      .then((d) => {
+        setItems(Array.isArray(d) ? d : []);
+        // Clear planned set on refresh since server data is fresh
+        useDashboardStore.setState({ backlogPlanned: new Set() });
+      })
       .catch(() => setItems([]))
       .finally(() => setLoading(false));
   };
 
   useEffect(() => { fetchItems(); }, []);
 
+  const planIssue = (num: number) => {
+    useDashboardStore.setState((s) => ({ backlogPending: new Set(s.backlogPending).add(num) }));
+    send({ type: "backlog:plan-issue", issueNumber: num });
+  };
+
+  // Hide items that were confirmed planned (until next refresh)
+  const visibleItems = items.filter((i) => !backlogPlanned.has(i.number));
+
   if (loading) return <div className="tab-loading">Loading backlog...</div>;
-  if (items.length === 0) return <div className="tab-empty">No backlog items.</div>;
+  if (visibleItems.length === 0) return <div className="tab-empty">No backlog items.</div>;
 
   return (
     <div className="tab-list-container">
       <div className="tab-list-header">
-        <h2>Backlog ({items.length})</h2>
+        <h2>Backlog ({visibleItems.length})</h2>
         <button className="btn btn-small" onClick={fetchItems}>↻ Refresh</button>
       </div>
       <ul className="tab-list">
-        {items.map((item) => (
+        {visibleItems.map((item) => (
           <li key={item.number} className="tab-list-item">
             <div className="tab-list-item-header">
               {repoUrl ? (
@@ -40,10 +55,11 @@ export function BacklogTab() {
               )}
               <span className="item-title">{item.title}</span>
               <button
-                className="btn btn-small btn-primary"
-                onClick={() => send({ type: "backlog:plan-issue", issueNumber: item.number })}
+                className={`btn btn-small btn-primary${backlogPending.has(item.number) ? " btn-pending" : ""}`}
+                disabled={backlogPending.has(item.number)}
+                onClick={() => planIssue(item.number)}
               >
-                + Sprint
+                {backlogPending.has(item.number) ? "Adding…" : `→ Sprint ${sprintNumber || "?"}`}
               </button>
             </div>
             {item.labels && item.labels.length > 0 && (

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -40,6 +40,10 @@ export interface DashboardStore {
   executionMode: "autonomous" | "hitl";
   sprintLimit: number; // 0 = infinite
 
+  // Backlog planning feedback
+  backlogPending: Set<number>;   // currently being added
+  backlogPlanned: Set<number>;   // confirmed added (hide from list)
+
   // Actions
   send: (msg: ClientMessage) => void;
   connect: () => void;
@@ -259,15 +263,25 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
       const p = msg.payload as { issueNumber: number } | undefined;
       if (p) {
         const store = get();
+        const pendNext = new Set(store.backlogPending);
+        pendNext.delete(p.issueNumber);
+        const plannedNext = new Set(store.backlogPlanned);
+        plannedNext.add(p.issueNumber);
+        set({ backlogPending: pendNext, backlogPlanned: plannedNext });
         addActivity(set, store, "backlog", `#${p.issueNumber} added to sprint`, null, "done");
       }
       break;
     }
 
     case "backlog:error": {
-      const p = msg.payload as { error: string } | undefined;
+      const p = msg.payload as { issueNumber?: number; error: string } | undefined;
       if (p) {
         const store = get();
+        if (p.issueNumber) {
+          const next = new Set(store.backlogPending);
+          next.delete(p.issueNumber);
+          set({ backlogPending: next });
+        }
         addActivity(set, store, "error", `Backlog error: ${p.error}`, null, "failed");
       }
       break;
@@ -437,6 +451,8 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
   chatStreaming: {},
   executionMode: "autonomous",
   sprintLimit: 0,
+  backlogPending: new Set<number>(),
+  backlogPlanned: new Set<number>(),
 
   // Actions
   send: (msg: ClientMessage) => {


### PR DESCRIPTION
## Problem
Clicking '+ Sprint' on backlog items had no visual feedback — no loading state, no indication which sprint, and the item stayed in the list after being added.

## Changes
- Button now shows target sprint: `→ Sprint 1`
- Button shows `Adding…` with disabled/dimmed state while request is pending
- Item disappears from backlog list once server confirms (`backlog:planned`)
- On error, button returns to clickable state
- State tracked via `backlogPending` / `backlogPlanned` sets in zustand store

## Files
- `src/dashboard/frontend/src/components/Tabs.tsx` — BacklogTab button UX
- `src/dashboard/frontend/src/store.ts` — backlogPending/backlogPlanned state
- `src/dashboard/frontend/src/components/TabList.css` — .btn-pending style

## Testing
- 574/574 tests pass
- Frontend builds cleanly
- Type check clean