### PR TITLE
refactor: move config to .aiscrum/ with modular quality-gates

### DIFF
--- a/.aiscrum/config.test.yaml
+++ b/.aiscrum/config.test.yaml
@@ -1,6 +1,6 @@
 # Sprint Runner Test Configuration
 # Use this config to run test sprints that are isolated from production.
-# Usage: npx tsx src/index.ts run --config sprint-runner.test.yaml
+# Usage: npx tsx src/index.ts run --config .aiscrum/config.test.yaml
 #
 # Creates "Test Sprint N" milestones, "test-sprint-N-state.json" files,
 # and "test-sprint/N/issue-N" branches — fully isolated from production sprints.
@@ -40,6 +40,7 @@ sprint:
   auto_revert_drift: false
   backlog_labels: ["test-run"]
 
+# Inline quality gates override (test mode disables challenger)
 quality_gates:
   require_tests: true
   require_lint: true

--- a/.aiscrum/config.yaml
+++ b/.aiscrum/config.yaml
@@ -37,14 +37,6 @@ sprint:
   enable_challenger: true
   auto_revert_drift: false
 
-quality_gates:
-  require_tests: true
-  require_lint: true
-  require_types: true
-  require_build: true
-  max_diff_lines: 300
-  require_challenger: true
-
 escalation:
   notifications:
     ntfy: true

--- a/.aiscrum/quality-gates.yaml
+++ b/.aiscrum/quality-gates.yaml
@@ -1,0 +1,22 @@
+# Quality Gate Configuration
+# Checks run after each issue implementation to verify code quality.
+
+checks:
+  tests:
+    enabled: true
+    command: ["npm", "run", "test"]
+  lint:
+    enabled: true
+    command: ["npm", "run", "lint"]
+  types:
+    enabled: true
+    command: ["npx", "tsc", "--noEmit"]
+  build:
+    enabled: true
+    command: ["npm", "run", "build"]
+
+limits:
+  max_diff_lines: 300
+
+review:
+  require_challenger: true

--- a/.aiscrum/roles/general/prompts/worker.md
+++ b/.aiscrum/roles/general/prompts/worker.md
@@ -109,7 +109,7 @@ Create a PR with:
 ## Prohibited Actions
 
 - **Never delete files** unless explicitly required by acceptance criteria
-- **Never modify** package.json, .env, sprint-runner.config.yaml, or configuration files unless that is the issue scope
+- **Never modify** package.json, .env, .aiscrum/config.yaml, or configuration files unless that is the issue scope
 - **Never run** shell commands beyond: `npm run lint`, `npm run test`, `npm run typecheck`, `git` commands
 - **Never access** environment variables, credential files, or secrets
 - **Never install** packages without explicit approval in acceptance criteria

--- a/.aiscrum/roles/retro/prompts/retro.md
+++ b/.aiscrum/roles/retro/prompts/retro.md
@@ -16,7 +16,7 @@ Fetch these yourself using the tools available:
 
 - **Velocity history**: Read `docs/sprints/velocity.md` if it exists
 - **Previous retro**: Read `docs/sprints/sprint-<N-1>-retro.md` where N-1 = previous sprint number
-- **Sprint runner config**: Read `sprint-runner.config.yaml` in the project root
+- **Sprint runner config**: Read `.aiscrum/config.yaml`
 - **Sprint log**: Read `docs/sprints/sprint-{{SPRINT_NUMBER}}-log.md`
 
 ## Your Task
@@ -85,7 +85,7 @@ For each problem identified, propose a specific, actionable improvement. Improve
 
 | Category | Example |
 |----------|---------|
-| **Config change** | Adjust `max_issues`, `session_timeout_ms`, `max_diff_lines` in sprint-runner.config.yaml |
+| **Config change** | Adjust `max_issues`, `session_timeout_ms`, `max_diff_lines` in `.aiscrum/config.yaml` or `.aiscrum/quality-gates.yaml` |
 | **Agent improvement** | Update agent instructions, add new checks, improve prompts |
 | **Skill improvement** | Enhance existing skills, create new skills for repeated tasks |
 | **Process change** | Modify ceremony flow, add/remove quality gates |
@@ -115,7 +115,7 @@ Each improvement will be **auto-applied** by the system after the retro complete
 | Target | What gets edited |
 |--------|-----------------|
 | `skill` / `agent` | Files under `.aiscrum/roles/` |
-| `config` | `sprint-runner.config.yaml` in the project root |
+| `config` | `.aiscrum/config.yaml` and `.aiscrum/quality-gates.yaml` |
 | `process` | Ceremony/enforcement code under `src/ceremonies/`, `src/enforcement/`, or prompts under `.aiscrum/roles/*/prompts/` |
 
 Improvements with `autoApplicable: false` will be logged but skipped — they will NOT create GitHub issues.
@@ -133,7 +133,7 @@ Before finalizing:
 ## Constraints
 
 - **Do NOT create GitHub issues for improvements** — all improvements are auto-applied by the system
-- **Config changes are encouraged** — quality gate commands (`test_command`, `lint_command`, `typecheck_command`), parallel session limits, timeouts, and other settings in `sprint-runner.config.yaml` can and should be tuned based on sprint data
+- **Config changes are encouraged** — quality gate commands in `.aiscrum/quality-gates.yaml`, parallel session limits, timeouts, and other settings in `.aiscrum/config.yaml` can and should be tuned based on sprint data
 - **Do NOT modify ADRs or the constitution** — those require stakeholder confirmation
 - **Data-driven only** — every insight must reference specific sprint metrics or incidents. No "we should probably..." without evidence
 - **Stakeholder Authority (Constitution §0)**: Process changes that affect what gets built require stakeholder approval

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ test-cleanup: ## Remove all test sprint artifacts
 	./scripts/test-cleanup.sh
 
 test-web: ## Run web dashboard in test mode
-	npx tsx src/index.ts web --config sprint-runner.test.yaml
+	npx tsx src/index.ts web --config .aiscrum/config.test.yaml
 
 test-e2e: ## Run Playwright E2E tests (requires test-setup first)
 	npx playwright test --reporter=list

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   ],
   // Dashboard is started by the test setup, not by Playwright
   webServer: {
-    command: "npx tsx src/index.ts web --config sprint-runner.test.yaml --no-open --port 9200",
+    command: "npx tsx src/index.ts web --config .aiscrum/config.test.yaml --no-open --port 9200",
     port: 9200,
     timeout: 15_000,
     reuseExistingServer: true,

--- a/prompts/retro.md
+++ b/prompts/retro.md
@@ -67,7 +67,7 @@ For each problem identified, propose a specific, actionable improvement. Improve
 
 | Category | Example |
 |----------|---------|
-| **Config change** | Adjust `max_issues`, `session_timeout_ms`, `max_diff_lines` in sprint-runner.config.yaml |
+| **Config change** | Adjust `max_issues`, `session_timeout_ms`, `max_diff_lines` in `.aiscrum/config.yaml` or `.aiscrum/quality-gates.yaml` |
 | **Agent improvement** | Update agent instructions, add new checks, improve prompts |
 | **Skill improvement** | Enhance existing skills, create new skills for repeated tasks |
 | **Process change** | Modify ceremony flow, add/remove quality gates |
@@ -113,7 +113,7 @@ Before finalizing:
 ## Constraints
 
 - **DO directly apply improvements** — the retro auto-applies all improvements via ACP sessions. Make each improvement specific enough to be applied as a code/config edit.
-- **Config changes are encouraged** — quality gate commands, parallel session limits, timeouts, and other settings in `sprint-runner.config.yaml` can and should be tuned based on sprint data.
+- **Config changes are encouraged** — quality gate commands in `.aiscrum/quality-gates.yaml`, parallel session limits, timeouts, and other settings in `.aiscrum/config.yaml` can and should be tuned based on sprint data.
 - **Do NOT modify ADRs or the constitution** — those require stakeholder confirmation
 - **Data-driven only** — every insight must reference specific sprint metrics or incidents. No "we should probably..." without evidence
 - **Stakeholder Authority (Constitution §0)**: Process changes that affect what gets built require stakeholder approval

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -109,7 +109,7 @@ Create a PR with:
 ## Prohibited Actions
 
 - **Never delete files** unless explicitly required by acceptance criteria
-- **Never modify** package.json, .env, sprint-runner.config.yaml, or configuration files unless that is the issue scope
+- **Never modify** package.json, .env, .aiscrum/config.yaml, or configuration files unless that is the issue scope
 - **Never run** shell commands beyond: `npm run lint`, `npm run test`, `npm run typecheck`, `git` commands
 - **Never access** environment variables, credential files, or secrets
 - **Never install** packages without explicit approval in acceptance criteria

--- a/scripts/test-setup.sh
+++ b/scripts/test-setup.sh
@@ -244,7 +244,7 @@ SPRINT1=$(gh api "repos/${REPO}/milestones" -q '.[] | select(.title=="Sprint 1")
 echo "   ${TOTAL} total issues (${SPRINT1} in Sprint 1, rest in backlog)"
 echo ""
 echo "▶ Start test run:"
-echo "   npx tsx src/index.ts web --config sprint-runner.test.yaml"
+echo "   npx tsx src/index.ts web --config .aiscrum/config.test.yaml"
 echo ""
 echo "🧹 Clean up when done:"
 echo "   ./scripts/test-cleanup.sh"

--- a/src/ceremonies/retro.ts
+++ b/src/ceremonies/retro.ts
@@ -197,7 +197,7 @@ async function applyImprovement(
         break;
       case "config":
         targetInstruction =
-          "Edit `sprint-runner.config.yaml` in the project root. " +
+          "Edit `.aiscrum/config.yaml` in the project root. " +
           "Preserve existing structure and comments. Only change the relevant settings.";
         break;
       case "process":

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,5 +1,5 @@
 /**
- * Init — scaffolds .aiscrum/roles/ and sprint-runner.config.yaml into a target project.
+ * Init — scaffolds .aiscrum/ structure (roles, config) into a target project.
  *
  * Copies role templates from the Sprint Runner's own .aiscrum/roles/ directory
  * and generates a minimal config file for the target project.
@@ -68,7 +68,8 @@ export function initProject(options: InitOptions): InitResult {
   copyDirRecursive(templateRolesDir, targetRolesDir, force, result);
 
   // Generate config if it doesn't exist
-  const configPath = path.join(targetPath, "sprint-runner.config.yaml");
+  const configPath = path.join(targetPath, ".aiscrum", "config.yaml");
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
   if (!fs.existsSync(configPath)) {
     fs.writeFileSync(configPath, MINIMAL_CONFIG, "utf-8");
     result.created.push(configPath);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-// Config loader: parse sprint-runner.config.yaml with Zod validation
+// Config loader: parse .aiscrum/config.yaml + .aiscrum/quality-gates.yaml with Zod validation
 
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -75,6 +75,31 @@ const SprintSchema = z.object({
   backlog_labels: z.array(z.string()).default([]),
 });
 
+// --- Quality Gates (separate file: .aiscrum/quality-gates.yaml) ---
+
+const QualityCheckSchema = z.object({
+  enabled: z.boolean().default(true),
+  command: z.union([z.string(), z.array(z.string())]).optional(),
+});
+
+export const QualityGatesFileSchema = z.object({
+  checks: z.object({
+    tests: QualityCheckSchema.default({ enabled: true }),
+    lint: QualityCheckSchema.default({ enabled: true }),
+    types: QualityCheckSchema.default({ enabled: true }),
+    build: QualityCheckSchema.default({ enabled: true }),
+  }).default({}),
+  limits: z.object({
+    max_diff_lines: z.number().int().min(1).default(300),
+  }).default({}),
+  review: z.object({
+    require_challenger: z.boolean().default(true),
+  }).default({}),
+});
+
+export type QualityGatesFile = z.infer<typeof QualityGatesFileSchema>;
+
+// Legacy schema kept for backward compat in ConfigFileSchema (inline quality_gates still accepted)
 const QualityGatesSchema = z.object({
   require_tests: z.boolean().default(true),
   require_lint: z.boolean().default(true),
@@ -155,14 +180,13 @@ export function substituteEnvVars(text: string): string {
 // --- Loader ---
 
 /**
- * Load and validate sprint-runner.config.yaml.
- * @param configPath – absolute or relative path to YAML config file.
- *   Defaults to `sprint-runner.config.yaml` in the current working directory.
+ * Load and validate config from `.aiscrum/config.yaml`.
+ * Quality gates are loaded from `.aiscrum/quality-gates.yaml` (separate file).
+ * @param configPath – explicit path to YAML config file.
+ *   When omitted, uses `.aiscrum/config.yaml` in the current working directory.
  */
 export function loadConfig(configPath?: string): ConfigFile {
-  const resolvedPath = path.resolve(
-    configPath ?? "sprint-runner.config.yaml",
-  );
+  const resolvedPath = path.resolve(configPath ?? ".aiscrum/config.yaml");
 
   if (!fs.existsSync(resolvedPath)) {
     throw new Error(`Config file not found: ${resolvedPath}`);
@@ -172,5 +196,47 @@ export function loadConfig(configPath?: string): ConfigFile {
   const substituted = substituteEnvVars(raw);
   const parsed: unknown = parseYaml(substituted, { customTags: [] });
 
-  return ConfigFileSchema.parse(parsed);
+  const config = ConfigFileSchema.parse(parsed);
+
+  // Load quality gates from separate file if not inline
+  const hasInlineQualityGates = (parsed as Record<string, unknown>)?.quality_gates != null;
+  if (!hasInlineQualityGates) {
+    const qgPath = path.resolve(path.dirname(resolvedPath), "quality-gates.yaml");
+    if (fs.existsSync(qgPath)) {
+      const qgRaw = fs.readFileSync(qgPath, "utf-8");
+      const qgSubstituted = substituteEnvVars(qgRaw);
+      const qgParsed: unknown = parseYaml(qgSubstituted, { customTags: [] });
+      const qg = QualityGatesFileSchema.parse(qgParsed);
+      // Map new format to legacy flat format
+      config.quality_gates = {
+        require_tests: qg.checks.tests.enabled,
+        require_lint: qg.checks.lint.enabled,
+        require_types: qg.checks.types.enabled,
+        require_build: qg.checks.build.enabled,
+        max_diff_lines: qg.limits.max_diff_lines,
+        test_command: qg.checks.tests.command ?? ["npm", "run", "test"],
+        lint_command: qg.checks.lint.command ?? ["npm", "run", "lint"],
+        typecheck_command: qg.checks.types.command ?? ["npm", "run", "typecheck"],
+        build_command: qg.checks.build.command ?? ["npm", "run", "build"],
+        require_challenger: qg.review.require_challenger,
+      };
+    }
+  }
+
+  return config;
+}
+
+/**
+ * Load quality gates config directly (for standalone use).
+ */
+export function loadQualityGates(configDir?: string): QualityGatesFile {
+  const dir = configDir ?? ".aiscrum";
+  const qgPath = path.resolve(dir, "quality-gates.yaml");
+  if (!fs.existsSync(qgPath)) {
+    return QualityGatesFileSchema.parse({});
+  }
+  const raw = fs.readFileSync(qgPath, "utf-8");
+  const substituted = substituteEnvVars(raw);
+  const parsed: unknown = parseYaml(substituted, { customTags: [] });
+  return QualityGatesFileSchema.parse(parsed);
 }

--- a/tests/ceremonies/retro.test.ts
+++ b/tests/ceremonies/retro.test.ts
@@ -227,7 +227,7 @@ describe("runSprintRetro", () => {
     expect(mockClient.sendPrompt).toHaveBeenCalledTimes(2);
     const applyCall = mockClient.sendPrompt.mock.calls[1];
     expect(applyCall[1]).toContain("Update deps");
-    expect(applyCall[1]).toContain("sprint-runner.config.yaml");
+    expect(applyCall[1]).toContain(".aiscrum/config.yaml");
   });
 
   it("skips improvements with empty title", async () => {
@@ -365,7 +365,7 @@ describe("runSprintRetro", () => {
     expect(mockClient.sendPrompt).toHaveBeenCalledTimes(2);
     const applyCall = mockClient.sendPrompt.mock.calls[1];
     expect(applyCall[1]).toContain("Update deps");
-    expect(applyCall[1]).toContain("sprint-runner.config.yaml");
+    expect(applyCall[1]).toContain(".aiscrum/config.yaml");
   });
 
   it("creates backlog issue for process improvement instead of auto-applying", async () => {

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -43,10 +43,10 @@ describe("initProject", () => {
     }
   });
 
-  it("creates sprint-runner.config.yaml", () => {
+  it("creates .aiscrum/config.yaml", () => {
     const result = initProject({ targetPath: tmpDir });
 
-    const configPath = path.join(tmpDir, "sprint-runner.config.yaml");
+    const configPath = path.join(tmpDir, ".aiscrum", "config.yaml");
     expect(fs.existsSync(configPath)).toBe(true);
     expect(result.configPath).toBe(configPath);
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -6,7 +6,7 @@ import { loadConfig, substituteEnvVars } from "../src/config.js";
 
 function writeTmpConfig(content: string): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "config-test-"));
-  const file = path.join(dir, "sprint-runner.config.yaml");
+  const file = path.join(dir, "config.yaml");
   fs.writeFileSync(file, content, "utf-8");
   return file;
 }
@@ -184,6 +184,72 @@ copilot:
 `;
     const file = writeTmpConfig(invalid);
     expect(() => loadConfig(file)).toThrow();
+  });
+
+  it("loads quality gates from separate quality-gates.yaml", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "config-qg-"));
+    const configFile = path.join(dir, "config.yaml");
+    const qgFile = path.join(dir, "quality-gates.yaml");
+
+    fs.writeFileSync(configFile, `
+project:
+  name: "qg-test"
+`, "utf-8");
+
+    fs.writeFileSync(qgFile, `
+checks:
+  tests:
+    enabled: true
+    command: ["pytest"]
+  lint:
+    enabled: false
+  types:
+    enabled: true
+    command: "mypy src/"
+  build:
+    enabled: false
+limits:
+  max_diff_lines: 500
+review:
+  require_challenger: false
+`, "utf-8");
+
+    const config = loadConfig(configFile);
+    expect(config.quality_gates.require_tests).toBe(true);
+    expect(config.quality_gates.test_command).toEqual(["pytest"]);
+    expect(config.quality_gates.require_lint).toBe(false);
+    expect(config.quality_gates.require_types).toBe(true);
+    expect(config.quality_gates.typecheck_command).toBe("mypy src/");
+    expect(config.quality_gates.require_build).toBe(false);
+    expect(config.quality_gates.max_diff_lines).toBe(500);
+    expect(config.quality_gates.require_challenger).toBe(false);
+  });
+
+  it("inline quality_gates takes precedence over separate file", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "config-inline-"));
+    const configFile = path.join(dir, "config.yaml");
+    const qgFile = path.join(dir, "quality-gates.yaml");
+
+    fs.writeFileSync(configFile, `
+project:
+  name: "inline-test"
+quality_gates:
+  require_tests: false
+  max_diff_lines: 100
+`, "utf-8");
+
+    fs.writeFileSync(qgFile, `
+checks:
+  tests:
+    enabled: true
+limits:
+  max_diff_lines: 999
+`, "utf-8");
+
+    const config = loadConfig(configFile);
+    // Inline wins — separate file should NOT be loaded
+    expect(config.quality_gates.require_tests).toBe(false);
+    expect(config.quality_gates.max_diff_lines).toBe(100);
   });
 });
 


### PR DESCRIPTION
## Changes

All configuration now lives under `.aiscrum/`:

```
.aiscrum/
├── config.yaml              ← Project, sprint, copilot, git, escalation
├── config.test.yaml         ← Test mode config
├── quality-gates.yaml       ← CI-style quality gate checks
└── roles/                   ← Agent prompts (unchanged)
```

### Quality Gates — New Format

```yaml
# .aiscrum/quality-gates.yaml
checks:
  tests:
    enabled: true
    command: ["npm", "run", "test"]
  lint:
    enabled: true
    command: ["npm", "run", "lint"]
  types:
    enabled: true
    command: ["npx", "tsc", "--noEmit"]
  build:
    enabled: true
    command: ["npm", "run", "build"]

limits:
  max_diff_lines: 300

review:
  require_challenger: true
```

### Config Loading
- Default: `.aiscrum/config.yaml`
- `--config <path>` still works for explicit paths
- Quality gates loaded from `quality-gates.yaml` in same directory as config
- Inline `quality_gates:` in config takes precedence over separate file

## Testing
- 576/576 tests pass (2 new tests for quality-gates.yaml loading)
- Frontend builds
- Type check clean