### PR TITLE
feat: side panel role header with status indicator

### DIFF
--- a/src/dashboard/frontend/src/components/SidePanel.css
+++ b/src/dashboard/frontend/src/components/SidePanel.css
@@ -45,6 +45,29 @@
   font-size: 14px;
 }
 
+.side-panel-status {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 10px;
+}
+.side-panel-status.loading {
+  color: var(--yellow);
+  background: rgba(210, 153, 34, 0.15);
+}
+.side-panel-status.connected {
+  color: var(--green);
+  background: rgba(63, 185, 80, 0.15);
+}
+
+.side-panel-model {
+  font-size: 10px;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  padding: 2px 6px;
+  background: var(--bg);
+  border-radius: 4px;
+}
+
 .side-panel-messages {
   flex: 1;
   overflow-y: auto;

--- a/src/dashboard/frontend/src/components/SidePanel.tsx
+++ b/src/dashboard/frontend/src/components/SidePanel.tsx
@@ -3,11 +3,21 @@ import { useDashboardStore } from "../store";
 import { Markdown } from "./Markdown";
 import "./SidePanel.css";
 
+const ROLE_META: Record<string, { icon: string; label: string }> = {
+  refiner:   { icon: "🔬", label: "Refiner" },
+  planner:   { icon: "📐", label: "Planner" },
+  reviewer:  { icon: "🔍", label: "Reviewer" },
+  researcher:{ icon: "🔎", label: "Researcher" },
+  general:   { icon: "💬", label: "General" },
+  challenger:{ icon: "⚔️", label: "Challenger" },
+};
+
 export function SidePanel() {
-  const chatSessions = useDashboardStore((s) => s.chatSessions);
   const activeChatId = useDashboardStore((s) => s.activeChatId);
+  const chatSessions = useDashboardStore((s) => s.chatSessions);
   const chatMessages = useDashboardStore((s) => s.chatMessages);
   const chatStreaming = useDashboardStore((s) => s.chatStreaming);
+  const sidePanelRole = useDashboardStore((s) => s.sidePanelRole);
   const send = useDashboardStore((s) => s.send);
 
   const [input, setInput] = useState("");
@@ -16,13 +26,17 @@ export function SidePanel() {
   const activeMessages = activeChatId ? chatMessages[activeChatId] ?? [] : [];
   const streaming = activeChatId ? chatStreaming[activeChatId] : undefined;
   const activeSession = chatSessions.find((s) => s.id === activeChatId);
+  const isLoading = !activeSession && activeChatId !== "__global__";
+
+  const role = activeSession?.role ?? sidePanelRole ?? "agent";
+  const meta = ROLE_META[role] ?? { icon: "🤖", label: role };
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [activeMessages, streaming]);
 
   const handleClose = () => {
-    if (activeChatId) {
+    if (activeChatId && activeChatId !== "__global__") {
       send({ type: "chat:close", sessionId: activeChatId });
     }
     useDashboardStore.setState({ chatPanelOpen: false, activeChatId: null });
@@ -46,28 +60,25 @@ export function SidePanel() {
     <div className="side-panel">
       <div className="side-panel-header">
         <span className="side-panel-title">
-          🔬 {activeSession?.role ?? "Session"}
+          {meta.icon} {meta.label}
         </span>
-        {chatSessions.length > 1 && (
-          <div className="side-panel-tabs">
-            {chatSessions.map((s) => (
-              <button
-                key={s.id}
-                className={`side-panel-tab ${s.id === activeChatId ? "side-panel-tab-active" : ""}`}
-                onClick={() => useDashboardStore.setState({ activeChatId: s.id })}
-              >
-                {s.role}
-              </button>
-            ))}
-          </div>
+        {isLoading && <span className="side-panel-status loading">Connecting…</span>}
+        {activeSession && <span className="side-panel-status connected">● Connected</span>}
+        {activeSession?.model && (
+          <span className="side-panel-model">{activeSession.model}</span>
         )}
         <button className="btn btn-small side-panel-close" onClick={handleClose}>✕</button>
       </div>
 
       <div className="side-panel-messages">
-        {activeMessages.length === 0 && !streaming && (
+        {activeMessages.length === 0 && !streaming && !isLoading && (
           <div className="side-panel-empty">
             Session ready. Send a message to start.
+          </div>
+        )}
+        {isLoading && activeMessages.length === 0 && (
+          <div className="side-panel-empty">
+            Loading {meta.label} agent…
           </div>
         )}
         {activeMessages.map((m, i) => (

--- a/src/dashboard/frontend/src/components/Tabs.tsx
+++ b/src/dashboard/frontend/src/components/Tabs.tsx
@@ -226,7 +226,7 @@ export function IdeasTab() {
 
   const startRefine = () => {
     send({ type: "chat:create", role: "refiner" });
-    useDashboardStore.setState({ chatPanelOpen: true });
+    useDashboardStore.setState({ chatPanelOpen: true, sidePanelRole: "refiner" });
   };
 
   useEffect(() => { fetchItems(); }, []);

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -30,12 +30,13 @@ export interface DashboardStore {
   viewingSessionId: string | null;
   sessionOutput: Map<string, string>;
 
-  // Chat
+  // Chat / Side panel
   chatSessions: ChatSession[];
   activeChatId: string | null;
   chatMessages: Record<string, ChatMessage[]>;
   chatStreaming: Record<string, string>;
   chatPanelOpen: boolean;
+  sidePanelRole: string | null;
 
   // Execution mode
   executionMode: "autonomous" | "hitl";
@@ -454,6 +455,7 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
   chatMessages: {},
   chatStreaming: {},
   chatPanelOpen: false,
+  sidePanelRole: null,
   executionMode: "autonomous",
   sprintLimit: 0,
   backlogPending: new Set<number>(),


### PR DESCRIPTION
## Changes

Replaces the session tab switcher with a clear role/status header.

**Header shows:**
- Role icon + label: 🔬 Refiner, 📐 Planner, 🔍 Reviewer, etc.
- Status badge: yellow "Connecting…" → green "● Connected"
- Model badge (mono font): e.g. `claude-sonnet-4`
- ✕ Close button

**Loading state:** Shows "Loading Refiner agent…" in the message area while connecting.

Uses `sidePanelRole` in store so the correct role shows immediately (before the server responds with `chat:created`).