### PR TITLE
feat: expandable issue cards and Sprint Backlog tab

### DIFF
--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -2,14 +2,16 @@ import { useEffect, useState } from "react";
 import { useDashboardStore } from "./store";
 import { Header } from "./components/Header";
 import { SprintTab } from "./components/SprintTab";
+import { SprintBacklogTab } from "./components/SprintBacklogTab";
 import { BacklogTab, BlockedTab, DecisionsTab, IdeasTab } from "./components/Tabs";
 import { ChatPanel } from "./components/ChatPanel";
 import "./index.css";
 
-type Tab = "sprint" | "backlog" | "blocked" | "decisions" | "ideas";
+type Tab = "sprint" | "sprint-backlog" | "backlog" | "blocked" | "decisions" | "ideas";
 
 const TABS: { id: Tab; label: string; icon: string }[] = [
   { id: "sprint", label: "Sprint", icon: "🏃" },
+  { id: "sprint-backlog", label: "Sprint Backlog", icon: "📦" },
   { id: "backlog", label: "Backlog", icon: "📋" },
   { id: "blocked", label: "Blocked", icon: "🚧" },
   { id: "decisions", label: "Decisions", icon: "⚖️" },
@@ -39,6 +41,7 @@ export default function App() {
         ))}
       </nav>
       {activeTab === "sprint" && <SprintTab />}
+      {activeTab === "sprint-backlog" && <SprintBacklogTab />}
       {activeTab === "backlog" && <BacklogTab />}
       {activeTab === "blocked" && <BlockedTab />}
       {activeTab === "decisions" && <DecisionsTab />}

--- a/src/dashboard/frontend/src/components/IssueCard.tsx
+++ b/src/dashboard/frontend/src/components/IssueCard.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import type { GhIssueItem } from "../types";
+import { useDashboardStore } from "../store";
+
+interface IssueCardProps {
+  item: GhIssueItem;
+  actions?: React.ReactNode;
+  /** Content shown only when expanded (below body) */
+  extraContent?: React.ReactNode;
+}
+
+export function IssueCard({ item, actions, extraContent }: IssueCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const repoUrl = useDashboardStore((s) => s.repoUrl);
+
+  return (
+    <li className={`tab-list-item${expanded ? " item-expanded" : ""}`}>
+      <div className="tab-list-item-header">
+        <button
+          className="item-expand-toggle"
+          onClick={() => setExpanded(!expanded)}
+          title={expanded ? "Collapse" : "Expand"}
+        >
+          {expanded ? "▾" : "▸"}
+        </button>
+        {repoUrl ? (
+          <a
+            href={`${repoUrl}/issues/${item.number}`}
+            target="_blank"
+            rel="noopener"
+            className="item-number"
+            onClick={(e) => e.stopPropagation()}
+          >
+            #{item.number}
+          </a>
+        ) : (
+          <span className="item-number">#{item.number}</span>
+        )}
+        <span
+          className="item-title item-title-clickable"
+          onClick={() => setExpanded(!expanded)}
+        >
+          {item.title}
+        </span>
+        {actions && <div className="item-actions">{actions}</div>}
+      </div>
+      {!expanded && item.labels && item.labels.length > 0 && (
+        <div className="item-labels">
+          {item.labels.map((l) => <span key={l} className="label-badge">{l}</span>)}
+        </div>
+      )}
+      {expanded && (
+        <div className="item-detail">
+          {item.labels && item.labels.length > 0 && (
+            <div className="item-labels">
+              {item.labels.map((l) => <span key={l} className="label-badge">{l}</span>)}
+            </div>
+          )}
+          {item.body ? (
+            <div className="item-body-full">{item.body}</div>
+          ) : (
+            <div className="item-body-empty">No description.</div>
+          )}
+          {item.blockedReason && (
+            <div className="item-blocked-reason">
+              <strong>⛔ Reason:</strong> {item.blockedReason}
+            </div>
+          )}
+          {extraContent}
+        </div>
+      )}
+    </li>
+  );
+}

--- a/src/dashboard/frontend/src/components/SprintBacklogTab.tsx
+++ b/src/dashboard/frontend/src/components/SprintBacklogTab.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import type { GhIssueItem } from "../types";
+import { useDashboardStore } from "../store";
+import { IssueCard } from "./IssueCard";
+import "./TabList.css";
+
+export function SprintBacklogTab() {
+  const [items, setItems] = useState<GhIssueItem[]>([]);
+  const [sprintNumber, setSprintNumber] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const send = useDashboardStore((s) => s.send);
+
+  const fetchItems = () => {
+    setLoading(true);
+    fetch("/api/sprint-backlog")
+      .then((r) => r.json())
+      .then((d) => {
+        setSprintNumber(d.sprintNumber ?? 0);
+        setItems(Array.isArray(d.items) ? d.items : []);
+      })
+      .catch(() => setItems([]))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => { fetchItems(); }, []);
+
+  const handleRemove = (issueNumber: number) => {
+    if (confirm(`Remove #${issueNumber} from Sprint ${sprintNumber}?`)) {
+      send({ type: "backlog:remove-issue", issueNumber });
+      setItems((prev) => prev.filter((i) => i.number !== issueNumber));
+    }
+  };
+
+  if (loading) return <div className="tab-loading">Loading sprint backlog...</div>;
+  if (items.length === 0) return <div className="tab-empty">No issues in sprint backlog.</div>;
+
+  return (
+    <div className="tab-list-container">
+      <div className="tab-list-header">
+        <h2>📦 Sprint {sprintNumber} Backlog ({items.length})</h2>
+        <button className="btn btn-small" onClick={fetchItems}>↻ Refresh</button>
+      </div>
+      <ul className="tab-list">
+        {items.map((item) => (
+          <IssueCard
+            key={item.number}
+            item={item}
+            actions={
+              <button
+                className="btn btn-small btn-danger"
+                onClick={() => handleRemove(item.number)}
+              >
+                ✕ Remove
+              </button>
+            }
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/components/TabList.css
+++ b/src/dashboard/frontend/src/components/TabList.css
@@ -49,11 +49,52 @@
 }
 .tab-list-item:hover { border-color: var(--blue); }
 
+.item-expanded { border-color: var(--blue); }
+
 .tab-list-item-header {
   display: flex;
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
+}
+
+.item-expand-toggle {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0 2px;
+  line-height: 1;
+}
+
+.item-title-clickable { cursor: pointer; }
+
+.item-actions {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.item-detail {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+
+.item-body-full {
+  font-size: 13px;
+  color: var(--text-dim);
+  white-space: pre-wrap;
+  line-height: 1.6;
+  margin-top: 8px;
+}
+
+.item-body-empty {
+  font-size: 12px;
+  color: var(--text-dim);
+  font-style: italic;
+  margin-top: 8px;
 }
 
 .item-number {

--- a/src/dashboard/frontend/src/components/Tabs.tsx
+++ b/src/dashboard/frontend/src/components/Tabs.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from "react";
 import type { GhIssueItem } from "../types";
 import { useDashboardStore } from "../store";
+import { IssueCard } from "./IssueCard";
 import "./TabList.css";
 
 export function BacklogTab() {
   const [items, setItems] = useState<GhIssueItem[]>([]);
   const [loading, setLoading] = useState(true);
   const send = useDashboardStore((s) => s.send);
-  const repoUrl = useDashboardStore((s) => s.repoUrl);
   const activeSprintNumber = useDashboardStore((s) => s.activeSprintNumber);
   const availableSprints = useDashboardStore((s) => s.availableSprints);
   const backlogPending = useDashboardStore((s) => s.backlogPending);
@@ -70,14 +70,10 @@ export function BacklogTab() {
       </div>
       <ul className="tab-list">
         {visibleItems.map((item) => (
-          <li key={item.number} className="tab-list-item">
-            <div className="tab-list-item-header">
-              {repoUrl ? (
-                <a href={`${repoUrl}/issues/${item.number}`} target="_blank" rel="noopener" className="item-number">#{item.number}</a>
-              ) : (
-                <span className="item-number">#{item.number}</span>
-              )}
-              <span className="item-title">{item.title}</span>
+          <IssueCard
+            key={item.number}
+            item={item}
+            actions={
               <button
                 className={`btn btn-small btn-primary${backlogPending.has(item.number) ? " btn-pending" : ""}`}
                 disabled={backlogPending.has(item.number)}
@@ -85,13 +81,8 @@ export function BacklogTab() {
               >
                 {backlogPending.has(item.number) ? "Adding…" : `→ Sprint ${targetSprint || "?"}`}
               </button>
-            </div>
-            {item.labels && item.labels.length > 0 && (
-              <div className="item-labels">
-                {item.labels.map((l) => <span key={l} className="label-badge">{l}</span>)}
-              </div>
-            )}
-          </li>
+            }
+          />
         ))}
       </ul>
     </div>
@@ -102,7 +93,6 @@ export function BlockedTab() {
   const [items, setItems] = useState<GhIssueItem[]>([]);
   const [loading, setLoading] = useState(true);
   const send = useDashboardStore((s) => s.send);
-  const repoUrl = useDashboardStore((s) => s.repoUrl);
 
   const fetchItems = () => {
     setLoading(true);
@@ -126,40 +116,32 @@ export function BlockedTab() {
       </div>
       <ul className="tab-list">
         {items.map((item) => (
-          <li key={item.number} className="tab-list-item">
-            <div className="tab-list-item-header">
-              {repoUrl ? (
-                <a href={`${repoUrl}/issues/${item.number}`} target="_blank" rel="noopener" className="item-number">#{item.number}</a>
-              ) : (
-                <span className="item-number">#{item.number}</span>
-              )}
-              <span className="item-title">{item.title}</span>
-              <button
-                className="btn btn-small"
-                onClick={() => {
-                  const msg = prompt("Add comment:");
-                  if (msg) send({ type: "blocked:comment", issueNumber: item.number, body: msg });
-                }}
-              >
-                💬
-              </button>
-              <button
-                className="btn btn-small btn-primary"
-                onClick={() => {
-                  if (confirm(`Unblock #${item.number}?`))
-                    send({ type: "blocked:unblock", issueNumber: item.number });
-                }}
-              >
-                🔓 Unblock
-              </button>
-            </div>
-            {item.blockedReason && (
-              <div className="item-blocked-reason">
-                <strong>⛔ Reason:</strong> {item.blockedReason}
-              </div>
-            )}
-            {item.body && <div className="item-body">{item.body.slice(0, 300)}</div>}
-          </li>
+          <IssueCard
+            key={item.number}
+            item={item}
+            actions={
+              <>
+                <button
+                  className="btn btn-small"
+                  onClick={() => {
+                    const msg = prompt("Add comment:");
+                    if (msg) send({ type: "blocked:comment", issueNumber: item.number, body: msg });
+                  }}
+                >
+                  💬
+                </button>
+                <button
+                  className="btn btn-small btn-primary"
+                  onClick={() => {
+                    if (confirm(`Unblock #${item.number}?`))
+                      send({ type: "blocked:unblock", issueNumber: item.number });
+                  }}
+                >
+                  🔓 Unblock
+                </button>
+              </>
+            }
+          />
         ))}
       </ul>
     </div>
@@ -170,7 +152,6 @@ export function DecisionsTab() {
   const [items, setItems] = useState<GhIssueItem[]>([]);
   const [loading, setLoading] = useState(true);
   const send = useDashboardStore((s) => s.send);
-  const repoUrl = useDashboardStore((s) => s.repoUrl);
 
   const fetchItems = () => {
     setLoading(true);
@@ -194,14 +175,10 @@ export function DecisionsTab() {
       </div>
       <ul className="tab-list">
         {items.map((item) => (
-          <li key={item.number} className="tab-list-item">
-            <div className="tab-list-item-header">
-              {repoUrl ? (
-                <a href={`${repoUrl}/issues/${item.number}`} target="_blank" rel="noopener" className="item-number">#{item.number}</a>
-              ) : (
-                <span className="item-number">#{item.number}</span>
-              )}
-              <span className="item-title">{item.title}</span>
+          <IssueCard
+            key={item.number}
+            item={item}
+            actions={
               <div className="decision-actions">
                 <button
                   className="btn btn-small btn-success"
@@ -225,9 +202,8 @@ export function DecisionsTab() {
                   💬
                 </button>
               </div>
-            </div>
-            {item.body && <div className="item-body">{item.body.slice(0, 500)}</div>}
-          </li>
+            }
+          />
         ))}
       </ul>
     </div>
@@ -237,7 +213,6 @@ export function DecisionsTab() {
 export function IdeasTab() {
   const [items, setItems] = useState<GhIssueItem[]>([]);
   const [loading, setLoading] = useState(true);
-  const repoUrl = useDashboardStore((s) => s.repoUrl);
 
   const fetchItems = () => {
     setLoading(true);
@@ -261,22 +236,7 @@ export function IdeasTab() {
       </div>
       <ul className="tab-list">
         {items.map((item) => (
-          <li key={item.number} className="tab-list-item">
-            <div className="tab-list-item-header">
-              {repoUrl ? (
-                <a href={`${repoUrl}/issues/${item.number}`} target="_blank" rel="noopener" className="item-number">#{item.number}</a>
-              ) : (
-                <span className="item-number">#{item.number}</span>
-              )}
-              <span className="item-title">{item.title}</span>
-            </div>
-            {item.body && <div className="item-body">{item.body.slice(0, 300)}</div>}
-            {item.labels && item.labels.length > 0 && (
-              <div className="item-labels">
-                {item.labels.map((l) => <span key={l} className="label-badge">{l}</span>)}
-              </div>
-            )}
-          </li>
+          <IssueCard key={item.number} item={item} />
         ))}
       </ul>
     </div>

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -827,6 +827,12 @@ export class DashboardWebServer {
       return;
     }
 
+    // /api/sprint-backlog — issues in the active sprint with full body
+    if (pathname === "/api/sprint-backlog") {
+      this.handleSprintBacklogRequest(res);
+      return;
+    }
+
     res.writeHead(404);
     res.end(JSON.stringify({ error: "Not found" }));
   }
@@ -916,6 +922,7 @@ export class DashboardWebServer {
           .map((i) => ({
             number: i.number,
             title: i.title,
+            body: i.body ?? "",
             labels: i.labels.map((l) => l.name),
           }));
         res.writeHead(200);
@@ -930,6 +937,32 @@ export class DashboardWebServer {
     });
   }
 
+  /** Return issues planned in the active sprint with full body for detail view. */
+  private handleSprintBacklogRequest(res: http.ServerResponse): void {
+    const prefix = this.options.sprintPrefix ?? "Sprint";
+    const sprintNum = this.activeSprintNumber ?? 1;
+    const milestoneName = `${prefix} ${sprintNum}`;
+    import("../github/issues.js").then(async ({ listIssues }) => {
+      try {
+        const ghIssues = await listIssues({ milestone: milestoneName, state: "open" });
+        const items = ghIssues.map((i) => ({
+          number: i.number,
+          title: i.title,
+          body: i.body ?? "",
+          labels: i.labels.map((l) => l.name),
+        }));
+        res.writeHead(200);
+        res.end(JSON.stringify({ sprintNumber: sprintNum, items }));
+      } catch {
+        res.writeHead(200);
+        res.end(JSON.stringify({ sprintNumber: sprintNum, items: [] }));
+      }
+    }).catch(() => {
+      res.writeHead(200);
+      res.end(JSON.stringify({ sprintNumber: sprintNum, items: [] }));
+    });
+  }
+
   /** Return idea issues (type:idea, awaiting refinement). */
   private handleIdeasRequest(res: http.ServerResponse): void {
     import("../github/issues.js").then(async ({ listIssues }) => {
@@ -938,7 +971,8 @@ export class DashboardWebServer {
         const ideas = ghIssues.map((i) => ({
           number: i.number,
           title: i.title,
-          body: (i.body ?? "").slice(0, 200),
+          body: i.body ?? "",
+          labels: i.labels.map((l) => l.name),
         }));
         res.writeHead(200);
         res.end(JSON.stringify(ideas));


### PR DESCRIPTION
## Changes

- **IssueCard component** — Shared expandable card used across all tabs. Click title to expand and see full issue body inline. Issue number links to GitHub. Supports custom action buttons via `actions` prop.

- **Sprint Backlog tab** — New tab (📦) showing issues planned for the active sprint. Includes "Remove" button to unassign issues from the sprint. Uses `/api/sprint-backlog` endpoint.

- **API improvements** — Backlog, Ideas, and new Sprint Backlog endpoints now return full issue body for detail display.

- **Refactored tabs** — BacklogTab, BlockedTab, DecisionsTab, IdeasTab all use `IssueCard` instead of inline markup. Reduced duplication.

## Files Changed

| File | What |
|------|------|
| `IssueCard.tsx` | New shared expandable card component |
| `SprintBacklogTab.tsx` | New Sprint Backlog tab |
| `Tabs.tsx` | Refactored to use IssueCard |
| `App.tsx` | Added Sprint Backlog tab |
| `TabList.css` | Expand/collapse styles |
| `ws-server.ts` | Added `/api/sprint-backlog`, body in backlog/ideas |