### PR TITLE
fix: side panel send and textarea input

### DIFF
--- a/src/dashboard/frontend/src/components/SidePanel.css
+++ b/src/dashboard/frontend/src/components/SidePanel.css
@@ -102,6 +102,8 @@
   font-size: 13px;
   font-family: var(--font);
   outline: none;
+  resize: none;
+  line-height: 1.5;
 }
 .side-panel-input:focus { border-color: var(--accent); }
 

--- a/src/dashboard/frontend/src/components/SidePanel.tsx
+++ b/src/dashboard/frontend/src/components/SidePanel.tsx
@@ -43,17 +43,26 @@ export function SidePanel() {
   };
 
   const handleSend = () => {
-    if (!input.trim() || !activeChatId) return;
-    send({ type: "chat:send", sessionId: activeChatId, message: input.trim() });
+    if (!input.trim()) return;
+    const chatId = useDashboardStore.getState().activeChatId;
+    if (!chatId || chatId === "__global__") return;
+    send({ type: "chat:send", sessionId: chatId, message: input.trim() });
     const store = useDashboardStore.getState();
-    const msgs = store.chatMessages[activeChatId] ?? [];
+    const msgs = store.chatMessages[chatId] ?? [];
     useDashboardStore.setState({
       chatMessages: {
         ...store.chatMessages,
-        [activeChatId]: [...msgs, { role: "user", content: input.trim() }],
+        [chatId]: [...msgs, { role: "user", content: input.trim() }],
       },
     });
     setInput("");
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
   };
 
   return (
@@ -97,12 +106,13 @@ export function SidePanel() {
       </div>
 
       <div className="side-panel-input-row">
-        <input
+        <textarea
           className="side-panel-input"
-          placeholder="Ask something..."
+          placeholder="Ask something… (Enter to send, Shift+Enter for new line)"
           value={input}
           onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && !e.shiftKey && handleSend()}
+          onKeyDown={handleKeyDown}
+          rows={2}
           autoFocus
         />
         <button className="btn btn-primary btn-small" onClick={handleSend}>


### PR DESCRIPTION
Fixes send button not working + adds multiline input.

- **Send fix**: `handleSend` was reading stale `activeChatId` from React closure — now reads fresh from `useDashboardStore.getState()`
- **Textarea**: Replaced `<input>` with `<textarea>` — Enter sends, Shift+Enter adds line break
- **Guard**: Skips send for `__global__` error-only sessions