### PR TITLE
feat: display ACP mode with toggle button in side panel

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -47,6 +47,8 @@ export interface AcpClientOptions {
   onToolCall?: (sessionId: string, toolCall: AcpToolCallEvent) => void;
   /** Callback for usage/token updates. */
   onUsageUpdate?: (sessionId: string, usage: AcpUsageEvent) => void;
+  /** Callback for mode changes. */
+  onModeChange?: (sessionId: string, modeId: string) => void;
 }
 
 export interface AcpToolCallEvent {
@@ -107,6 +109,7 @@ export class AcpClient {
   private readonly onThinkingChunk?: (sessionId: string, text: string) => void;
   private readonly onToolCall?: (sessionId: string, toolCall: AcpToolCallEvent) => void;
   private readonly onUsageUpdate?: (sessionId: string, usage: AcpUsageEvent) => void;
+  private readonly onModeChange?: (sessionId: string, modeId: string) => void;
 
   // Accumulate streamed chunks per session
   private sessionChunks = new Map<string, string[]>();
@@ -129,6 +132,7 @@ export class AcpClient {
     this.onThinkingChunk = options.onThinkingChunk;
     this.onToolCall = options.onToolCall;
     this.onUsageUpdate = options.onUsageUpdate;
+    this.onModeChange = options.onModeChange;
     this.permissionHandler = createPermissionHandler(
       options.permissions ?? DEFAULT_PERMISSION_CONFIG,
       this.log,
@@ -223,6 +227,7 @@ export class AcpClient {
       const onThinking = this.onThinkingChunk;
       const onTool = this.onToolCall;
       const onUsage = this.onUsageUpdate;
+      const onMode = this.onModeChange;
 
       this.connection = new ClientSideConnection(
         (_agent) => {
@@ -265,6 +270,11 @@ export class AcpClient {
                   size: Number(u.size ?? 0),
                   cost: u.cost as AcpUsageEvent["cost"],
                 });
+              } else if (update.sessionUpdate === "current_mode_update") {
+                const m = update as Record<string, unknown>;
+                if (m.currentModeId) {
+                  onMode?.(sid, String(m.currentModeId));
+                }
               }
 
               log.debug(

--- a/src/dashboard/chat-manager.ts
+++ b/src/dashboard/chat-manager.ts
@@ -36,6 +36,7 @@ export interface ChatManagerOptions {
   onThinkingChunk?: (sessionId: string, text: string) => void;
   onToolCall?: (sessionId: string, toolCall: { toolCallId: string; title: string; status?: string; kind?: string }) => void;
   onUsageUpdate?: (sessionId: string, usage: { used: number; size: number }) => void;
+  onModeChange?: (sessionId: string, modeId: string) => void;
 }
 
 export class ChatManager {
@@ -81,6 +82,10 @@ export class ChatManager {
       onUsageUpdate: (acpSessionId, usage) => {
         const chatId = this.findChatId(acpSessionId);
         if (chatId) this.options.onUsageUpdate?.(chatId, usage);
+      },
+      onModeChange: (acpSessionId, modeId) => {
+        const chatId = this.findChatId(acpSessionId);
+        if (chatId) this.options.onModeChange?.(chatId, modeId);
       },
     });
 
@@ -159,6 +164,15 @@ export class ChatManager {
 
     this.sessions.delete(chatId);
     log.info({ chatId }, "Chat session closed");
+  }
+
+  /** Set the ACP mode for a chat session. */
+  async setMode(chatId: string, modeId: string): Promise<void> {
+    const session = this.sessions.get(chatId);
+    if (!session) throw new Error(`Chat session ${chatId} not found`);
+    const client = await this.ensureClient();
+    await client.setMode(session.acpSessionId, modeId);
+    log.info({ chatId, modeId }, "Chat session mode changed");
   }
 
   /** Get a chat session by ID. */

--- a/src/dashboard/frontend/src/components/SidePanel.css
+++ b/src/dashboard/frontend/src/components/SidePanel.css
@@ -134,6 +134,24 @@
   border-radius: 4px;
 }
 
+.side-panel-mode-btn {
+  font-size: 10px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text-dim);
+  cursor: pointer;
+  font-family: var(--font);
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+.side-panel-mode-btn:hover {
+  color: var(--text);
+  border-color: var(--accent);
+  background: var(--bg-hover);
+}
+
 .side-panel-messages {
   flex: 1;
   overflow-y: auto;

--- a/src/dashboard/frontend/src/components/SidePanel.tsx
+++ b/src/dashboard/frontend/src/components/SidePanel.tsx
@@ -12,6 +12,17 @@ const ROLE_META: Record<string, { icon: string; label: string }> = {
   challenger:{ icon: "⚔️", label: "Challenger Agent" },
 };
 
+const MODE_LABELS: Record<string, { short: string; icon: string }> = {
+  "https://agentclientprotocol.com/protocol/session-modes#agent": { short: "Agent", icon: "🤖" },
+  "https://agentclientprotocol.com/protocol/session-modes#plan": { short: "Plan", icon: "📋" },
+  "https://agentclientprotocol.com/protocol/session-modes#autopilot": { short: "Autopilot", icon: "🚀" },
+};
+
+const MODE_CYCLE = [
+  "https://agentclientprotocol.com/protocol/session-modes#agent",
+  "https://agentclientprotocol.com/protocol/session-modes#plan",
+];
+
 export function SidePanel() {
   const activeChatId = useDashboardStore((s) => s.activeChatId);
   const chatSessions = useDashboardStore((s) => s.chatSessions);
@@ -130,6 +141,23 @@ export function SidePanel() {
         {activeSession && <span className="side-panel-status connected">● Connected</span>}
         {activeSession?.model && (
           <span className="side-panel-model">{activeSession.model}</span>
+        )}
+        {activeSession && (
+          <button
+            className="side-panel-mode-btn"
+            onClick={() => {
+              const currentMode = activeSession.modeId ?? MODE_CYCLE[0]!;
+              const idx = MODE_CYCLE.indexOf(currentMode);
+              const nextMode = MODE_CYCLE[(idx + 1) % MODE_CYCLE.length]!;
+              send({ type: "chat:set-mode", sessionId: activeSession.id, mode: nextMode });
+            }}
+            title="Toggle mode (Shift+Tab)"
+          >
+            {(() => {
+              const m = MODE_LABELS[activeSession.modeId ?? ""] ?? MODE_LABELS[MODE_CYCLE[0]!]!;
+              return `${m.icon} ${m.short}`;
+            })()}
+          </button>
         )}
       </div>
 

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -342,6 +342,19 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
       break;
     }
 
+    case "chat:mode": {
+      const p = msg.payload as { sessionId: string; modeId: string } | undefined;
+      if (p) {
+        set((prev) => ({
+          ...prev,
+          chatSessions: prev.chatSessions.map((s) =>
+            s.id === p.sessionId ? { ...s, modeId: p.modeId } : s,
+          ),
+        }));
+      }
+      break;
+    }
+
     case "chat:error": {
       const p = msg.payload as {
         sessionId?: string;

--- a/src/dashboard/frontend/src/types.ts
+++ b/src/dashboard/frontend/src/types.ts
@@ -18,6 +18,7 @@ export interface ServerMessage {
     | "chat:thinking"
     | "chat:tool-call"
     | "chat:usage"
+    | "chat:mode"
     | "pong";
   eventName?: string;
   payload?: unknown;
@@ -42,6 +43,7 @@ export interface ClientMessage {
     | "chat:create"
     | "chat:send"
     | "chat:close"
+    | "chat:set-mode"
     | "blocked:comment"
     | "blocked:unblock"
     | "decisions:approve"
@@ -93,6 +95,7 @@ export interface ChatSession {
   id: string;
   role: string;
   model?: string;
+  modeId?: string;
 }
 
 /** Chat message. */

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -31,7 +31,7 @@ export interface IssueEntry {
 
 /** Message sent from server to browser clients. */
 export interface ServerMessage {
-  type: "sprint:event" | "sprint:state" | "sprint:issues" | "sprint:switched" | "backlog:planned" | "backlog:removed" | "backlog:error" | "session:list" | "session:output" | "session:status" | "chat:chunk" | "chat:done" | "chat:created" | "chat:error" | "chat:thinking" | "chat:tool-call" | "chat:usage" | "pong";
+  type: "sprint:event" | "sprint:state" | "sprint:issues" | "sprint:switched" | "backlog:planned" | "backlog:removed" | "backlog:error" | "session:list" | "session:output" | "session:status" | "chat:chunk" | "chat:done" | "chat:created" | "chat:error" | "chat:thinking" | "chat:tool-call" | "chat:usage" | "chat:mode" | "pong";
   eventName?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   payload?: any;
@@ -39,7 +39,7 @@ export interface ServerMessage {
 
 /** Message sent from browser client to server. */
 export interface ClientMessage {
-  type: "sprint:start" | "sprint:stop" | "sprint:pause" | "sprint:resume" | "sprint:switch" | "sprint:set-limit" | "mode:set" | "backlog:plan-issue" | "backlog:remove-issue" | "session:subscribe" | "session:unsubscribe" | "session:send-message" | "session:stop" | "chat:create" | "chat:send" | "chat:close" | "blocked:comment" | "blocked:unblock" | "decisions:approve" | "decisions:reject" | "decisions:comment" | "ping";
+  type: "sprint:start" | "sprint:stop" | "sprint:pause" | "sprint:resume" | "sprint:switch" | "sprint:set-limit" | "mode:set" | "backlog:plan-issue" | "backlog:remove-issue" | "session:subscribe" | "session:unsubscribe" | "session:send-message" | "session:stop" | "chat:create" | "chat:send" | "chat:close" | "chat:set-mode" | "blocked:comment" | "blocked:unblock" | "decisions:approve" | "decisions:reject" | "decisions:comment" | "ping";
   sprintNumber?: number;
   issueNumber?: number;
   sessionId?: string;
@@ -541,6 +541,11 @@ export class DashboardWebServer {
           this.handleChatClose(msg.sessionId);
         }
         break;
+      case "chat:set-mode":
+        if (msg.sessionId && msg.mode) {
+          this.handleChatSetMode(msg.sessionId, msg.mode, ws);
+        }
+        break;
       case "session:subscribe":
         if (msg.sessionId) {
           let subs = this.sessionSubscribers.get(msg.sessionId);
@@ -654,6 +659,12 @@ export class DashboardWebServer {
             payload: { sessionId: chatId, ...usage },
           });
         },
+        onModeChange: (chatId, modeId) => {
+          this.broadcast({
+            type: "chat:mode",
+            payload: { sessionId: chatId, modeId },
+          });
+        },
       });
     }
     return this.chatManager;
@@ -711,6 +722,23 @@ export class DashboardWebServer {
       await this.getChatManager().closeSession(sessionId);
     } catch (err: unknown) {
       log.warn({ err, sessionId }, "Failed to close chat session");
+    }
+  }
+
+  private async handleChatSetMode(sessionId: string, modeId: string, ws: WebSocket): Promise<void> {
+    try {
+      await this.getChatManager().setMode(sessionId, modeId);
+      this.broadcast({
+        type: "chat:mode",
+        payload: { sessionId, modeId },
+      });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error({ err, sessionId, modeId }, "Failed to set chat mode");
+      this.sendTo(ws, {
+        type: "chat:error",
+        payload: { sessionId, error: `Failed to set mode: ${msg}` },
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
Display current ACP session mode (Agent/Plan) in the side panel header with a toggle button to switch between modes.

## Changes
- **AcpClient**: Capture `current_mode_update` events via `onModeChange` callback
- **ChatManager**: Add `setMode()` method and relay mode changes
- **ws-server**: Add `chat:mode` broadcast and `chat:set-mode` handler
- **Frontend types**: Add `modeId` to ChatSession, `chat:set-mode` to ClientMessage
- **Store**: Handle `chat:mode` messages, update session modeId
- **SidePanel**: Mode pill badge with click-to-toggle (Agent ↔ Plan cycle)

## Testing
- `npx tsc --noEmit` — ✅ passes
- `npx vitest run` — ✅ 573/573 tests pass
- Playwright — 11 pre-existing failures (old vanilla DOM selectors from React rebuild)