### PR TITLE
feat: resizable side panel, agent labels, auto-send context

### DIFF
--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useDashboardStore } from "./store";
 import { Header } from "./components/Header";
 import { SprintTab } from "./components/SprintTab";
@@ -18,14 +18,42 @@ const TABS: { id: Tab; label: string; icon: string }[] = [
   { id: "ideas", label: "Ideas", icon: "💡" },
 ];
 
+const MIN_SIDE_WIDTH = 320;
+const MAX_SIDE_WIDTH = 800;
+const DEFAULT_SIDE_WIDTH = 420;
+
 export default function App() {
   const connect = useDashboardStore((s) => s.connect);
   const chatPanelOpen = useDashboardStore((s) => s.chatPanelOpen);
   const [activeTab, setActiveTab] = useState<Tab>("sprint");
+  const [sideWidth, setSideWidth] = useState(DEFAULT_SIDE_WIDTH);
+  const dragging = useRef(false);
 
   useEffect(() => {
     connect();
   }, [connect]);
+
+  const onMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    dragging.current = true;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!dragging.current) return;
+      const newWidth = window.innerWidth - ev.clientX;
+      setSideWidth(Math.max(MIN_SIDE_WIDTH, Math.min(MAX_SIDE_WIDTH, newWidth)));
+    };
+    const onMouseUp = () => {
+      dragging.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+    };
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  }, []);
 
   return (
     <>
@@ -51,9 +79,12 @@ export default function App() {
           {activeTab === "ideas" && <IdeasTab />}
         </div>
         {chatPanelOpen && (
-          <div className="app-side">
-            <SidePanel />
-          </div>
+          <>
+            <div className="app-resize-handle" onMouseDown={onMouseDown} />
+            <div className="app-side" style={{ width: sideWidth }}>
+              <SidePanel />
+            </div>
+          </>
         )}
       </div>
     </>

--- a/src/dashboard/frontend/src/components/SidePanel.css
+++ b/src/dashboard/frontend/src/components/SidePanel.css
@@ -121,7 +121,21 @@
 }
 
 .app-side {
-  width: 420px;
   flex-shrink: 0;
   overflow: hidden;
+}
+
+/* Resize handle between main and side panel */
+.app-resize-handle {
+  width: 5px;
+  cursor: col-resize;
+  background: transparent;
+  flex-shrink: 0;
+  position: relative;
+  z-index: 10;
+  transition: background 0.15s;
+}
+.app-resize-handle:hover,
+.app-resize-handle:active {
+  background: var(--accent);
 }

--- a/src/dashboard/frontend/src/components/SidePanel.tsx
+++ b/src/dashboard/frontend/src/components/SidePanel.tsx
@@ -4,12 +4,12 @@ import { Markdown } from "./Markdown";
 import "./SidePanel.css";
 
 const ROLE_META: Record<string, { icon: string; label: string }> = {
-  refiner:   { icon: "🔬", label: "Refiner" },
-  planner:   { icon: "📐", label: "Planner" },
-  reviewer:  { icon: "🔍", label: "Reviewer" },
-  researcher:{ icon: "🔎", label: "Researcher" },
-  general:   { icon: "💬", label: "General" },
-  challenger:{ icon: "⚔️", label: "Challenger" },
+  refiner:   { icon: "🔬", label: "Refinement Agent" },
+  planner:   { icon: "📐", label: "Planning Agent" },
+  reviewer:  { icon: "🔍", label: "Review Agent" },
+  researcher:{ icon: "🔎", label: "Research Agent" },
+  general:   { icon: "💬", label: "General Agent" },
+  challenger:{ icon: "⚔️", label: "Challenger Agent" },
 };
 
 export function SidePanel() {
@@ -93,13 +93,15 @@ export function SidePanel() {
         )}
         {activeMessages.map((m, i) => (
           <div key={i} className={`chat-msg chat-${m.role}`}>
-            <span className="chat-role">{m.role}</span>
+            <span className="chat-role">
+              {m.role === "assistant" ? meta.label : m.role === "user" ? "You" : m.role}
+            </span>
             <div className="chat-content"><Markdown text={m.content} /></div>
           </div>
         ))}
         {streaming && (
           <div className="chat-msg chat-assistant">
-            <span className="chat-role">assistant</span>
+            <span className="chat-role">{meta.label}</span>
             <div className="chat-content chat-streaming">{streaming}▌</div>
           </div>
         )}

--- a/src/dashboard/frontend/src/components/Tabs.tsx
+++ b/src/dashboard/frontend/src/components/Tabs.tsx
@@ -224,9 +224,17 @@ export function IdeasTab() {
       .finally(() => setLoading(false));
   };
 
-  const startRefine = () => {
+  const startRefine = (item: GhIssueItem) => {
+    const contextMessage = [
+      `I'd like you to help me refine this idea. Please review the issue context below and ask clarifying questions to help define clear, testable acceptance criteria. Don't make any changes yet — just interview me to understand what I need.`,
+      ``,
+      `---`,
+      `**Issue #${item.number}: ${item.title}**`,
+      ``,
+      item.body || '_No description provided._',
+    ].join("\n");
+    useDashboardStore.setState({ chatPanelOpen: true, sidePanelRole: "refiner", pendingChatMessage: contextMessage });
     send({ type: "chat:create", role: "refiner" });
-    useDashboardStore.setState({ chatPanelOpen: true, sidePanelRole: "refiner" });
   };
 
   useEffect(() => { fetchItems(); }, []);
@@ -248,7 +256,7 @@ export function IdeasTab() {
             actions={
               <button
                 className="btn btn-small btn-primary"
-                onClick={() => startRefine()}
+                onClick={() => startRefine(item)}
               >
                 🔬 Refine
               </button>

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -37,6 +37,7 @@ export interface DashboardStore {
   chatStreaming: Record<string, string>;
   chatPanelOpen: boolean;
   sidePanelRole: string | null;
+  pendingChatMessage: string | null;
 
   // Execution mode
   executionMode: "autonomous" | "hitl";
@@ -186,12 +187,22 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
       const raw = msg.payload as { sessionId: string; role: string; model?: string } | undefined;
       if (raw) {
         const p: ChatSession = { id: raw.sessionId, role: raw.role, model: raw.model };
+        const pending = get().pendingChatMessage;
+        const initialMessages: ChatMessage[] = pending
+          ? [{ role: "user", content: pending }]
+          : [];
         set((prev) => ({
           ...prev,
           chatSessions: [...prev.chatSessions, p],
           activeChatId: p.id,
-          chatMessages: { ...prev.chatMessages, [p.id]: [] },
+          chatMessages: { ...prev.chatMessages, [p.id]: initialMessages },
+          pendingChatMessage: null,
         }));
+        // Auto-send the pending message to the agent
+        if (pending) {
+          const sendFn = get().send;
+          sendFn({ type: "chat:send", sessionId: p.id, message: pending });
+        }
       }
       break;
     }
@@ -457,6 +468,7 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
   chatStreaming: {},
   chatPanelOpen: false,
   sidePanelRole: null,
+  pendingChatMessage: null,
   executionMode: "autonomous",
   sprintLimit: 0,
   backlogPending: new Set<number>(),


### PR DESCRIPTION
**Resizable side panel:** Drag handle between main content and side panel. Range 320px–800px.

**Agent labels:** Renamed all roles to full labels (Refinement Agent, Planning Agent, etc.). Messages show role label instead of 'assistant' and 'You' instead of 'user'.

**Auto-send issue context:** Clicking Refine on an idea auto-sends the issue title+body as the first message. Agent starts with reverse-interviewing — asking clarifying questions without making changes.