### PR TITLE
feat: reasoning effort chips in model popup

### DIFF
--- a/src/dashboard/frontend/src/components/SidePanel.css
+++ b/src/dashboard/frontend/src/components/SidePanel.css
@@ -200,8 +200,48 @@
 }
 .mode-selector-menu.model-menu {
   min-width: 220px;
-  max-height: 280px;
+  max-height: 320px;
   overflow-y: auto;
+}
+.model-menu-section {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-dim);
+  padding: 6px 12px 2px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.model-menu-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 8px;
+}
+.model-menu-reasoning {
+  display: flex;
+  gap: 4px;
+  padding: 4px 10px 8px;
+}
+.reasoning-chip {
+  flex: 1;
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text-dim);
+  font-size: 11px;
+  cursor: pointer;
+  text-align: center;
+  font-family: var(--font);
+  transition: all 0.15s;
+}
+.reasoning-chip:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+.reasoning-chip.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
 }
 .mode-selector-option {
   display: flex;

--- a/src/dashboard/frontend/src/components/SidePanel.tsx
+++ b/src/dashboard/frontend/src/components/SidePanel.tsx
@@ -216,7 +216,7 @@ export function SidePanel() {
         {activeSession?.model && (
           <span className="side-panel-model">{activeSession.model}</span>
         )}
-        {configs && configs.filter((c) => c.category !== "mode" && c.category !== "model").length > 0 && (
+        {configs && configs.filter((c) => c.category !== "mode" && c.category !== "model" && c.category !== "thought_level").length > 0 && (
           <div className="side-panel-config-wrapper">
             <button
               className="side-panel-settings-btn"
@@ -227,7 +227,7 @@ export function SidePanel() {
             </button>
             {showSettings && (
               <div className="side-panel-settings-panel">
-                {configs.filter((c) => c.category !== "mode" && c.category !== "model").map((cfg) => (
+                {configs.filter((c) => c.category !== "mode" && c.category !== "model" && c.category !== "thought_level").map((cfg) => (
                   <div key={cfg.id} className="settings-group">
                     <label className="settings-label">{cfg.name}</label>
                     <select
@@ -417,20 +417,25 @@ export function SidePanel() {
           </div>
           {(() => {
             const modelCfg = configs?.find((c) => c.category === "model");
+            const reasoningCfg = configs?.find((c) => c.category === "thought_level");
             if (!modelCfg) return null;
             const currentOpt = modelCfg.options.find((o) => o.value === modelCfg.currentValue);
             const shortLabel = currentOpt?.name ?? modelCfg.currentValue;
+            const reasoningLabel = reasoningCfg
+              ? reasoningCfg.options.find((o) => o.value === reasoningCfg.currentValue)?.name ?? reasoningCfg.currentValue
+              : null;
             return (
               <div className="mode-selector-wrapper">
                 <button
                   className="mode-selector-btn"
                   onClick={() => { setShowModelMenu(!showModelMenu); setShowModeMenu(false); }}
                 >
-                  🧠 {shortLabel}
+                  🧠 {shortLabel}{reasoningLabel ? ` · ${reasoningLabel}` : ""}
                   <span className="mode-selector-arrow">▲</span>
                 </button>
                 {showModelMenu && (
                   <div className="mode-selector-menu model-menu">
+                    <div className="model-menu-section">Model</div>
                     {modelCfg.options.map((opt) => (
                       <button
                         key={opt.value}
@@ -445,6 +450,27 @@ export function SidePanel() {
                         {opt.name}
                       </button>
                     ))}
+                    {reasoningCfg && (
+                      <>
+                        <div className="model-menu-divider" />
+                        <div className="model-menu-section">Reasoning</div>
+                        <div className="model-menu-reasoning">
+                          {reasoningCfg.options.map((opt) => (
+                            <button
+                              key={opt.value}
+                              className={`reasoning-chip${opt.value === reasoningCfg.currentValue ? " active" : ""}`}
+                              onClick={() => {
+                                if (activeChatId) {
+                                  send({ type: "chat:set-config", sessionId: activeChatId, optionId: reasoningCfg.id, value: opt.value });
+                                }
+                              }}
+                            >
+                              {opt.name}
+                            </button>
+                          ))}
+                        </div>
+                      </>
+                    )}
                   </div>
                 )}
               </div>


### PR DESCRIPTION
Model popup now has two sections: Model list + Reasoning chips (low/mid/high). Button shows both: '🧠 Claude Sonnet · medium'. Reasoning removed from settings.