### PR TITLE
feat: styled chat message bubbles

### DIFF
--- a/src/dashboard/frontend/src/components/SidePanel.css
+++ b/src/dashboard/frontend/src/components/SidePanel.css
@@ -10,9 +10,10 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 12px 16px;
+  padding: 8px 16px;
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
+  background: var(--bg);
 }
 
 .side-panel-title {
@@ -139,7 +140,82 @@
   padding: 16px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 16px;
+}
+
+/* Chat message layout */
+.chat-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-width: 92%;
+}
+
+.chat-role {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 0 4px;
+}
+
+.chat-content {
+  font-size: 13px;
+  line-height: 1.6;
+  word-break: break-word;
+  padding: 10px 14px;
+  border-radius: 12px;
+}
+
+/* User messages — right-aligned bubble */
+.chat-user {
+  align-self: flex-end;
+  align-items: flex-end;
+}
+.chat-user .chat-role {
+  color: var(--accent);
+}
+.chat-user .chat-content {
+  background: rgba(88, 166, 255, 0.15);
+  border: 1px solid rgba(88, 166, 255, 0.25);
+  border-bottom-right-radius: 4px;
+}
+
+/* Agent/assistant messages — left-aligned bubble */
+.chat-assistant {
+  align-self: flex-start;
+  align-items: flex-start;
+}
+.chat-assistant .chat-role {
+  color: var(--green);
+}
+.chat-assistant .chat-content {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-bottom-left-radius: 4px;
+}
+
+/* System messages */
+.chat-system {
+  align-self: center;
+  max-width: 100%;
+}
+.chat-system .chat-role {
+  display: none;
+}
+.chat-system .chat-content {
+  background: rgba(210, 153, 34, 0.1);
+  border: 1px solid rgba(210, 153, 34, 0.25);
+  color: var(--yellow);
+  font-size: 12px;
+  text-align: center;
+  padding: 6px 12px;
+  border-radius: 8px;
+}
+
+/* Streaming indicator */
+.chat-streaming {
+  opacity: 0.9;
 }
 
 .side-panel-empty {


### PR DESCRIPTION
Visual overhaul of the chat messages in the side panel:

- **User messages**: right-aligned blue bubble with accent border, flat bottom-right corner
- **Agent messages**: left-aligned with subtle background, green role label, flat bottom-left corner
- **System messages**: centered yellow warning style
- Role labels are small uppercase color-coded tags
- 16px gap between messages for clearer separation
- Streaming content has slight opacity reduction