### PR TITLE
fix: don't auto-prime chat sessions

### DIFF
--- a/src/dashboard/chat-manager.ts
+++ b/src/dashboard/chat-manager.ts
@@ -1,12 +1,10 @@
 /**
  * Chat Manager — manages interactive ACP chat sessions for the web dashboard.
  *
- * Each chat session gets its own ACP session pre-primed with a role-specific
- * system prompt. Responses stream via callbacks.
+ * Each chat session gets its own ACP session. The agent loads role context
+ * from .aiscrum/roles/ automatically via copilot-instructions.md.
  */
 
-import * as fs from "node:fs";
-import * as path from "node:path";
 import { AcpClient, ACP_MODES, type SessionInfo } from "../acp/client.js";
 import type { PermissionConfig } from "../acp/permissions.js";
 import { logger } from "../logger.js";
@@ -40,7 +38,6 @@ export interface ChatManagerOptions {
 export class ChatManager {
   private client: AcpClient | null = null;
   private sessions = new Map<string, ChatSession>();
-  private primingPromises = new Map<string, Promise<void>>();
   private readonly options: ChatManagerOptions;
   private connected = false;
 
@@ -98,18 +95,7 @@ export class ChatManager {
     };
 
     this.sessions.set(chatId, session);
-
-    // Prime with role system prompt in background — don't block session creation
-    const systemPrompt = this.buildSystemPrompt(role);
-    log.info({ chatId, role, acpSessionId: sessionInfo.sessionId }, "Chat session created, priming in background");
-
-    const primingPromise = client.sendPrompt(sessionInfo.sessionId, systemPrompt, 120_000)
-      .then(() => { this.primingPromises.delete(chatId); })
-      .catch((err) => {
-        log.error({ chatId, err }, "Failed to prime chat session with system prompt");
-        this.primingPromises.delete(chatId);
-      });
-    this.primingPromises.set(chatId, primingPromise);
+    log.info({ chatId, role, acpSessionId: sessionInfo.sessionId }, "Chat session created");
 
     return session;
   }
@@ -118,13 +104,6 @@ export class ChatManager {
   async sendMessage(chatId: string, message: string): Promise<string> {
     const session = this.sessions.get(chatId);
     if (!session) throw new Error(`Chat session ${chatId} not found`);
-
-    // Wait for system prompt priming to finish before sending user message
-    const priming = this.primingPromises.get(chatId);
-    if (priming) {
-      log.info({ chatId }, "Waiting for system prompt priming to complete");
-      await priming;
-    }
 
     const client = await this.ensureClient();
 
@@ -185,43 +164,5 @@ export class ChatManager {
       this.connected = false;
     }
     log.info("Chat manager shut down");
-  }
-
-  private buildSystemPrompt(role: ChatRole): string {
-    const roleDir = path.join(this.options.projectPath, ".aiscrum", "roles", role);
-    const roleContext = this.loadRoleContext(roleDir);
-
-    if (!roleContext) {
-      return `You are a ${role} assistant. Respond helpfully and concisely.`;
-    }
-
-    return `${roleContext}\n\nYou are in an interactive chat session. Respond helpfully and concisely.`;
-  }
-
-  /** Recursively load all .md files from a role directory. */
-  private loadRoleContext(dir: string): string | null {
-    try {
-      if (!fs.existsSync(dir)) return null;
-
-      const parts: string[] = [];
-      const walk = (d: string) => {
-        for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
-          const full = path.join(d, entry.name);
-          if (entry.isDirectory()) {
-            if (entry.name === "log") return;
-            walk(full);
-          } else if (entry.name.endsWith(".md")) {
-            parts.push(fs.readFileSync(full, "utf-8"));
-          }
-        }
-      };
-      walk(dir);
-
-      if (parts.length === 0) return null;
-      log.info({ dir, fileCount: parts.length }, "Loaded role context");
-      return parts.join("\n\n---\n\n");
-    } catch {
-      return null;
-    }
   }
 }

--- a/tests/dashboard/chat-manager.test.ts
+++ b/tests/dashboard/chat-manager.test.ts
@@ -29,34 +29,14 @@ vi.mock("../../src/acp/client.js", () => {
   };
 });
 
-// Mock fs to avoid real file reads
-vi.mock("node:fs", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:fs")>();
-  return {
-    ...actual,
-    existsSync: vi.fn().mockReturnValue(true),
-    readFileSync: vi.fn().mockReturnValue("# Agent Instructions\nDefault role context for testing"),
-    readdirSync: vi.fn().mockReturnValue([
-      { name: "copilot-instructions.md", isDirectory: () => false, isFile: () => true },
-    ]),
-  };
-});
-
 import { ChatManager, type ChatRole } from "../../src/dashboard/chat-manager.js";
 import { AcpClient } from "../../src/acp/client.js";
-import * as fs from "node:fs";
 
 describe("ChatManager", () => {
   let manager: ChatManager;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default: role folder exists with a copilot-instructions.md
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-    vi.mocked(fs.readdirSync).mockReturnValue([
-      { name: "copilot-instructions.md", isDirectory: () => false, isFile: () => true } as unknown as fs.Dirent,
-    ]);
-    vi.mocked(fs.readFileSync).mockReturnValue("# Agent Instructions\nDefault role context for testing");
     manager = new ChatManager({ projectPath: "/tmp/test-project" });
   });
 
@@ -92,74 +72,10 @@ describe("ChatManager", () => {
       );
     });
 
-    it("sends a role-specific system prompt from .aiscrum/roles/", async () => {
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readdirSync).mockReturnValue([
-        { name: "copilot-instructions.md", isDirectory: () => false, isFile: () => true } as unknown as fs.Dirent,
-      ]);
-      vi.mocked(fs.readFileSync).mockReturnValue("# Reviewer Agent\nCode Review Agent instructions");
-
+    it("does not send any prompt on creation", async () => {
       await manager.createSession("reviewer");
 
-      const sendPromptCall = vi.mocked(AcpClient.prototype.sendPrompt).mock.calls[0];
-      expect(sendPromptCall[0]).toBe("acp-session-1");
-      expect(sendPromptCall[1]).toContain("Code Review Agent");
-      expect(sendPromptCall[1]).toContain("Respond helpfully and concisely");
-    });
-
-    it("loads all .md files from role directory", async () => {
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readdirSync).mockReturnValue([
-        { name: "copilot-instructions.md", isDirectory: () => false, isFile: () => true } as unknown as fs.Dirent,
-      ]);
-      vi.mocked(fs.readFileSync).mockReturnValue("# Refiner Agent Instructions\nCustom refiner context");
-
-      await manager.createSession("refiner");
-
-      const prompt = vi.mocked(AcpClient.prototype.sendPrompt).mock.calls[0][1] as string;
-      expect(prompt).toContain("# Refiner Agent Instructions");
-      expect(prompt).toContain("Custom refiner context");
-    });
-
-    it("falls back to generic prompt when role folder does not exist", async () => {
-      vi.mocked(fs.existsSync).mockReturnValue(false);
-
-      const session = await manager.createSession("planner");
-      expect(session.role).toBe("planner");
-    });
-
-    it("excludes log/ directory from role context loading", async () => {
-      const callTracker: string[] = [];
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readdirSync).mockImplementation((dir) => {
-        const d = String(dir);
-        if (d.endsWith("refiner")) {
-          return [
-            { name: "copilot-instructions.md", isDirectory: () => false, isFile: () => true },
-            { name: "log", isDirectory: () => true, isFile: () => false },
-            { name: "skills", isDirectory: () => true, isFile: () => false },
-          ] as unknown as fs.Dirent[];
-        }
-        if (d.endsWith("skills")) {
-          return [
-            { name: "SKILL.md", isDirectory: () => false, isFile: () => true },
-          ] as unknown as fs.Dirent[];
-        }
-        // log/ should never be walked
-        if (d.includes("log")) {
-          callTracker.push(d);
-          return [] as unknown as fs.Dirent[];
-        }
-        return [] as unknown as fs.Dirent[];
-      });
-      vi.mocked(fs.readFileSync).mockReturnValue("# Instructions");
-
-      await manager.createSession("refiner");
-
-      // The log/ directory should NOT have been walked
-      expect(callTracker.filter((p) => p.includes("log"))).toHaveLength(0);
-      // skills/ should have been walked (readdirSync called for root + skills)
-      expect(fs.readFileSync).toHaveBeenCalled();
+      expect(AcpClient.prototype.sendPrompt).not.toHaveBeenCalled();
     });
 
     it("reuses the ACP client on second createSession call", async () => {


### PR DESCRIPTION
Session was sending the role system prompt as a user message on creation, causing the agent to immediately start working (refining all 5 ideas) without waiting for user input.

**Fix:** Removed all priming logic (`buildSystemPrompt`, `loadRoleContext`, `primingPromises`). The agent picks up role context from `.aiscrum/roles/` via `copilot-instructions.md` automatically. Session now opens clean, waiting for user's first message.

**Removed:** ~140 lines of priming code + 3 related tests.