### PR TITLE
feat: session tabs and Agents toggle in nav

### DIFF
--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -25,8 +25,7 @@ const DEFAULT_SIDE_WIDTH = 420;
 export default function App() {
   const connect = useDashboardStore((s) => s.connect);
   const chatPanelOpen = useDashboardStore((s) => s.chatPanelOpen);
-  const generalChatId = useDashboardStore((s) => s.generalChatId);
-  const activeChatId = useDashboardStore((s) => s.activeChatId);
+  const chatSessions = useDashboardStore((s) => s.chatSessions);
   const [activeTab, setActiveTab] = useState<Tab>("sprint");
   const [sideWidth, setSideWidth] = useState(DEFAULT_SIDE_WIDTH);
   const dragging = useRef(false);
@@ -35,20 +34,21 @@ export default function App() {
     connect();
   }, [connect]);
 
-  const toggleGeneralChat = useCallback(() => {
-    const isShowingGeneral = chatPanelOpen && activeChatId === generalChatId;
-    if (isShowingGeneral) {
-      // Hide panel (keep session alive)
-      useDashboardStore.setState({ chatPanelOpen: false, activeChatId: null });
-    } else if (generalChatId) {
-      // Show/switch to general session
+  const toggleAgentPanel = useCallback(() => {
+    if (chatPanelOpen) {
+      useDashboardStore.setState({ chatPanelOpen: false });
+    } else {
+      // Open panel — show last active session or fall back to general
+      const store = useDashboardStore.getState();
+      const target = store.activeChatId ?? store.generalChatId;
+      const session = store.chatSessions.find((s) => s.id === target);
       useDashboardStore.setState({
         chatPanelOpen: true,
-        activeChatId: generalChatId,
-        sidePanelRole: "general",
+        activeChatId: target,
+        sidePanelRole: session?.role ?? "general",
       });
     }
-  }, [chatPanelOpen, activeChatId, generalChatId]);
+  }, [chatPanelOpen]);
 
   const onMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -72,6 +72,8 @@ export default function App() {
     document.addEventListener("mouseup", onMouseUp);
   }, []);
 
+  const sessionCount = chatSessions.length;
+
   return (
     <>
       <Header />
@@ -85,6 +87,15 @@ export default function App() {
             {t.icon} {t.label}
           </button>
         ))}
+        <div className="tab-nav-spacer" />
+        <button
+          className={`tab-btn agent-toggle-btn ${chatPanelOpen ? "tab-active" : ""}`}
+          onClick={toggleAgentPanel}
+          title={chatPanelOpen ? "Hide Agent Panel" : "Show Agent Panel"}
+        >
+          🤖 Agents{sessionCount > 0 ? ` (${sessionCount})` : ""}
+          {chatPanelOpen ? " ◀" : " ▶"}
+        </button>
       </nav>
       <div className="app-layout">
         <div className="app-main">
@@ -104,17 +115,6 @@ export default function App() {
           </>
         )}
       </div>
-
-      {/* Floating chat bubble for persistent general agent */}
-      {generalChatId && (
-        <button
-          className={`chat-bubble${chatPanelOpen && activeChatId === generalChatId ? " chat-bubble-active" : ""}`}
-          onClick={toggleGeneralChat}
-          title="General Agent"
-        >
-          💬
-        </button>
-      )}
     </>
   );
 }

--- a/src/dashboard/frontend/src/components/SidePanel.css
+++ b/src/dashboard/frontend/src/components/SidePanel.css
@@ -40,9 +40,74 @@
 .side-panel-tab:hover { color: var(--text); }
 .side-panel-tab-active { background: var(--accent); color: #fff; }
 
+/* Session tabs in side panel */
+.session-tabs {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  flex-shrink: 0;
+  overflow-x: auto;
+}
+
+.session-tab {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 11px;
+  cursor: pointer;
+  white-space: nowrap;
+  color: var(--text-dim);
+  background: transparent;
+  transition: background 0.1s;
+}
+.session-tab:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.session-tab-active {
+  background: var(--accent);
+  color: #fff;
+}
+.session-tab-active:hover {
+  background: var(--accent);
+  color: #fff;
+}
+
+.session-tab-label {
+  pointer-events: none;
+}
+
+.session-tab-close {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 10px;
+  cursor: pointer;
+  padding: 0 2px;
+  opacity: 0.6;
+  line-height: 1;
+}
+.session-tab-close:hover {
+  opacity: 1;
+}
+
 .side-panel-close {
   margin-left: auto;
-  font-size: 14px;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+/* Agent toggle button in tab nav */
+.tab-nav-spacer {
+  flex: 1;
+}
+.agent-toggle-btn {
+  margin-left: auto;
 }
 
 .side-panel-status {
@@ -138,32 +203,4 @@
 .app-resize-handle:hover,
 .app-resize-handle:active {
   background: var(--accent);
-}
-
-/* Floating chat bubble */
-.chat-bubble {
-  position: fixed;
-  bottom: 24px;
-  right: 24px;
-  width: 52px;
-  height: 52px;
-  border-radius: 50%;
-  background: var(--accent);
-  color: #fff;
-  border: none;
-  font-size: 24px;
-  cursor: pointer;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 100;
-  transition: transform 0.15s, box-shadow 0.15s;
-}
-.chat-bubble:hover {
-  transform: scale(1.1);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
-}
-.chat-bubble-active {
-  background: var(--green);
 }

--- a/src/dashboard/frontend/src/components/SidePanel.tsx
+++ b/src/dashboard/frontend/src/components/SidePanel.tsx
@@ -15,6 +15,7 @@ const ROLE_META: Record<string, { icon: string; label: string }> = {
 export function SidePanel() {
   const activeChatId = useDashboardStore((s) => s.activeChatId);
   const chatSessions = useDashboardStore((s) => s.chatSessions);
+  const generalChatId = useDashboardStore((s) => s.generalChatId);
   const chatMessages = useDashboardStore((s) => s.chatMessages);
   const chatStreaming = useDashboardStore((s) => s.chatStreaming);
   const sidePanelRole = useDashboardStore((s) => s.sidePanelRole);
@@ -26,7 +27,7 @@ export function SidePanel() {
   const activeMessages = activeChatId ? chatMessages[activeChatId] ?? [] : [];
   const streaming = activeChatId ? chatStreaming[activeChatId] : undefined;
   const activeSession = chatSessions.find((s) => s.id === activeChatId);
-  const isLoading = !activeSession && activeChatId !== "__global__";
+  const isLoading = !activeSession && activeChatId !== "__global__" && activeChatId !== null;
 
   const role = activeSession?.role ?? sidePanelRole ?? "agent";
   const meta = ROLE_META[role] ?? { icon: "🤖", label: role };
@@ -35,13 +36,31 @@ export function SidePanel() {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [activeMessages, streaming]);
 
-  const handleClose = () => {
+  const handleClosePanel = () => {
+    useDashboardStore.setState({ chatPanelOpen: false });
+  };
+
+  const switchToSession = (sessionId: string) => {
+    const session = chatSessions.find((s) => s.id === sessionId);
+    useDashboardStore.setState({
+      activeChatId: sessionId,
+      sidePanelRole: session?.role ?? null,
+    });
+  };
+
+  const closeSession = (sessionId: string) => {
+    if (sessionId === generalChatId) return;
+    send({ type: "chat:close", sessionId });
     const store = useDashboardStore.getState();
-    // Don't kill the persistent general session — just hide the panel
-    if (activeChatId && activeChatId !== "__global__" && activeChatId !== store.generalChatId) {
-      send({ type: "chat:close", sessionId: activeChatId });
-    }
-    useDashboardStore.setState({ chatPanelOpen: false, activeChatId: null });
+    const remaining = store.chatSessions.filter((s) => s.id !== sessionId);
+    const nextActive = sessionId === activeChatId
+      ? (generalChatId ?? remaining[0]?.id ?? null)
+      : activeChatId;
+    useDashboardStore.setState({
+      chatSessions: remaining,
+      activeChatId: nextActive,
+      sidePanelRole: remaining.find((s) => s.id === nextActive)?.role ?? null,
+    });
   };
 
   const handleSend = () => {
@@ -70,6 +89,33 @@ export function SidePanel() {
 
   return (
     <div className="side-panel">
+      {/* Session tabs */}
+      <div className="session-tabs">
+        {chatSessions.map((s) => {
+          const m = ROLE_META[s.role] ?? { icon: "🤖", label: s.role };
+          const isActive = s.id === activeChatId;
+          return (
+            <div
+              key={s.id}
+              className={`session-tab${isActive ? " session-tab-active" : ""}`}
+              onClick={() => switchToSession(s.id)}
+            >
+              <span className="session-tab-label">{m.icon} {m.label}</span>
+              {s.id !== generalChatId && (
+                <button
+                  className="session-tab-close"
+                  onClick={(e) => { e.stopPropagation(); closeSession(s.id); }}
+                >
+                  ✕
+                </button>
+              )}
+            </div>
+          );
+        })}
+        <button className="btn btn-small side-panel-close" onClick={handleClosePanel} title="Hide panel">◀</button>
+      </div>
+
+      {/* Status bar */}
       <div className="side-panel-header">
         <span className="side-panel-title">
           {meta.icon} {meta.label}
@@ -79,7 +125,6 @@ export function SidePanel() {
         {activeSession?.model && (
           <span className="side-panel-model">{activeSession.model}</span>
         )}
-        <button className="btn btn-small side-panel-close" onClick={handleClose}>✕</button>
       </div>
 
       <div className="side-panel-messages">


### PR DESCRIPTION
Replaces the floating chat bubble with proper session management:

- **🤖 Agents button** in the tab nav bar toggles the side panel (shows session count)
- **Session tabs** at the top of the side panel list all open sessions
- Click a tab to switch between sessions (General Agent, Refinement Agent, etc.)
- ✕ button on each tab to close that session (except General Agent which persists)
- ◀ button to collapse the panel
- Panel remembers the last active session when reopened