### PR TITLE
feat: render markdown during streaming

### DIFF
--- a/src/dashboard/frontend/src/components/Markdown.css
+++ b/src/dashboard/frontend/src/components/Markdown.css
@@ -47,3 +47,11 @@
   background: var(--bg-hover);
   font-weight: 600;
 }
+
+/* Streaming cursor */
+.streaming-cursor {
+  animation: blink 0.8s step-end infinite;
+}
+@keyframes blink {
+  50% { opacity: 0; }
+}

--- a/src/dashboard/frontend/src/components/SidePanel.tsx
+++ b/src/dashboard/frontend/src/components/SidePanel.tsx
@@ -149,7 +149,10 @@ export function SidePanel() {
         {streaming && (
           <div className="chat-msg chat-assistant">
             <span className="chat-role">{meta.label}</span>
-            <div className="chat-content chat-streaming">{streaming}▌</div>
+            <div className="chat-content chat-streaming">
+              <Markdown text={streaming} />
+              <span className="streaming-cursor">▌</span>
+            </div>
           </div>
         )}
         <div ref={messagesEndRef} />


### PR DESCRIPTION
Streaming agent responses now render markdown formatting live as chunks arrive — headers, bold, code blocks, lists, tables all format in real-time instead of showing raw text until completion.

Added blinking cursor (▌) animation.