### PR TITLE
feat: slash commands, config dropdowns, plan progress, rich tool calls

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -49,6 +49,12 @@ export interface AcpClientOptions {
   onUsageUpdate?: (sessionId: string, usage: AcpUsageEvent) => void;
   /** Callback for mode changes. */
   onModeChange?: (sessionId: string, modeId: string) => void;
+  /** Callback for plan updates. */
+  onPlanUpdate?: (sessionId: string, plan: AcpPlanEvent) => void;
+  /** Callback for available commands updates. */
+  onCommandsUpdate?: (sessionId: string, commands: AcpCommand[]) => void;
+  /** Callback for config option updates. */
+  onConfigUpdate?: (sessionId: string, configs: AcpConfigOption[]) => void;
 }
 
 export interface AcpToolCallEvent {
@@ -63,6 +69,31 @@ export interface AcpUsageEvent {
   used: number;
   size: number;
   cost?: { amount?: number; currency?: string } | null;
+}
+
+export interface AcpPlanEntry {
+  content: string;
+  priority: "high" | "medium" | "low";
+  status: "pending" | "in_progress" | "completed";
+}
+
+export interface AcpPlanEvent {
+  entries: AcpPlanEntry[];
+}
+
+export interface AcpCommand {
+  name: string;
+  description: string;
+  hint?: string;
+}
+
+export interface AcpConfigOption {
+  id: string;
+  name: string;
+  category?: string;
+  description?: string;
+  currentValue: string;
+  options: Array<{ value: string; name: string; description?: string }>;
 }
 
 export interface CreateSessionOptions {
@@ -110,6 +141,9 @@ export class AcpClient {
   private readonly onToolCall?: (sessionId: string, toolCall: AcpToolCallEvent) => void;
   private readonly onUsageUpdate?: (sessionId: string, usage: AcpUsageEvent) => void;
   private readonly onModeChange?: (sessionId: string, modeId: string) => void;
+  private readonly onPlanUpdate?: (sessionId: string, plan: AcpPlanEvent) => void;
+  private readonly onCommandsUpdate?: (sessionId: string, commands: AcpCommand[]) => void;
+  private readonly onConfigUpdate?: (sessionId: string, configs: AcpConfigOption[]) => void;
 
   // Accumulate streamed chunks per session
   private sessionChunks = new Map<string, string[]>();
@@ -133,6 +167,9 @@ export class AcpClient {
     this.onToolCall = options.onToolCall;
     this.onUsageUpdate = options.onUsageUpdate;
     this.onModeChange = options.onModeChange;
+    this.onPlanUpdate = options.onPlanUpdate;
+    this.onCommandsUpdate = options.onCommandsUpdate;
+    this.onConfigUpdate = options.onConfigUpdate;
     this.permissionHandler = createPermissionHandler(
       options.permissions ?? DEFAULT_PERMISSION_CONFIG,
       this.log,
@@ -228,6 +265,9 @@ export class AcpClient {
       const onTool = this.onToolCall;
       const onUsage = this.onUsageUpdate;
       const onMode = this.onModeChange;
+      const onPlan = this.onPlanUpdate;
+      const onCommands = this.onCommandsUpdate;
+      const onConfig = this.onConfigUpdate;
 
       this.connection = new ClientSideConnection(
         (_agent) => {
@@ -274,6 +314,54 @@ export class AcpClient {
                 const m = update as Record<string, unknown>;
                 if (m.currentModeId) {
                   onMode?.(sid, String(m.currentModeId));
+                }
+              } else if (update.sessionUpdate === "plan") {
+                const p = update as Record<string, unknown>;
+                const entries = p.entries as Array<{ content: string; priority: string; status: string }> | undefined;
+                if (entries) {
+                  onPlan?.(sid, {
+                    entries: entries.map((e) => ({
+                      content: e.content,
+                      priority: (e.priority ?? "medium") as AcpPlanEntry["priority"],
+                      status: (e.status ?? "pending") as AcpPlanEntry["status"],
+                    })),
+                  });
+                }
+              } else if (update.sessionUpdate === "available_commands_update") {
+                const c = update as Record<string, unknown>;
+                const cmds = c.availableCommands as Array<{ name: string; description: string; input?: { hint?: string } }> | undefined;
+                if (cmds) {
+                  onCommands?.(sid, cmds.map((cmd) => ({
+                    name: cmd.name,
+                    description: cmd.description,
+                    hint: cmd.input?.hint,
+                  })));
+                }
+              } else if (update.sessionUpdate === "config_option_update") {
+                const c = update as Record<string, unknown>;
+                const opts = c.configOptions as Array<Record<string, unknown>> | undefined;
+                if (opts) {
+                  onConfig?.(sid, opts.map((o) => {
+                    const flatOpts = Array.isArray(o.options)
+                      ? (o.options as Array<Record<string, unknown>>).flatMap((item) =>
+                          item.group != null
+                            ? ((item.options as Array<Record<string, unknown>>) ?? []).map((sub) => ({
+                                value: String(sub.value ?? ""),
+                                name: String(sub.name ?? ""),
+                                description: sub.description as string | undefined,
+                              }))
+                            : [{ value: String(item.value ?? ""), name: String(item.name ?? ""), description: item.description as string | undefined }],
+                        )
+                      : [];
+                    return {
+                      id: String(o.id ?? ""),
+                      name: String(o.name ?? ""),
+                      category: o.category as string | undefined,
+                      description: o.description as string | undefined,
+                      currentValue: String(o.currentValue ?? ""),
+                      options: flatOpts,
+                    };
+                  }));
                 }
               }
 
@@ -356,6 +444,15 @@ export class AcpClient {
     const conn = this.requireConnection();
     this.log.info({ sessionId, modelId }, "setting session model");
     await conn.unstable_setSessionModel({ sessionId, modelId });
+  }
+
+  /**
+   * Set a session config option (e.g., model, thought level).
+   */
+  async setConfigOption(sessionId: string, optionId: string, value: string): Promise<void> {
+    const conn = this.requireConnection();
+    this.log.info({ sessionId, optionId, value }, "setting session config option");
+    await conn.setSessionConfigOption({ sessionId, configOptionId: optionId, value });
   }
 
   /**

--- a/src/dashboard/chat-manager.ts
+++ b/src/dashboard/chat-manager.ts
@@ -37,6 +37,9 @@ export interface ChatManagerOptions {
   onToolCall?: (sessionId: string, toolCall: { toolCallId: string; title: string; status?: string; kind?: string }) => void;
   onUsageUpdate?: (sessionId: string, usage: { used: number; size: number }) => void;
   onModeChange?: (sessionId: string, modeId: string) => void;
+  onPlanUpdate?: (sessionId: string, plan: { entries: Array<{ content: string; priority: string; status: string }> }) => void;
+  onCommandsUpdate?: (sessionId: string, commands: Array<{ name: string; description: string; hint?: string }>) => void;
+  onConfigUpdate?: (sessionId: string, configs: Array<{ id: string; name: string; category?: string; currentValue: string; options: Array<{ value: string; name: string }> }>) => void;
 }
 
 export class ChatManager {
@@ -86,6 +89,18 @@ export class ChatManager {
       onModeChange: (acpSessionId, modeId) => {
         const chatId = this.findChatId(acpSessionId);
         if (chatId) this.options.onModeChange?.(chatId, modeId);
+      },
+      onPlanUpdate: (acpSessionId, plan) => {
+        const chatId = this.findChatId(acpSessionId);
+        if (chatId) this.options.onPlanUpdate?.(chatId, plan);
+      },
+      onCommandsUpdate: (acpSessionId, commands) => {
+        const chatId = this.findChatId(acpSessionId);
+        if (chatId) this.options.onCommandsUpdate?.(chatId, commands);
+      },
+      onConfigUpdate: (acpSessionId, configs) => {
+        const chatId = this.findChatId(acpSessionId);
+        if (chatId) this.options.onConfigUpdate?.(chatId, configs);
       },
     });
 
@@ -173,6 +188,15 @@ export class ChatManager {
     const client = await this.ensureClient();
     await client.setMode(session.acpSessionId, modeId);
     log.info({ chatId, modeId }, "Chat session mode changed");
+  }
+
+  /** Set a config option for a chat session. */
+  async setConfig(chatId: string, optionId: string, value: string): Promise<void> {
+    const session = this.sessions.get(chatId);
+    if (!session) throw new Error(`Chat session ${chatId} not found`);
+    const client = await this.ensureClient();
+    await client.setConfigOption(session.acpSessionId, optionId, value);
+    log.info({ chatId, optionId, value }, "Chat session config changed");
   }
 
   /** Get a chat session by ID. */

--- a/src/dashboard/frontend/src/components/SidePanel.css
+++ b/src/dashboard/frontend/src/components/SidePanel.css
@@ -387,3 +387,164 @@
   border-radius: 2px;
   transition: width 0.3s;
 }
+
+/* Plan progress panel */
+.chat-plan {
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(88, 166, 255, 0.06);
+  border: 1px solid rgba(88, 166, 255, 0.15);
+  font-size: 12px;
+}
+.chat-plan-header {
+  font-weight: 600;
+  font-size: 11px;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+.chat-plan-entry {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 3px 0;
+  line-height: 1.4;
+}
+.chat-plan-check {
+  flex-shrink: 0;
+  font-size: 11px;
+  width: 14px;
+  text-align: center;
+}
+.chat-plan-completed .chat-plan-check { color: var(--green); }
+.chat-plan-in_progress .chat-plan-check {
+  color: var(--yellow);
+  animation: spin 1s linear infinite;
+}
+.chat-plan-pending .chat-plan-check { color: var(--text-dim); }
+.chat-plan-text {
+  color: var(--text-dim);
+  font-size: 11px;
+}
+.chat-plan-completed .chat-plan-text {
+  text-decoration: line-through;
+  opacity: 0.6;
+}
+.chat-plan-in_progress .chat-plan-text {
+  color: var(--text);
+  font-weight: 500;
+}
+
+/* Tool call kind icon */
+.chat-tool-kind {
+  font-size: 11px;
+  flex-shrink: 0;
+}
+.chat-tool-locations {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+}
+.chat-tool-location {
+  font-size: 10px;
+  color: var(--accent);
+  opacity: 0.7;
+}
+
+/* Slash command menu */
+.slash-menu {
+  border-top: 1px solid var(--border);
+  background: var(--bg-panel);
+  max-height: 200px;
+  overflow-y: auto;
+  flex-shrink: 0;
+}
+.slash-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 16px;
+  border: none;
+  background: none;
+  color: var(--text);
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font);
+}
+.slash-menu-item:hover {
+  background: var(--bg-hover);
+}
+.slash-menu-name {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--accent);
+  white-space: nowrap;
+  min-width: 120px;
+}
+.slash-menu-desc {
+  color: var(--text-dim);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Config dropdowns */
+.side-panel-config-wrapper {
+  position: relative;
+}
+.side-panel-config-btn {
+  font-size: 10px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text-dim);
+  cursor: pointer;
+  font-family: var(--font);
+  transition: all 0.15s;
+  white-space: nowrap;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.side-panel-config-btn:hover {
+  color: var(--text);
+  border-color: var(--accent);
+  background: var(--bg-hover);
+}
+.side-panel-config-dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  min-width: 160px;
+  max-height: 240px;
+  overflow-y: auto;
+  z-index: 100;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+.side-panel-config-option {
+  display: block;
+  width: 100%;
+  padding: 6px 12px;
+  border: none;
+  background: none;
+  color: var(--text-dim);
+  font-size: 11px;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font);
+}
+.side-panel-config-option:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.side-panel-config-option.active {
+  color: var(--accent);
+  font-weight: 600;
+}

--- a/src/dashboard/frontend/src/components/SidePanel.tsx
+++ b/src/dashboard/frontend/src/components/SidePanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { useDashboardStore } from "../store";
+import type { ChatCommand } from "../store";
 import { Markdown } from "./Markdown";
 import "./SidePanel.css";
 
@@ -23,6 +24,19 @@ const MODE_CYCLE = [
   "https://agentclientprotocol.com/protocol/session-modes#plan",
 ];
 
+const TOOL_KIND_ICONS: Record<string, string> = {
+  read: "📖",
+  edit: "✏️",
+  delete: "🗑️",
+  move: "📁",
+  search: "🔍",
+  execute: "▶️",
+  think: "💭",
+  fetch: "🌐",
+  switch_mode: "🔄",
+  other: "🔧",
+};
+
 export function SidePanel() {
   const activeChatId = useDashboardStore((s) => s.activeChatId);
   const chatSessions = useDashboardStore((s) => s.chatSessions);
@@ -32,17 +46,27 @@ export function SidePanel() {
   const chatThinking = useDashboardStore((s) => s.chatThinking);
   const chatToolCalls = useDashboardStore((s) => s.chatToolCalls);
   const chatUsage = useDashboardStore((s) => s.chatUsage);
+  const chatPlan = useDashboardStore((s) => s.chatPlan);
+  const chatCommands = useDashboardStore((s) => s.chatCommands);
+  const chatConfig = useDashboardStore((s) => s.chatConfig);
   const sidePanelRole = useDashboardStore((s) => s.sidePanelRole);
   const send = useDashboardStore((s) => s.send);
 
   const [input, setInput] = useState("");
+  const [showSlashMenu, setShowSlashMenu] = useState(false);
+  const [slashFilter, setSlashFilter] = useState("");
+  const [showConfigDropdown, setShowConfigDropdown] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
 
   const activeMessages = activeChatId ? chatMessages[activeChatId] ?? [] : [];
   const streaming = activeChatId ? chatStreaming[activeChatId] : undefined;
   const thinking = activeChatId ? chatThinking[activeChatId] : undefined;
   const toolCalls = activeChatId ? chatToolCalls[activeChatId] : undefined;
   const usage = activeChatId ? chatUsage[activeChatId] : undefined;
+  const plan = activeChatId ? chatPlan[activeChatId] : undefined;
+  const commands = activeChatId ? chatCommands[activeChatId] : undefined;
+  const configs = activeChatId ? chatConfig[activeChatId] : undefined;
   const activeSession = chatSessions.find((s) => s.id === activeChatId);
   const isLoading = !activeSession && activeChatId !== "__global__" && activeChatId !== null;
 
@@ -51,7 +75,7 @@ export function SidePanel() {
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [activeMessages, streaming, thinking, toolCalls]);
+  }, [activeMessages, streaming, thinking, toolCalls, plan]);
 
   const handleClosePanel = () => {
     useDashboardStore.setState({ chatPanelOpen: false });
@@ -95,6 +119,26 @@ export function SidePanel() {
       },
     });
     setInput("");
+    setShowSlashMenu(false);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const val = e.target.value;
+    setInput(val);
+    // Slash command detection
+    if (val.startsWith("/") && commands && commands.length > 0) {
+      setShowSlashMenu(true);
+      setSlashFilter(val.slice(1).toLowerCase());
+    } else {
+      setShowSlashMenu(false);
+    }
+  };
+
+  const selectCommand = (cmd: ChatCommand) => {
+    const text = `/${cmd.name} `;
+    setInput(text);
+    setShowSlashMenu(false);
+    inputRef.current?.focus();
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -103,6 +147,10 @@ export function SidePanel() {
       handleSend();
     }
   };
+
+  const filteredCommands = commands?.filter((c) =>
+    c.name.toLowerCase().includes(slashFilter) || c.description.toLowerCase().includes(slashFilter),
+  ) ?? [];
 
   return (
     <div className="side-panel">
@@ -159,6 +207,35 @@ export function SidePanel() {
             })()}
           </button>
         )}
+        {configs && configs.length > 0 && configs.map((cfg) => (
+          <div key={cfg.id} className="side-panel-config-wrapper">
+            <button
+              className="side-panel-config-btn"
+              onClick={() => setShowConfigDropdown(showConfigDropdown === cfg.id ? null : cfg.id)}
+              title={cfg.name}
+            >
+              {cfg.name}: {cfg.options.find((o) => o.value === cfg.currentValue)?.name ?? cfg.currentValue}
+            </button>
+            {showConfigDropdown === cfg.id && (
+              <div className="side-panel-config-dropdown">
+                {cfg.options.map((opt) => (
+                  <button
+                    key={opt.value}
+                    className={`side-panel-config-option${opt.value === cfg.currentValue ? " active" : ""}`}
+                    onClick={() => {
+                      if (activeChatId) {
+                        send({ type: "chat:set-config", sessionId: activeChatId, optionId: cfg.id, value: opt.value });
+                      }
+                      setShowConfigDropdown(null);
+                    }}
+                  >
+                    {opt.name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
       </div>
 
       <div className="side-panel-messages">
@@ -197,7 +274,34 @@ export function SidePanel() {
                 <span className="chat-tool-icon">
                   {tc.status === "completed" ? "✓" : tc.status === "failed" ? "✗" : "⟳"}
                 </span>
+                <span className="chat-tool-kind">{TOOL_KIND_ICONS[tc.kind ?? ""] ?? "🔧"}</span>
                 <span className="chat-tool-title">{tc.title}</span>
+                {tc.locations && tc.locations.length > 0 && (
+                  <span className="chat-tool-locations">
+                    {tc.locations.map((l, i) => (
+                      <span key={i} className="chat-tool-location">
+                        {l.path.split("/").pop()}{l.line ? `:${l.line}` : ""}
+                      </span>
+                    ))}
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Plan progress */}
+        {plan && plan.length > 0 && (
+          <div className="chat-plan">
+            <div className="chat-plan-header">
+              📋 Plan ({plan.filter((e) => e.status === "completed").length}/{plan.length})
+            </div>
+            {plan.map((entry, i) => (
+              <div key={i} className={`chat-plan-entry chat-plan-${entry.status}`}>
+                <span className="chat-plan-check">
+                  {entry.status === "completed" ? "✓" : entry.status === "in_progress" ? "⟳" : "○"}
+                </span>
+                <span className="chat-plan-text">{entry.content}</span>
               </div>
             ))}
           </div>
@@ -230,13 +334,33 @@ export function SidePanel() {
         </div>
       )}
 
+      {/* Slash command menu */}
+      {showSlashMenu && filteredCommands.length > 0 && (
+        <div className="slash-menu">
+          {filteredCommands.map((cmd) => (
+            <button
+              key={cmd.name}
+              className="slash-menu-item"
+              onClick={() => selectCommand(cmd)}
+            >
+              <span className="slash-menu-name">/{cmd.name}</span>
+              <span className="slash-menu-desc">{cmd.description}</span>
+            </button>
+          ))}
+        </div>
+      )}
+
       <div className="side-panel-input-row">
         <textarea
+          ref={inputRef}
           className="side-panel-input"
-          placeholder="Ask something… (Enter to send, Shift+Enter for new line)"
+          placeholder={commands && commands.length > 0
+            ? "Type / for commands or ask something…"
+            : "Ask something… (Enter to send, Shift+Enter for new line)"}
           value={input}
-          onChange={(e) => setInput(e.target.value)}
+          onChange={handleInputChange}
           onKeyDown={handleKeyDown}
+          onBlur={() => setTimeout(() => setShowSlashMenu(false), 200)}
           rows={2}
           autoFocus
         />

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -14,6 +14,27 @@ export interface ChatToolCall {
   title: string;
   status?: string;
   kind?: string;
+  locations?: Array<{ path: string; line?: number }>;
+}
+
+export interface ChatPlanEntry {
+  content: string;
+  priority: "high" | "medium" | "low";
+  status: "pending" | "in_progress" | "completed";
+}
+
+export interface ChatCommand {
+  name: string;
+  description: string;
+  hint?: string;
+}
+
+export interface ChatConfigOption {
+  id: string;
+  name: string;
+  category?: string;
+  currentValue: string;
+  options: Array<{ value: string; name: string }>;
 }
 
 export interface DashboardStore {
@@ -46,6 +67,9 @@ export interface DashboardStore {
   chatThinking: Record<string, string>;
   chatToolCalls: Record<string, ChatToolCall[]>;
   chatUsage: Record<string, { used: number; size: number }>;
+  chatPlan: Record<string, ChatPlanEntry[]>;
+  chatCommands: Record<string, ChatCommand[]>;
+  chatConfig: Record<string, ChatConfigOption[]>;
   chatPanelOpen: boolean;
   sidePanelRole: string | null;
   pendingChatMessage: string | null;
@@ -304,16 +328,22 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
         title: string;
         status?: string;
         kind?: string;
+        locations?: Array<{ uri?: string; path?: string; line?: number }>;
       } | undefined;
       if (p) {
         set((prev) => {
           const existing = prev.chatToolCalls[p.sessionId] ?? [];
           const idx = existing.findIndex((t) => t.toolCallId === p.toolCallId);
+          const locs = p.locations?.map((l) => ({
+            path: l.path ?? l.uri?.replace("file://", "") ?? "",
+            line: l.line,
+          }));
           const entry: ChatToolCall = {
             toolCallId: p.toolCallId,
             title: p.title,
             status: p.status,
             kind: p.kind,
+            locations: locs,
           };
           const updated = idx >= 0
             ? existing.map((t, i) => (i === idx ? entry : t))
@@ -350,6 +380,39 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
           chatSessions: prev.chatSessions.map((s) =>
             s.id === p.sessionId ? { ...s, modeId: p.modeId } : s,
           ),
+        }));
+      }
+      break;
+    }
+
+    case "chat:plan": {
+      const p = msg.payload as { sessionId: string; entries: ChatPlanEntry[] } | undefined;
+      if (p) {
+        set((prev) => ({
+          ...prev,
+          chatPlan: { ...prev.chatPlan, [p.sessionId]: p.entries },
+        }));
+      }
+      break;
+    }
+
+    case "chat:commands": {
+      const p = msg.payload as { sessionId: string; commands: ChatCommand[] } | undefined;
+      if (p) {
+        set((prev) => ({
+          ...prev,
+          chatCommands: { ...prev.chatCommands, [p.sessionId]: p.commands },
+        }));
+      }
+      break;
+    }
+
+    case "chat:config": {
+      const p = msg.payload as { sessionId: string; configs: ChatConfigOption[] } | undefined;
+      if (p) {
+        set((prev) => ({
+          ...prev,
+          chatConfig: { ...prev.chatConfig, [p.sessionId]: p.configs },
         }));
       }
       break;
@@ -578,6 +641,9 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
   chatThinking: {},
   chatToolCalls: {},
   chatUsage: {},
+  chatPlan: {},
+  chatCommands: {},
+  chatConfig: {},
   chatPanelOpen: false,
   sidePanelRole: null,
   pendingChatMessage: null,

--- a/src/dashboard/frontend/src/types.ts
+++ b/src/dashboard/frontend/src/types.ts
@@ -19,6 +19,9 @@ export interface ServerMessage {
     | "chat:tool-call"
     | "chat:usage"
     | "chat:mode"
+    | "chat:plan"
+    | "chat:commands"
+    | "chat:config"
     | "pong";
   eventName?: string;
   payload?: unknown;
@@ -44,6 +47,7 @@ export interface ClientMessage {
     | "chat:send"
     | "chat:close"
     | "chat:set-mode"
+    | "chat:set-config"
     | "blocked:comment"
     | "blocked:unblock"
     | "decisions:approve"
@@ -58,6 +62,8 @@ export interface ClientMessage {
   mode?: string;
   body?: string;
   limit?: number;
+  optionId?: string;
+  value?: string;
 }
 
 /** Sprint state from server. */

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -31,7 +31,7 @@ export interface IssueEntry {
 
 /** Message sent from server to browser clients. */
 export interface ServerMessage {
-  type: "sprint:event" | "sprint:state" | "sprint:issues" | "sprint:switched" | "backlog:planned" | "backlog:removed" | "backlog:error" | "session:list" | "session:output" | "session:status" | "chat:chunk" | "chat:done" | "chat:created" | "chat:error" | "chat:thinking" | "chat:tool-call" | "chat:usage" | "chat:mode" | "pong";
+  type: "sprint:event" | "sprint:state" | "sprint:issues" | "sprint:switched" | "backlog:planned" | "backlog:removed" | "backlog:error" | "session:list" | "session:output" | "session:status" | "chat:chunk" | "chat:done" | "chat:created" | "chat:error" | "chat:thinking" | "chat:tool-call" | "chat:usage" | "chat:mode" | "chat:plan" | "chat:commands" | "chat:config" | "pong";
   eventName?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   payload?: any;
@@ -39,7 +39,7 @@ export interface ServerMessage {
 
 /** Message sent from browser client to server. */
 export interface ClientMessage {
-  type: "sprint:start" | "sprint:stop" | "sprint:pause" | "sprint:resume" | "sprint:switch" | "sprint:set-limit" | "mode:set" | "backlog:plan-issue" | "backlog:remove-issue" | "session:subscribe" | "session:unsubscribe" | "session:send-message" | "session:stop" | "chat:create" | "chat:send" | "chat:close" | "chat:set-mode" | "blocked:comment" | "blocked:unblock" | "decisions:approve" | "decisions:reject" | "decisions:comment" | "ping";
+  type: "sprint:start" | "sprint:stop" | "sprint:pause" | "sprint:resume" | "sprint:switch" | "sprint:set-limit" | "mode:set" | "backlog:plan-issue" | "backlog:remove-issue" | "session:subscribe" | "session:unsubscribe" | "session:send-message" | "session:stop" | "chat:create" | "chat:send" | "chat:close" | "chat:set-mode" | "chat:set-config" | "blocked:comment" | "blocked:unblock" | "decisions:approve" | "decisions:reject" | "decisions:comment" | "ping";
   sprintNumber?: number;
   issueNumber?: number;
   sessionId?: string;
@@ -48,6 +48,8 @@ export interface ClientMessage {
   mode?: string;
   body?: string;
   limit?: number;
+  optionId?: string;
+  value?: string;
 }
 
 const MIME_TYPES: Record<string, string> = {
@@ -546,6 +548,11 @@ export class DashboardWebServer {
           this.handleChatSetMode(msg.sessionId, msg.mode, ws);
         }
         break;
+      case "chat:set-config":
+        if (msg.sessionId && msg.optionId && msg.value) {
+          this.handleChatSetConfig(msg.sessionId, msg.optionId, msg.value, ws);
+        }
+        break;
       case "session:subscribe":
         if (msg.sessionId) {
           let subs = this.sessionSubscribers.get(msg.sessionId);
@@ -665,6 +672,24 @@ export class DashboardWebServer {
             payload: { sessionId: chatId, modeId },
           });
         },
+        onPlanUpdate: (chatId, plan) => {
+          this.broadcast({
+            type: "chat:plan",
+            payload: { sessionId: chatId, entries: plan.entries },
+          });
+        },
+        onCommandsUpdate: (chatId, commands) => {
+          this.broadcast({
+            type: "chat:commands",
+            payload: { sessionId: chatId, commands },
+          });
+        },
+        onConfigUpdate: (chatId, configs) => {
+          this.broadcast({
+            type: "chat:config",
+            payload: { sessionId: chatId, configs },
+          });
+        },
       });
     }
     return this.chatManager;
@@ -738,6 +763,19 @@ export class DashboardWebServer {
       this.sendTo(ws, {
         type: "chat:error",
         payload: { sessionId, error: `Failed to set mode: ${msg}` },
+      });
+    }
+  }
+
+  private async handleChatSetConfig(sessionId: string, optionId: string, value: string, ws: WebSocket): Promise<void> {
+    try {
+      await this.getChatManager().setConfig(sessionId, optionId, value);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error({ err, sessionId, optionId, value }, "Failed to set chat config");
+      this.sendTo(ws, {
+        type: "chat:error",
+        payload: { sessionId, error: `Failed to set config: ${msg}` },
       });
     }
   }


### PR DESCRIPTION
## Summary
Wire up remaining ACP protocol events to the dashboard: slash commands, config options, plan progress, and enriched tool calls.

## Changes

### 1. Slash Commands (`available_commands_update`)
- Type `/` in chat input → shows available agent commands as dropdown
- Filtered as you type, click to insert command
- Agent advertises commands dynamically during session

### 2. Config Options (`config_option_update`)
- Agent-provided config dropdowns appear in side panel header
- Shows model picker, thought level, or any agent-defined config
- Click to select → sends `chat:set-config` → ACP `setSessionConfigOption()`

### 3. Plan Progress (`plan`)
- VS Code style plan panel with task list
- Shows ○ pending / ⟳ in_progress / ✓ completed status
- Completed items are struck-through, active item is highlighted
- Progress counter in header (e.g., "📋 Plan (2/5)")

### 4. Rich Tool Calls
- Kind icons: 📖 read, ✏️ edit, 🔍 search, ▶️ execute, etc.
- File locations shown inline (filename:line)
- Full pipeline through all layers

### Pipeline (all 4 features)
`AcpClient` → `ChatManager` → `ws-server` → WebSocket → `store` → `SidePanel`

## Testing
- `npx tsc --noEmit` ✅
- `npx vitest run` ✅ 573/573
- `npm run build` ✅