### PR TITLE
fix: clear stale chat state on WebSocket reconnect

### DIFF
--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -137,7 +137,20 @@ function createWebSocket(set: SetFn, get: GetFn): void {
   };
 
   ws.onclose = () => {
-    set({ connected: false });
+    set({
+      connected: false,
+      chatSessions: [],
+      activeChatId: null,
+      generalChatId: null,
+      chatMessages: {},
+      chatStreaming: {},
+      chatThinking: {},
+      chatToolCalls: {},
+      chatUsage: {},
+      chatPlan: {},
+      chatCommands: {},
+      chatConfig: {},
+    });
     ws = null;
     setTimeout(() => createWebSocket(set, get), 2000);
   };


### PR DESCRIPTION
Old chat session IDs became invalid after server restart, causing config/model changes to fail with 'session not found'. Now clears all chat state on disconnect so reconnection starts fresh.