### PR TITLE
fix: test scripts deploy .aiscrum config to test repo

### DIFF
--- a/scripts/test-cleanup.sh
+++ b/scripts/test-cleanup.sh
@@ -102,6 +102,16 @@ if [[ $file_count -eq 0 ]]; then
   echo "  (none found)"
 fi
 
+# --- 5. Clean deployed .aiscrum config (keep roles) ---
+echo ""
+echo "📄 Cleaning deployed config in test repo..."
+for f in "${TEST_REPO_DIR}/.aiscrum/config.yaml" "${TEST_REPO_DIR}/.aiscrum/quality-gates.yaml"; do
+  if [[ -f "$f" ]]; then
+    rm "$f"
+    echo "  ❌ Deleted: $(basename "$f")"
+  fi
+done
+
 echo ""
 echo "✅ Cleanup complete! (${REPO})"
 echo ""

--- a/scripts/test-setup.sh
+++ b/scripts/test-setup.sh
@@ -236,6 +236,22 @@ create_issue "idea: Agent performance leaderboard" \
 "Track which agent configurations (model, prompts) produce the best results over time. Visualize in dashboard metrics tab." \
 "type:idea"
 
+# --- Deploy .aiscrum config to test repo ---
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RUNNER_DIR="$(dirname "$SCRIPT_DIR")"
+TEST_REPO_DIR="${HOME}/dev/GitHub/ai-scrum-test-project"
+
+if [ -d "$TEST_REPO_DIR" ]; then
+  mkdir -p "$TEST_REPO_DIR/.aiscrum"
+  cp "$RUNNER_DIR/.aiscrum/config.test.yaml" "$TEST_REPO_DIR/.aiscrum/config.yaml"
+  cp "$RUNNER_DIR/.aiscrum/quality-gates.yaml" "$TEST_REPO_DIR/.aiscrum/quality-gates.yaml"
+  # Copy roles if not present
+  if [ -d "$RUNNER_DIR/.aiscrum/roles" ]; then
+    cp -r "$RUNNER_DIR/.aiscrum/roles" "$TEST_REPO_DIR/.aiscrum/" 2>/dev/null || true
+  fi
+  echo "📁 Deployed .aiscrum/ config to ${TEST_REPO_DIR}"
+fi
+
 echo ""
 echo "✅ Test setup complete! (${REPO})"
 echo ""
@@ -244,7 +260,7 @@ SPRINT1=$(gh api "repos/${REPO}/milestones" -q '.[] | select(.title=="Sprint 1")
 echo "   ${TOTAL} total issues (${SPRINT1} in Sprint 1, rest in backlog)"
 echo ""
 echo "▶ Start test run:"
-echo "   npx tsx src/index.ts web --config .aiscrum/config.test.yaml"
+echo "   cd ${TEST_REPO_DIR} && npx tsx ${RUNNER_DIR}/src/index.ts web"
 echo ""
 echo "🧹 Clean up when done:"
 echo "   ./scripts/test-cleanup.sh"


### PR DESCRIPTION
Config now lives at `.aiscrum/config.yaml` in the target repo. The test scripts need to deploy it there.

- `test-setup.sh`: copies `config.test.yaml` → test-repo `.aiscrum/config.yaml` + `quality-gates.yaml`
- `test-cleanup.sh`: removes deployed config files
- Running from test repo no longer needs `--config` flag