### PR TITLE
fix: replace config pills with ⚙️ settings icon

### DIFF
--- a/src/dashboard/frontend/src/components/SidePanel.css
+++ b/src/dashboard/frontend/src/components/SidePanel.css
@@ -492,61 +492,63 @@
   white-space: nowrap;
 }
 
-/* Config dropdowns */
+/* Settings icon and panel */
 .side-panel-config-wrapper {
   position: relative;
+  margin-left: auto;
 }
-.side-panel-config-btn {
-  font-size: 10px;
-  padding: 2px 8px;
-  border-radius: 10px;
-  border: 1px solid var(--border);
-  background: var(--bg);
-  color: var(--text-dim);
+.side-panel-settings-btn {
+  font-size: 14px;
+  padding: 2px 4px;
+  border: none;
+  background: none;
   cursor: pointer;
-  font-family: var(--font);
-  transition: all 0.15s;
-  white-space: nowrap;
-  max-width: 180px;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  opacity: 0.6;
+  transition: opacity 0.15s;
+  line-height: 1;
 }
-.side-panel-config-btn:hover {
-  color: var(--text);
-  border-color: var(--accent);
-  background: var(--bg-hover);
+.side-panel-settings-btn:hover {
+  opacity: 1;
 }
-.side-panel-config-dropdown {
+.side-panel-settings-panel {
   position: absolute;
   top: 100%;
   right: 0;
   margin-top: 4px;
   background: var(--bg-panel);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  min-width: 160px;
-  max-height: 240px;
-  overflow-y: auto;
+  border-radius: 8px;
+  min-width: 220px;
+  padding: 8px;
   z-index: 100;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
-.side-panel-config-option {
-  display: block;
-  width: 100%;
-  padding: 6px 12px;
-  border: none;
-  background: none;
-  color: var(--text-dim);
-  font-size: 11px;
-  cursor: pointer;
-  text-align: left;
-  font-family: var(--font);
+.settings-group {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
 }
-.side-panel-config-option:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-.side-panel-config-option.active {
-  color: var(--accent);
+.settings-label {
+  font-size: 10px;
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-dim);
+}
+.settings-select {
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-family: var(--font);
+  cursor: pointer;
+  outline: none;
+}
+.settings-select:focus {
+  border-color: var(--accent);
 }

--- a/src/dashboard/frontend/src/components/SidePanel.tsx
+++ b/src/dashboard/frontend/src/components/SidePanel.tsx
@@ -66,7 +66,7 @@ export function SidePanel() {
   const [input, setInput] = useState("");
   const [showSlashMenu, setShowSlashMenu] = useState(false);
   const [slashFilter, setSlashFilter] = useState("");
-  const [showConfigDropdown, setShowConfigDropdown] = useState<string | null>(null);
+  const [showSettings, setShowSettings] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -218,35 +218,39 @@ export function SidePanel() {
             })()}
           </button>
         )}
-        {configs && configs.length > 0 && configs.map((cfg) => (
-          <div key={cfg.id} className="side-panel-config-wrapper">
+        {configs && configs.length > 0 && (
+          <div className="side-panel-config-wrapper">
             <button
-              className="side-panel-config-btn"
-              onClick={() => setShowConfigDropdown(showConfigDropdown === cfg.id ? null : cfg.id)}
-              title={cfg.name}
+              className="side-panel-settings-btn"
+              onClick={() => setShowSettings(!showSettings)}
+              title="Session settings"
             >
-              {cfg.name}: {cfg.options.find((o) => o.value === cfg.currentValue)?.name ?? cfg.currentValue}
+              ⚙️
             </button>
-            {showConfigDropdown === cfg.id && (
-              <div className="side-panel-config-dropdown">
-                {cfg.options.map((opt) => (
-                  <button
-                    key={opt.value}
-                    className={`side-panel-config-option${opt.value === cfg.currentValue ? " active" : ""}`}
-                    onClick={() => {
-                      if (activeChatId) {
-                        send({ type: "chat:set-config", sessionId: activeChatId, optionId: cfg.id, value: opt.value });
-                      }
-                      setShowConfigDropdown(null);
-                    }}
-                  >
-                    {opt.name}
-                  </button>
+            {showSettings && (
+              <div className="side-panel-settings-panel">
+                {configs.map((cfg) => (
+                  <div key={cfg.id} className="settings-group">
+                    <label className="settings-label">{cfg.name}</label>
+                    <select
+                      className="settings-select"
+                      value={cfg.currentValue}
+                      onChange={(e) => {
+                        if (activeChatId) {
+                          send({ type: "chat:set-config", sessionId: activeChatId, optionId: cfg.id, value: e.target.value });
+                        }
+                      }}
+                    >
+                      {cfg.options.map((opt) => (
+                        <option key={opt.value} value={opt.value}>{opt.name}</option>
+                      ))}
+                    </select>
+                  </div>
                 ))}
               </div>
             )}
           </div>
-        ))}
+        )}
       </div>
 
       <div className="side-panel-messages">


### PR DESCRIPTION
Config options (Mode, Model, Reasoning Effort) cluttered the header as individual pill buttons. Now consolidated behind a single ⚙️ icon that opens a settings dropdown panel with native select elements.