### PR TITLE
fix: chat session ID mismatch — Send button now works

### DIFF
--- a/src/dashboard/frontend/src/components/SidePanel.tsx
+++ b/src/dashboard/frontend/src/components/SidePanel.tsx
@@ -43,16 +43,17 @@ export function SidePanel() {
   };
 
   const handleSend = () => {
-    if (!input.trim()) return;
+    const trimmed = input.trim();
+    if (!trimmed) return;
     const chatId = useDashboardStore.getState().activeChatId;
     if (!chatId || chatId === "__global__") return;
-    send({ type: "chat:send", sessionId: chatId, message: input.trim() });
+    send({ type: "chat:send", sessionId: chatId, message: trimmed });
     const store = useDashboardStore.getState();
     const msgs = store.chatMessages[chatId] ?? [];
     useDashboardStore.setState({
       chatMessages: {
         ...store.chatMessages,
-        [chatId]: [...msgs, { role: "user", content: input.trim() }],
+        [chatId]: [...msgs, { role: "user", content: trimmed }],
       },
     });
     setInput("");

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -183,8 +183,9 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
     }
 
     case "chat:created": {
-      const p = msg.payload as ChatSession | undefined;
-      if (p) {
+      const raw = msg.payload as { sessionId: string; role: string; model?: string } | undefined;
+      if (raw) {
+        const p: ChatSession = { id: raw.sessionId, role: raw.role, model: raw.model };
         set((prev) => ({
           ...prev,
           chatSessions: [...prev.chatSessions, p],


### PR DESCRIPTION
## Root Cause

Server sends `chat:created` with `{ sessionId, role, model }` but the store handler cast it as `ChatSession` which has `{ id, role, model }`. Since `id` was never set, `activeChatId` was always `undefined`, so `handleSend` returned early every time.

## Fix

Map `sessionId` → `id` when handling `chat:created`:
```typescript
const raw = msg.payload as { sessionId: string; role: string; model?: string };
const p: ChatSession = { id: raw.sessionId, role: raw.role, model: raw.model };
```

## Verification

Tested end-to-end with Playwright:
1. ✅ Click Refine → session created, status shows "● Connected"
2. ✅ Type message → user message appears in panel
3. ✅ Click Send → assistant response streams back