### PR TITLE
feat: display ACP thinking, tool calls, and token usage

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -41,6 +41,26 @@ export interface AcpClientOptions {
   logger?: Logger;
   /** Callback for streaming text chunks from ACP sessions. */
   onStreamChunk?: (sessionId: string, text: string) => void;
+  /** Callback for agent thinking/reasoning chunks. */
+  onThinkingChunk?: (sessionId: string, text: string) => void;
+  /** Callback for tool call events. */
+  onToolCall?: (sessionId: string, toolCall: AcpToolCallEvent) => void;
+  /** Callback for usage/token updates. */
+  onUsageUpdate?: (sessionId: string, usage: AcpUsageEvent) => void;
+}
+
+export interface AcpToolCallEvent {
+  toolCallId: string;
+  title: string;
+  status?: string;
+  kind?: string;
+  locations?: Array<{ uri?: string; range?: unknown }>;
+}
+
+export interface AcpUsageEvent {
+  used: number;
+  size: number;
+  cost?: { amount?: number; currency?: string } | null;
 }
 
 export interface CreateSessionOptions {
@@ -84,6 +104,9 @@ export class AcpClient {
   ) => Promise<RequestPermissionResponse>;
   private readonly defaultTimeoutMs: number;
   private readonly onStreamChunk?: (sessionId: string, text: string) => void;
+  private readonly onThinkingChunk?: (sessionId: string, text: string) => void;
+  private readonly onToolCall?: (sessionId: string, toolCall: AcpToolCallEvent) => void;
+  private readonly onUsageUpdate?: (sessionId: string, usage: AcpUsageEvent) => void;
 
   // Accumulate streamed chunks per session
   private sessionChunks = new Map<string, string[]>();
@@ -103,6 +126,9 @@ export class AcpClient {
     this.extraArgs = options.args ?? [];
     this.defaultTimeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.onStreamChunk = options.onStreamChunk;
+    this.onThinkingChunk = options.onThinkingChunk;
+    this.onToolCall = options.onToolCall;
+    this.onUsageUpdate = options.onUsageUpdate;
     this.permissionHandler = createPermissionHandler(
       options.permissions ?? DEFAULT_PERMISSION_CONFIG,
       this.log,
@@ -194,6 +220,9 @@ export class AcpClient {
       const sessionChunks = this.sessionChunks;
       const log = this.log;
       const onChunk = this.onStreamChunk;
+      const onThinking = this.onThinkingChunk;
+      const onTool = this.onToolCall;
+      const onUsage = this.onUsageUpdate;
 
       this.connection = new ClientSideConnection(
         (_agent) => {
@@ -205,18 +234,41 @@ export class AcpClient {
             },
             async sessionUpdate(params: SessionNotification): Promise<void> {
               const update = params.update;
+              const sid = params.sessionId;
+
               if (update.sessionUpdate === "agent_message_chunk") {
                 const content = update.content;
                 if (content.type === "text") {
-                  const sid = params.sessionId;
                   const chunks = sessionChunks.get(sid) ?? [];
                   chunks.push(content.text);
                   sessionChunks.set(sid, chunks);
                   onChunk?.(sid, content.text);
                 }
+              } else if (update.sessionUpdate === "agent_thought_chunk") {
+                const content = (update as Record<string, unknown>).content as { type?: string; text?: string } | undefined;
+                if (content?.type === "text" && content.text) {
+                  onThinking?.(sid, content.text);
+                }
+              } else if (update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update") {
+                const tc = update as Record<string, unknown>;
+                onTool?.(sid, {
+                  toolCallId: String(tc.toolCallId ?? ""),
+                  title: String(tc.title ?? ""),
+                  status: tc.status as string | undefined,
+                  kind: tc.kind as string | undefined,
+                  locations: tc.locations as Array<{ uri?: string; range?: unknown }> | undefined,
+                });
+              } else if (update.sessionUpdate === "usage_update") {
+                const u = update as Record<string, unknown>;
+                onUsage?.(sid, {
+                  used: Number(u.used ?? 0),
+                  size: Number(u.size ?? 0),
+                  cost: u.cost as AcpUsageEvent["cost"],
+                });
               }
+
               log.debug(
-                { sessionId: params.sessionId, type: update.sessionUpdate },
+                { sessionId: sid, type: update.sessionUpdate },
                 "session update",
               );
             },

--- a/src/dashboard/chat-manager.ts
+++ b/src/dashboard/chat-manager.ts
@@ -33,6 +33,9 @@ export interface ChatManagerOptions {
   permissions?: PermissionConfig;
   timeoutMs?: number;
   onStreamChunk?: (sessionId: string, text: string) => void;
+  onThinkingChunk?: (sessionId: string, text: string) => void;
+  onToolCall?: (sessionId: string, toolCall: { toolCallId: string; title: string; status?: string; kind?: string }) => void;
+  onUsageUpdate?: (sessionId: string, usage: { used: number; size: number }) => void;
 }
 
 export class ChatManager {
@@ -43,6 +46,14 @@ export class ChatManager {
 
   constructor(options: ChatManagerOptions) {
     this.options = options;
+  }
+
+  /** Find the chat ID for an ACP session ID. */
+  private findChatId(acpSessionId: string): string | undefined {
+    for (const [chatId, session] of this.sessions) {
+      if (session.acpSessionId === acpSessionId) return chatId;
+    }
+    return undefined;
   }
 
   /** Ensure ACP client is connected. Lazy-connects on first use. */
@@ -56,13 +67,20 @@ export class ChatManager {
         allowPatterns: [],
       },
       onStreamChunk: (acpSessionId, text) => {
-        // Find our chat session by ACP session ID and relay chunk
-        for (const [chatId, session] of this.sessions) {
-          if (session.acpSessionId === acpSessionId) {
-            this.options.onStreamChunk?.(chatId, text);
-            break;
-          }
-        }
+        const chatId = this.findChatId(acpSessionId);
+        if (chatId) this.options.onStreamChunk?.(chatId, text);
+      },
+      onThinkingChunk: (acpSessionId, text) => {
+        const chatId = this.findChatId(acpSessionId);
+        if (chatId) this.options.onThinkingChunk?.(chatId, text);
+      },
+      onToolCall: (acpSessionId, toolCall) => {
+        const chatId = this.findChatId(acpSessionId);
+        if (chatId) this.options.onToolCall?.(chatId, toolCall);
+      },
+      onUsageUpdate: (acpSessionId, usage) => {
+        const chatId = this.findChatId(acpSessionId);
+        if (chatId) this.options.onUsageUpdate?.(chatId, usage);
       },
     });
 

--- a/src/dashboard/frontend/src/components/SidePanel.css
+++ b/src/dashboard/frontend/src/components/SidePanel.css
@@ -280,3 +280,92 @@
 .app-resize-handle:active {
   background: var(--accent);
 }
+
+/* Thinking indicator */
+.chat-thinking {
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(188, 140, 255, 0.08);
+  border: 1px solid rgba(188, 140, 255, 0.2);
+  font-size: 12px;
+}
+.chat-thinking-label {
+  font-weight: 600;
+  color: var(--purple);
+  font-size: 11px;
+}
+.chat-thinking-content {
+  color: var(--text-dim);
+  font-size: 11px;
+  margin-top: 4px;
+  overflow: hidden;
+  max-height: 60px;
+  line-height: 1.4;
+  opacity: 0.7;
+}
+
+/* Tool call indicators */
+.chat-tool-calls {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.chat-tool-call {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  background: var(--bg);
+  border: 1px solid var(--border);
+}
+.chat-tool-icon {
+  font-size: 12px;
+  flex-shrink: 0;
+}
+.chat-tool-running .chat-tool-icon {
+  color: var(--yellow);
+  animation: spin 1s linear infinite;
+}
+.chat-tool-completed .chat-tool-icon { color: var(--green); }
+.chat-tool-failed .chat-tool-icon { color: var(--red); }
+.chat-tool-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-dim);
+}
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Usage bar */
+.chat-usage-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 16px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+  font-size: 10px;
+  color: var(--text-dim);
+}
+.chat-usage-tokens {
+  white-space: nowrap;
+  font-family: var(--font-mono);
+}
+.chat-usage-meter {
+  flex: 1;
+  height: 3px;
+  background: var(--bg);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.chat-usage-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  transition: width 0.3s;
+}

--- a/src/dashboard/frontend/src/components/SidePanel.tsx
+++ b/src/dashboard/frontend/src/components/SidePanel.tsx
@@ -18,6 +18,9 @@ export function SidePanel() {
   const generalChatId = useDashboardStore((s) => s.generalChatId);
   const chatMessages = useDashboardStore((s) => s.chatMessages);
   const chatStreaming = useDashboardStore((s) => s.chatStreaming);
+  const chatThinking = useDashboardStore((s) => s.chatThinking);
+  const chatToolCalls = useDashboardStore((s) => s.chatToolCalls);
+  const chatUsage = useDashboardStore((s) => s.chatUsage);
   const sidePanelRole = useDashboardStore((s) => s.sidePanelRole);
   const send = useDashboardStore((s) => s.send);
 
@@ -26,6 +29,9 @@ export function SidePanel() {
 
   const activeMessages = activeChatId ? chatMessages[activeChatId] ?? [] : [];
   const streaming = activeChatId ? chatStreaming[activeChatId] : undefined;
+  const thinking = activeChatId ? chatThinking[activeChatId] : undefined;
+  const toolCalls = activeChatId ? chatToolCalls[activeChatId] : undefined;
+  const usage = activeChatId ? chatUsage[activeChatId] : undefined;
   const activeSession = chatSessions.find((s) => s.id === activeChatId);
   const isLoading = !activeSession && activeChatId !== "__global__" && activeChatId !== null;
 
@@ -34,7 +40,7 @@ export function SidePanel() {
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [activeMessages, streaming]);
+  }, [activeMessages, streaming, thinking, toolCalls]);
 
   const handleClosePanel = () => {
     useDashboardStore.setState({ chatPanelOpen: false });
@@ -146,6 +152,29 @@ export function SidePanel() {
             <div className="chat-content"><Markdown text={m.content} /></div>
           </div>
         ))}
+
+        {/* Thinking indicator */}
+        {thinking && !streaming && (
+          <div className="chat-thinking">
+            <span className="chat-thinking-label">💭 Thinking…</span>
+            <div className="chat-thinking-content">{thinking.slice(-200)}</div>
+          </div>
+        )}
+
+        {/* Active tool calls */}
+        {toolCalls && toolCalls.length > 0 && (
+          <div className="chat-tool-calls">
+            {toolCalls.map((tc) => (
+              <div key={tc.toolCallId} className={`chat-tool-call chat-tool-${tc.status ?? "running"}`}>
+                <span className="chat-tool-icon">
+                  {tc.status === "completed" ? "✓" : tc.status === "failed" ? "✗" : "⟳"}
+                </span>
+                <span className="chat-tool-title">{tc.title}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
         {streaming && (
           <div className="chat-msg chat-assistant">
             <span className="chat-role">{meta.label}</span>
@@ -157,6 +186,21 @@ export function SidePanel() {
         )}
         <div ref={messagesEndRef} />
       </div>
+
+      {/* Usage bar */}
+      {usage && (
+        <div className="chat-usage-bar">
+          <span className="chat-usage-tokens">
+            Tokens: {usage.used.toLocaleString()} / {usage.size.toLocaleString()}
+          </span>
+          <div className="chat-usage-meter">
+            <div
+              className="chat-usage-fill"
+              style={{ width: `${Math.min(100, (usage.used / usage.size) * 100)}%` }}
+            />
+          </div>
+        </div>
+      )}
 
       <div className="side-panel-input-row">
         <textarea

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -9,6 +9,13 @@ import type {
   ServerMessage,
 } from "./types";
 
+export interface ChatToolCall {
+  toolCallId: string;
+  title: string;
+  status?: string;
+  kind?: string;
+}
+
 export interface DashboardStore {
   // Connection
   connected: boolean;
@@ -36,6 +43,9 @@ export interface DashboardStore {
   generalChatId: string | null;
   chatMessages: Record<string, ChatMessage[]>;
   chatStreaming: Record<string, string>;
+  chatThinking: Record<string, string>;
+  chatToolCalls: Record<string, ChatToolCall[]>;
+  chatUsage: Record<string, { used: number; size: number }>;
   chatPanelOpen: boolean;
   sidePanelRole: string | null;
   pendingChatMessage: string | null;
@@ -250,7 +260,11 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
         set((prev) => {
           const msgs = prev.chatMessages[p.sessionId] ?? [];
           const streaming = { ...prev.chatStreaming };
+          const thinking = { ...prev.chatThinking };
+          const toolCalls = { ...prev.chatToolCalls };
           delete streaming[p.sessionId];
+          delete thinking[p.sessionId];
+          delete toolCalls[p.sessionId];
           return {
             ...prev,
             chatMessages: {
@@ -261,8 +275,69 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
               ],
             },
             chatStreaming: streaming,
+            chatThinking: thinking,
+            chatToolCalls: toolCalls,
           };
         });
+      }
+      break;
+    }
+
+    case "chat:thinking": {
+      const p = msg.payload as { sessionId: string; text: string } | undefined;
+      if (p) {
+        set((prev) => ({
+          ...prev,
+          chatThinking: {
+            ...prev.chatThinking,
+            [p.sessionId]: (prev.chatThinking[p.sessionId] ?? "") + p.text,
+          },
+        }));
+      }
+      break;
+    }
+
+    case "chat:tool-call": {
+      const p = msg.payload as {
+        sessionId: string;
+        toolCallId: string;
+        title: string;
+        status?: string;
+        kind?: string;
+      } | undefined;
+      if (p) {
+        set((prev) => {
+          const existing = prev.chatToolCalls[p.sessionId] ?? [];
+          const idx = existing.findIndex((t) => t.toolCallId === p.toolCallId);
+          const entry: ChatToolCall = {
+            toolCallId: p.toolCallId,
+            title: p.title,
+            status: p.status,
+            kind: p.kind,
+          };
+          const updated = idx >= 0
+            ? existing.map((t, i) => (i === idx ? entry : t))
+            : [...existing, entry];
+          return {
+            ...prev,
+            chatToolCalls: { ...prev.chatToolCalls, [p.sessionId]: updated },
+          };
+        });
+      }
+      break;
+    }
+
+    case "chat:usage": {
+      const p = msg.payload as {
+        sessionId: string;
+        used: number;
+        size: number;
+      } | undefined;
+      if (p) {
+        set((prev) => ({
+          ...prev,
+          chatUsage: { ...prev.chatUsage, [p.sessionId]: { used: p.used, size: p.size } },
+        }));
       }
       break;
     }
@@ -487,6 +562,9 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
   generalChatId: null,
   chatMessages: {},
   chatStreaming: {},
+  chatThinking: {},
+  chatToolCalls: {},
+  chatUsage: {},
   chatPanelOpen: false,
   sidePanelRole: null,
   pendingChatMessage: null,

--- a/src/dashboard/frontend/src/types.ts
+++ b/src/dashboard/frontend/src/types.ts
@@ -15,6 +15,9 @@ export interface ServerMessage {
     | "chat:done"
     | "chat:created"
     | "chat:error"
+    | "chat:thinking"
+    | "chat:tool-call"
+    | "chat:usage"
     | "pong";
   eventName?: string;
   payload?: unknown;

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -31,7 +31,7 @@ export interface IssueEntry {
 
 /** Message sent from server to browser clients. */
 export interface ServerMessage {
-  type: "sprint:event" | "sprint:state" | "sprint:issues" | "sprint:switched" | "backlog:planned" | "backlog:removed" | "backlog:error" | "session:list" | "session:output" | "session:status" | "chat:chunk" | "chat:done" | "chat:created" | "chat:error" | "pong";
+  type: "sprint:event" | "sprint:state" | "sprint:issues" | "sprint:switched" | "backlog:planned" | "backlog:removed" | "backlog:error" | "session:list" | "session:output" | "session:status" | "chat:chunk" | "chat:done" | "chat:created" | "chat:error" | "chat:thinking" | "chat:tool-call" | "chat:usage" | "pong";
   eventName?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   payload?: any;
@@ -634,6 +634,24 @@ export class DashboardWebServer {
           this.broadcast({
             type: "chat:chunk",
             payload: { sessionId: chatId, text },
+          });
+        },
+        onThinkingChunk: (chatId, text) => {
+          this.broadcast({
+            type: "chat:thinking",
+            payload: { sessionId: chatId, text },
+          });
+        },
+        onToolCall: (chatId, toolCall) => {
+          this.broadcast({
+            type: "chat:tool-call",
+            payload: { sessionId: chatId, ...toolCall },
+          });
+        },
+        onUsageUpdate: (chatId, usage) => {
+          this.broadcast({
+            type: "chat:usage",
+            payload: { sessionId: chatId, ...usage },
           });
         },
       });


### PR DESCRIPTION
Captures and displays ACP session events that were previously discarded:

**💭 Thinking** — Shows agent's internal reasoning with a purple indicator. Displays last 200 chars of thinking text.

**🔧 Tool calls** — Lists active tool calls with status indicators:
- ⟳ running (yellow, spinning)
- ✓ completed (green)
- ✗ failed (red)

**📊 Token usage** — Bar at bottom of chat showing tokens used/available with a visual meter.

Full pipeline wired: `ACP SDK → client.ts → chat-manager → ws-server → store → SidePanel`