### PR TITLE
feat: persistent general agent with chat bubble

### DIFF
--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -25,6 +25,8 @@ const DEFAULT_SIDE_WIDTH = 420;
 export default function App() {
   const connect = useDashboardStore((s) => s.connect);
   const chatPanelOpen = useDashboardStore((s) => s.chatPanelOpen);
+  const generalChatId = useDashboardStore((s) => s.generalChatId);
+  const activeChatId = useDashboardStore((s) => s.activeChatId);
   const [activeTab, setActiveTab] = useState<Tab>("sprint");
   const [sideWidth, setSideWidth] = useState(DEFAULT_SIDE_WIDTH);
   const dragging = useRef(false);
@@ -32,6 +34,21 @@ export default function App() {
   useEffect(() => {
     connect();
   }, [connect]);
+
+  const toggleGeneralChat = useCallback(() => {
+    const isShowingGeneral = chatPanelOpen && activeChatId === generalChatId;
+    if (isShowingGeneral) {
+      // Hide panel (keep session alive)
+      useDashboardStore.setState({ chatPanelOpen: false, activeChatId: null });
+    } else if (generalChatId) {
+      // Show/switch to general session
+      useDashboardStore.setState({
+        chatPanelOpen: true,
+        activeChatId: generalChatId,
+        sidePanelRole: "general",
+      });
+    }
+  }, [chatPanelOpen, activeChatId, generalChatId]);
 
   const onMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -87,6 +104,17 @@ export default function App() {
           </>
         )}
       </div>
+
+      {/* Floating chat bubble for persistent general agent */}
+      {generalChatId && (
+        <button
+          className={`chat-bubble${chatPanelOpen && activeChatId === generalChatId ? " chat-bubble-active" : ""}`}
+          onClick={toggleGeneralChat}
+          title="General Agent"
+        >
+          💬
+        </button>
+      )}
     </>
   );
 }

--- a/src/dashboard/frontend/src/components/SidePanel.css
+++ b/src/dashboard/frontend/src/components/SidePanel.css
@@ -139,3 +139,32 @@
 .app-resize-handle:active {
   background: var(--accent);
 }
+
+/* Floating chat bubble */
+.chat-bubble {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+.chat-bubble:hover {
+  transform: scale(1.1);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+}
+.chat-bubble-active {
+  background: var(--green);
+}
+}

--- a/src/dashboard/frontend/src/components/SidePanel.tsx
+++ b/src/dashboard/frontend/src/components/SidePanel.tsx
@@ -36,7 +36,9 @@ export function SidePanel() {
   }, [activeMessages, streaming]);
 
   const handleClose = () => {
-    if (activeChatId && activeChatId !== "__global__") {
+    const store = useDashboardStore.getState();
+    // Don't kill the persistent general session — just hide the panel
+    if (activeChatId && activeChatId !== "__global__" && activeChatId !== store.generalChatId) {
       send({ type: "chat:close", sessionId: activeChatId });
     }
     useDashboardStore.setState({ chatPanelOpen: false, activeChatId: null });

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -33,6 +33,7 @@ export interface DashboardStore {
   // Chat / Side panel
   chatSessions: ChatSession[];
   activeChatId: string | null;
+  generalChatId: string | null;
   chatMessages: Record<string, ChatMessage[]>;
   chatStreaming: Record<string, string>;
   chatPanelOpen: boolean;
@@ -77,6 +78,7 @@ export interface LogEntry {
 
 let ws: WebSocket | null = null;
 const pendingMessages: ClientMessage[] = [];
+let pendingGeneralCreate = false;
 
 // Sprint caches (survive navigation between sprints)
 const stateCache = new Map<number, { state: SprintState; issues: SprintIssue[] }>();
@@ -92,6 +94,11 @@ function createWebSocket(set: SetFn, get: GetFn): void {
     while (pendingMessages.length > 0) {
       const msg = pendingMessages.shift();
       if (msg) ws?.send(JSON.stringify(msg));
+    }
+    // Auto-create persistent general session if none exists
+    if (!get().generalChatId) {
+      pendingGeneralCreate = true;
+      ws?.send(JSON.stringify({ type: "chat:create", role: "general" }));
     }
   };
 
@@ -187,6 +194,19 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
       const raw = msg.payload as { sessionId: string; role: string; model?: string } | undefined;
       if (raw) {
         const p: ChatSession = { id: raw.sessionId, role: raw.role, model: raw.model };
+
+        // Background general session — store silently, don't open panel
+        if (pendingGeneralCreate && raw.role === "general") {
+          pendingGeneralCreate = false;
+          set((prev) => ({
+            ...prev,
+            chatSessions: [...prev.chatSessions, p],
+            generalChatId: p.id,
+            chatMessages: { ...prev.chatMessages, [p.id]: [] },
+          }));
+          break;
+        }
+
         const pending = get().pendingChatMessage;
         const initialMessages: ChatMessage[] = pending
           ? [{ role: "user", content: pending }]
@@ -464,6 +484,7 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
   sessionOutput: new Map(),
   chatSessions: [],
   activeChatId: null,
+  generalChatId: null,
   chatMessages: {},
   chatStreaming: {},
   chatPanelOpen: false,


### PR DESCRIPTION
Adds an always-on general ACP session with a floating chat bubble toggle.

**Behavior:**
- General session auto-creates on page load (background, no panel)
- 💬 bubble in bottom-right toggles the general session panel
- Closing the panel hides it — session stays alive, conversation persists
- Clicking bubble again reopens the same conversation
- Contextual sessions (Refine/Discuss) work independently alongside it
- Bubble turns green when showing the general session