### PR TITLE
fix: model selector works, add stop button

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -452,7 +452,16 @@ export class AcpClient {
   async setConfigOption(sessionId: string, optionId: string, value: string): Promise<void> {
     const conn = this.requireConnection();
     this.log.info({ sessionId, optionId, value }, "setting session config option");
-    await conn.setSessionConfigOption({ sessionId, configOptionId: optionId, value });
+    await conn.setSessionConfigOption({ sessionId, configId: optionId, value });
+  }
+
+  /**
+   * Cancel an in-progress prompt turn.
+   */
+  async cancelSession(sessionId: string): Promise<void> {
+    const conn = this.requireConnection();
+    this.log.info({ sessionId }, "cancelling session");
+    await conn.cancel({ sessionId });
   }
 
   /**

--- a/src/dashboard/chat-manager.ts
+++ b/src/dashboard/chat-manager.ts
@@ -212,6 +212,15 @@ export class ChatManager {
     log.info({ chatId, optionId, value }, "Chat session config changed");
   }
 
+  /** Cancel an in-progress prompt turn. */
+  async cancelSession(chatId: string): Promise<void> {
+    const session = this.sessions.get(chatId);
+    if (!session) throw new Error(`Chat session ${chatId} not found`);
+    const client = await this.ensureClient();
+    await client.cancelSession(session.acpSessionId);
+    log.info({ chatId }, "Chat session cancelled");
+  }
+
   /** Get a chat session by ID. */
   getSession(chatId: string): ChatSession | undefined {
     return this.sessions.get(chatId);

--- a/src/dashboard/frontend/src/components/SidePanel.tsx
+++ b/src/dashboard/frontend/src/components/SidePanel.tsx
@@ -369,9 +369,21 @@ export function SidePanel() {
           rows={2}
           autoFocus
         />
-        <button className="btn btn-primary btn-small" onClick={handleSend}>
-          Send
-        </button>
+        {(streaming || thinking) ? (
+          <button
+            className="btn btn-danger btn-icon"
+            onClick={() => {
+              if (activeChatId) send({ type: "chat:cancel", sessionId: activeChatId });
+            }}
+            title="Stop"
+          >
+            ■
+          </button>
+        ) : (
+          <button className="btn btn-primary btn-icon" onClick={handleSend} title="Send">
+            ▶
+          </button>
+        )}
       </div>
 
       {/* Mode & Model selectors */}

--- a/src/dashboard/frontend/src/index.css
+++ b/src/dashboard/frontend/src/index.css
@@ -45,6 +45,7 @@ body {
 }
 .btn:hover { background: var(--border); }
 .btn-small { padding: 3px 8px; font-size: 12px; }
+.btn-icon { width: 36px; height: 36px; padding: 0; font-size: 14px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
 .btn-primary { background: var(--green); color: #000; border-color: var(--green); }
 .btn-primary:hover { opacity: 0.85; }
 .btn-danger { background: var(--red); color: #fff; border-color: var(--red); }

--- a/src/dashboard/frontend/src/types.ts
+++ b/src/dashboard/frontend/src/types.ts
@@ -46,6 +46,7 @@ export interface ClientMessage {
     | "chat:create"
     | "chat:send"
     | "chat:close"
+    | "chat:cancel"
     | "chat:set-mode"
     | "chat:set-config"
     | "blocked:comment"

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -39,7 +39,7 @@ export interface ServerMessage {
 
 /** Message sent from browser client to server. */
 export interface ClientMessage {
-  type: "sprint:start" | "sprint:stop" | "sprint:pause" | "sprint:resume" | "sprint:switch" | "sprint:set-limit" | "mode:set" | "backlog:plan-issue" | "backlog:remove-issue" | "session:subscribe" | "session:unsubscribe" | "session:send-message" | "session:stop" | "chat:create" | "chat:send" | "chat:close" | "chat:set-mode" | "chat:set-config" | "blocked:comment" | "blocked:unblock" | "decisions:approve" | "decisions:reject" | "decisions:comment" | "ping";
+  type: "sprint:start" | "sprint:stop" | "sprint:pause" | "sprint:resume" | "sprint:switch" | "sprint:set-limit" | "mode:set" | "backlog:plan-issue" | "backlog:remove-issue" | "session:subscribe" | "session:unsubscribe" | "session:send-message" | "session:stop" | "chat:create" | "chat:send" | "chat:close" | "chat:cancel" | "chat:set-mode" | "chat:set-config" | "blocked:comment" | "blocked:unblock" | "decisions:approve" | "decisions:reject" | "decisions:comment" | "ping";
   sprintNumber?: number;
   issueNumber?: number;
   sessionId?: string;
@@ -543,6 +543,11 @@ export class DashboardWebServer {
           this.handleChatClose(msg.sessionId);
         }
         break;
+      case "chat:cancel":
+        if (msg.sessionId) {
+          this.handleChatCancel(msg.sessionId, ws);
+        }
+        break;
       case "chat:set-mode":
         if (msg.sessionId && msg.mode) {
           this.handleChatSetMode(msg.sessionId, msg.mode, ws);
@@ -778,6 +783,19 @@ export class DashboardWebServer {
       this.sendTo(ws, {
         type: "chat:error",
         payload: { sessionId, error: `Failed to set config: ${msg}` },
+      });
+    }
+  }
+
+  private async handleChatCancel(sessionId: string, ws: WebSocket): Promise<void> {
+    try {
+      await this.getChatManager().cancelSession(sessionId);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error({ err, sessionId }, "Failed to cancel chat session");
+      this.sendTo(ws, {
+        type: "chat:error",
+        payload: { sessionId, error: `Failed to cancel: ${msg}` },
       });
     }
   }


### PR DESCRIPTION
- Fixed configId param (ACP SDK expects configId not configOptionId)
- Added cancel/stop support through full stack (ACP → chat-manager → ws-server → frontend)
- Send button now ▶ icon, red ■ stop button appears during streaming
- chat:cancel message type added