### PR TITLE
feat: add Refine button to Ideas tab

### DIFF
--- a/src/dashboard/frontend/src/components/ChatPanel.tsx
+++ b/src/dashboard/frontend/src/components/ChatPanel.tsx
@@ -8,12 +8,14 @@ export function ChatPanel() {
   const activeChatId = useDashboardStore((s) => s.activeChatId);
   const chatMessages = useDashboardStore((s) => s.chatMessages);
   const chatStreaming = useDashboardStore((s) => s.chatStreaming);
+  const chatPanelOpen = useDashboardStore((s) => s.chatPanelOpen);
   const send = useDashboardStore((s) => s.send);
 
-  const [isOpen, setIsOpen] = useState(false);
   const [input, setInput] = useState("");
   const [role, setRole] = useState("general");
   const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const setIsOpen = (open: boolean) => useDashboardStore.setState({ chatPanelOpen: open });
 
   const activeMessages = activeChatId ? chatMessages[activeChatId] ?? [] : [];
   const streaming = activeChatId ? chatStreaming[activeChatId] : undefined;
@@ -48,11 +50,11 @@ export function ChatPanel() {
 
   return (
     <>
-      <button className="chat-toggle" onClick={() => setIsOpen(!isOpen)}>
-        💬 {isOpen ? "Close" : "Chat"}
+      <button className="chat-toggle" onClick={() => setIsOpen(!chatPanelOpen)}>
+        💬 {chatPanelOpen ? "Close" : "Chat"}
       </button>
 
-      {isOpen && (
+      {chatPanelOpen && (
         <div className="chat-panel">
           <div className="chat-header">
             <span>💬 Chat</span>
@@ -74,6 +76,7 @@ export function ChatPanel() {
                 onChange={(e) => setRole(e.target.value)}
               >
                 <option value="general">General</option>
+                <option value="refiner">Refiner</option>
                 <option value="code-review">Code Review</option>
                 <option value="planner">Planner</option>
                 <option value="challenger">Challenger</option>

--- a/src/dashboard/frontend/src/components/Tabs.tsx
+++ b/src/dashboard/frontend/src/components/Tabs.tsx
@@ -213,6 +213,7 @@ export function DecisionsTab() {
 export function IdeasTab() {
   const [items, setItems] = useState<GhIssueItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const send = useDashboardStore((s) => s.send);
 
   const fetchItems = () => {
     setLoading(true);
@@ -221,6 +222,11 @@ export function IdeasTab() {
       .then((d) => setItems(Array.isArray(d) ? d : []))
       .catch(() => setItems([]))
       .finally(() => setLoading(false));
+  };
+
+  const startRefine = () => {
+    send({ type: "chat:create", role: "refiner" });
+    useDashboardStore.setState({ chatPanelOpen: true });
   };
 
   useEffect(() => { fetchItems(); }, []);
@@ -236,7 +242,18 @@ export function IdeasTab() {
       </div>
       <ul className="tab-list">
         {items.map((item) => (
-          <IssueCard key={item.number} item={item} />
+          <IssueCard
+            key={item.number}
+            item={item}
+            actions={
+              <button
+                className="btn btn-small btn-primary"
+                onClick={() => startRefine()}
+              >
+                🔬 Refine
+              </button>
+            }
+          />
         ))}
       </ul>
     </div>

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -35,6 +35,7 @@ export interface DashboardStore {
   activeChatId: string | null;
   chatMessages: Record<string, ChatMessage[]>;
   chatStreaming: Record<string, string>;
+  chatPanelOpen: boolean;
 
   // Execution mode
   executionMode: "autonomous" | "hitl";
@@ -449,6 +450,7 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
   activeChatId: null,
   chatMessages: {},
   chatStreaming: {},
+  chatPanelOpen: false,
   executionMode: "autonomous",
   sprintLimit: 0,
   backlogPending: new Set<number>(),


### PR DESCRIPTION
## Changes

- **🔬 Refine button** on each idea card in Ideas tab
- Clicking creates an ACP chat session with `refiner` role (no initial prompt)
- Chat panel opens automatically to show the new session
- `chatPanelOpen` moved from local ChatPanel state to zustand store (enables opening from any component)
- Added `refiner` to chat panel role selector dropdown

## Files Changed
| File | What |
|------|------|
| `Tabs.tsx` | Added Refine button + `startRefine()` to IdeasTab |
| `ChatPanel.tsx` | Uses store-driven `chatPanelOpen`, added refiner role |
| `store.ts` | Added `chatPanelOpen: boolean` to store interface + default |