### PR TITLE
feat: replace chat bubble with side panel layout

### DIFF
--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import { Header } from "./components/Header";
 import { SprintTab } from "./components/SprintTab";
 import { SprintBacklogTab } from "./components/SprintBacklogTab";
 import { BacklogTab, BlockedTab, DecisionsTab, IdeasTab } from "./components/Tabs";
-import { ChatPanel } from "./components/ChatPanel";
+import { SidePanel } from "./components/SidePanel";
 import "./index.css";
 
 type Tab = "sprint" | "sprint-backlog" | "backlog" | "blocked" | "decisions" | "ideas";
@@ -20,6 +20,7 @@ const TABS: { id: Tab; label: string; icon: string }[] = [
 
 export default function App() {
   const connect = useDashboardStore((s) => s.connect);
+  const chatPanelOpen = useDashboardStore((s) => s.chatPanelOpen);
   const [activeTab, setActiveTab] = useState<Tab>("sprint");
 
   useEffect(() => {
@@ -40,13 +41,21 @@ export default function App() {
           </button>
         ))}
       </nav>
-      {activeTab === "sprint" && <SprintTab />}
-      {activeTab === "sprint-backlog" && <SprintBacklogTab />}
-      {activeTab === "backlog" && <BacklogTab />}
-      {activeTab === "blocked" && <BlockedTab />}
-      {activeTab === "decisions" && <DecisionsTab />}
-      {activeTab === "ideas" && <IdeasTab />}
-      <ChatPanel />
+      <div className="app-layout">
+        <div className="app-main">
+          {activeTab === "sprint" && <SprintTab />}
+          {activeTab === "sprint-backlog" && <SprintBacklogTab />}
+          {activeTab === "backlog" && <BacklogTab />}
+          {activeTab === "blocked" && <BlockedTab />}
+          {activeTab === "decisions" && <DecisionsTab />}
+          {activeTab === "ideas" && <IdeasTab />}
+        </div>
+        {chatPanelOpen && (
+          <div className="app-side">
+            <SidePanel />
+          </div>
+        )}
+      </div>
     </>
   );
 }

--- a/src/dashboard/frontend/src/components/SidePanel.css
+++ b/src/dashboard/frontend/src/components/SidePanel.css
@@ -1,0 +1,102 @@
+.side-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg-panel);
+  border-left: 1px solid var(--border);
+}
+
+.side-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.side-panel-title {
+  font-weight: 600;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+.side-panel-tabs {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+  margin-right: 8px;
+}
+
+.side-panel-tab {
+  background: var(--bg-hover);
+  border: none;
+  color: var(--text-dim);
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  cursor: pointer;
+}
+.side-panel-tab:hover { color: var(--text); }
+.side-panel-tab-active { background: var(--accent); color: #fff; }
+
+.side-panel-close {
+  margin-left: auto;
+  font-size: 14px;
+}
+
+.side-panel-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.side-panel-empty {
+  color: var(--text-dim);
+  font-size: 13px;
+  text-align: center;
+  padding: 40px 20px;
+}
+
+.side-panel-input-row {
+  display: flex;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.side-panel-input {
+  flex: 1;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 13px;
+  font-family: var(--font);
+  outline: none;
+}
+.side-panel-input:focus { border-color: var(--accent); }
+
+/* Two-pane layout */
+.app-layout {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.app-main {
+  flex: 1;
+  overflow-y: auto;
+  min-width: 0;
+}
+
+.app-side {
+  width: 420px;
+  flex-shrink: 0;
+  overflow: hidden;
+}

--- a/src/dashboard/frontend/src/components/SidePanel.tsx
+++ b/src/dashboard/frontend/src/components/SidePanel.tsx
@@ -1,0 +1,103 @@
+import { useState, useRef, useEffect } from "react";
+import { useDashboardStore } from "../store";
+import { Markdown } from "./Markdown";
+import "./SidePanel.css";
+
+export function SidePanel() {
+  const chatSessions = useDashboardStore((s) => s.chatSessions);
+  const activeChatId = useDashboardStore((s) => s.activeChatId);
+  const chatMessages = useDashboardStore((s) => s.chatMessages);
+  const chatStreaming = useDashboardStore((s) => s.chatStreaming);
+  const send = useDashboardStore((s) => s.send);
+
+  const [input, setInput] = useState("");
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const activeMessages = activeChatId ? chatMessages[activeChatId] ?? [] : [];
+  const streaming = activeChatId ? chatStreaming[activeChatId] : undefined;
+  const activeSession = chatSessions.find((s) => s.id === activeChatId);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [activeMessages, streaming]);
+
+  const handleClose = () => {
+    if (activeChatId) {
+      send({ type: "chat:close", sessionId: activeChatId });
+    }
+    useDashboardStore.setState({ chatPanelOpen: false, activeChatId: null });
+  };
+
+  const handleSend = () => {
+    if (!input.trim() || !activeChatId) return;
+    send({ type: "chat:send", sessionId: activeChatId, message: input.trim() });
+    const store = useDashboardStore.getState();
+    const msgs = store.chatMessages[activeChatId] ?? [];
+    useDashboardStore.setState({
+      chatMessages: {
+        ...store.chatMessages,
+        [activeChatId]: [...msgs, { role: "user", content: input.trim() }],
+      },
+    });
+    setInput("");
+  };
+
+  return (
+    <div className="side-panel">
+      <div className="side-panel-header">
+        <span className="side-panel-title">
+          🔬 {activeSession?.role ?? "Session"}
+        </span>
+        {chatSessions.length > 1 && (
+          <div className="side-panel-tabs">
+            {chatSessions.map((s) => (
+              <button
+                key={s.id}
+                className={`side-panel-tab ${s.id === activeChatId ? "side-panel-tab-active" : ""}`}
+                onClick={() => useDashboardStore.setState({ activeChatId: s.id })}
+              >
+                {s.role}
+              </button>
+            ))}
+          </div>
+        )}
+        <button className="btn btn-small side-panel-close" onClick={handleClose}>✕</button>
+      </div>
+
+      <div className="side-panel-messages">
+        {activeMessages.length === 0 && !streaming && (
+          <div className="side-panel-empty">
+            Session ready. Send a message to start.
+          </div>
+        )}
+        {activeMessages.map((m, i) => (
+          <div key={i} className={`chat-msg chat-${m.role}`}>
+            <span className="chat-role">{m.role}</span>
+            <div className="chat-content"><Markdown text={m.content} /></div>
+          </div>
+        ))}
+        {streaming && (
+          <div className="chat-msg chat-assistant">
+            <span className="chat-role">assistant</span>
+            <div className="chat-content chat-streaming">{streaming}▌</div>
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      <div className="side-panel-input-row">
+        <input
+          className="side-panel-input"
+          placeholder="Ask something..."
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && !e.shiftKey && handleSend()}
+          autoFocus
+        />
+        <button className="btn btn-primary btn-small" onClick={handleSend}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Changes

Replaces the floating chat bubble with a proper two-pane layout.

**Before:** Floating `ChatPanel` bubble at bottom-right (removed)
**After:** `SidePanel` slides in from the right when triggered, creating a split view

### How it works
- Click **🔬 Refine** on any idea → creates ACP session with `refiner` role → side panel opens
- Two-pane layout: main content (left) + side panel (right, 420px)
- Side panel shows session messages, streaming response, and input
- **✕ Close** button closes the ACP session and hides the panel
- Multiple sessions supported via tabs in the header

### Files
| File | What |
|------|------|
| `SidePanel.tsx` | New side panel component |
| `SidePanel.css` | Styles + two-pane layout classes |
| `App.tsx` | Two-pane layout, removed ChatPanel |