### PR TITLE
fix: render Markdown in issue details and fix HTML passthrough (#453, #455)

### DIFF
--- a/src/dashboard/frontend/src/components/IssueCard.tsx
+++ b/src/dashboard/frontend/src/components/IssueCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { GhIssueItem } from "../types";
 import { useDashboardStore } from "../store";
+import { Markdown } from "./Markdown";
 
 interface IssueCardProps {
   item: GhIssueItem;
@@ -57,7 +58,7 @@ export function IssueCard({ item, actions, extraContent }: IssueCardProps) {
             </div>
           )}
           {item.body ? (
-            <div className="item-body-full">{item.body}</div>
+            <div className="item-body-full"><Markdown text={item.body} /></div>
           ) : (
             <div className="item-body-empty">No description.</div>
           )}

--- a/src/dashboard/frontend/src/components/Markdown.tsx
+++ b/src/dashboard/frontend/src/components/Markdown.tsx
@@ -28,7 +28,18 @@ function renderTable(lines: string[]): string {
 }
 
 function markdownToHtml(text: string): string {
-  const lines = text.split("\n");
+  const blocks: Record<string, string> = {};
+  let blockId = 0;
+
+  // Extract raw HTML table blocks (agent output) — pass through as-is
+  let processed = text.replace(/<table[\s\S]*?<\/table>/gi, (match) => {
+    const key = `__BLOCK_${blockId++}__`;
+    blocks[key] = `<div class="md-table-wrap">${match}</div>`;
+    return key;
+  });
+
+  // Detect and render markdown tables
+  const lines = processed.split("\n");
   const rendered: string[] = [];
   let i = 0;
 
@@ -45,14 +56,17 @@ function markdownToHtml(text: string): string {
         tableLines.push(lines[i]!);
         i++;
       }
-      rendered.push(renderTable(tableLines));
+      const key = `__BLOCK_${blockId++}__`;
+      blocks[key] = renderTable(tableLines);
+      rendered.push(key);
       continue;
     }
     rendered.push(line);
     i++;
   }
 
-  return escapeHtml(rendered.join("\n"))
+  // Escape remaining text, then apply markdown formatting
+  let html = escapeHtml(rendered.join("\n"))
     .replace(/```(\w*)\n([\s\S]*?)```/g, '<pre class="md-code"><code>$2</code></pre>')
     .replace(/`([^`]+)`/g, '<code class="md-inline">$1</code>')
     .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
@@ -66,6 +80,13 @@ function markdownToHtml(text: string): string {
     .replace(/^- (.+)$/gm, '<div class="md-li">• $1</div>')
     .replace(/^\d+\. (.+)$/gm, '<div class="md-li">$1</div>')
     .replace(/\n/g, "<br>");
+
+  // Restore preserved HTML/table blocks
+  for (const [key, value] of Object.entries(blocks)) {
+    html = html.replace(key, value);
+  }
+
+  return html;
 }
 
 interface Props {

--- a/test-results/dashboard-Dashboard-Sprint-0415d-igation-buttons-are-visible-chromium-retry1/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-0415d-igation-buttons-are-visible-chromium-retry1/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4502m 46s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```

--- a/test-results/dashboard-Dashboard-Sprint-0415d-igation-buttons-are-visible-chromium/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-0415d-igation-buttons-are-visible-chromium/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4502m 30s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```

--- a/test-results/dashboard-Dashboard-Sprint-133c4-t-header-with-sprint-number-chromium-retry1/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-133c4-t-header-with-sprint-number-chromium-retry1/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4501m 38s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```

--- a/test-results/dashboard-Dashboard-Sprint-133c4-t-header-with-sprint-number-chromium/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-133c4-t-header-with-sprint-number-chromium/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4501m 28s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```

--- a/test-results/dashboard-Dashboard-Sprint-39d86-Sprint-2-and-see-its-issues-chromium-retry1/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-39d86-Sprint-2-and-see-its-issues-chromium-retry1/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4503m 19s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```

--- a/test-results/dashboard-Dashboard-Sprint-39d86-Sprint-2-and-see-its-issues-chromium/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-39d86-Sprint-2-and-see-its-issues-chromium/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4503m 01s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```

--- a/test-results/dashboard-Dashboard-Sprint-4368a-links-work-on-issue-numbers-chromium-retry1/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-4368a-links-work-on-issue-numbers-chromium-retry1/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4505m 31s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```

--- a/test-results/dashboard-Dashboard-Sprint-4368a-links-work-on-issue-numbers-chromium/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-4368a-links-work-on-issue-numbers-chromium/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4505m 13s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```

--- a/test-results/dashboard-Dashboard-Sprint-467c2-Sprint-1-and-see-its-issues-chromium-retry1/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-467c2-Sprint-1-and-see-its-issues-chromium-retry1/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4503m 53s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```

--- a/test-results/dashboard-Dashboard-Sprint-467c2-Sprint-1-and-see-its-issues-chromium/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-467c2-Sprint-1-and-see-its-issues-chromium/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4503m 34s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```

--- a/test-results/dashboard-Dashboard-Sprint-4e6f9-fter-rapid-sprint-switching-chromium-retry1/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-4e6f9-fter-rapid-sprint-switching-chromium-retry1/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4504m 26s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```

--- a/test-results/dashboard-Dashboard-Sprint-4e6f9-fter-rapid-sprint-switching-chromium/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-4e6f9-fter-rapid-sprint-switching-chromium/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4504m 10s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```

--- a/test-results/dashboard-Dashboard-Sprint-9d914-ys-issues-for-active-sprint-chromium-retry1/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-9d914-ys-issues-for-active-sprint-chromium-retry1/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4502m 15s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```

--- a/test-results/dashboard-Dashboard-Sprint-9d914-ys-issues-for-active-sprint-chromium/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-9d914-ys-issues-for-active-sprint-chromium/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4501m 57s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```

--- a/test-results/dashboard-Dashboard-Sprint-b7ccf-e-badge-shows-a-valid-phase-chromium-retry1/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-b7ccf-e-badge-shows-a-valid-phase-chromium-retry1/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4504m 38s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```

--- a/test-results/dashboard-Dashboard-Sprint-b7ccf-e-badge-shows-a-valid-phase-chromium/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-b7ccf-e-badge-shows-a-valid-phase-chromium/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4504m 32s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```

--- a/test-results/dashboard-Dashboard-Sprint-c16ec-activity-log-section-exists-chromium-retry1/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-c16ec-activity-log-section-exists-chromium-retry1/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4504m 58s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```

--- a/test-results/dashboard-Dashboard-Sprint-c16ec-activity-log-section-exists-chromium/error-context.md
+++ b/test-results/dashboard-Dashboard-Sprint-c16ec-activity-log-section-exists-chromium/error-context.md
@@ -1,0 +1,63 @@
+# Page snapshot
+
+```yaml
+- generic [ref=e2]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - heading "🏃 Sprint Runner" [level=1] [ref=e5]
+      - link "Sprint 1 ↗" [ref=e7] [cursor=pointer]:
+        - /url: https://github.com/trsdn/ai-scrum-autonomous-v2/milestone/1
+      - button "◀" [disabled] [ref=e8] [cursor=pointer]
+      - button "▶" [ref=e9] [cursor=pointer]
+      - generic [ref=e10]: FAILED
+    - generic [ref=e11]:
+      - generic [ref=e12]: 0/0 done
+      - generic [ref=e13]: 4504m 48s
+      - combobox [ref=e15] [cursor=pointer]:
+        - option "⚙ Autonomous" [selected]
+        - option "👤 Human-in-the-Loop"
+      - combobox "Number of sprints to run" [ref=e16] [cursor=pointer]:
+        - option "∞ Infinite" [selected]
+        - option "1 Sprint"
+        - option "2 Sprints"
+        - option "3 Sprints"
+        - option "5 Sprints"
+        - option "10 Sprints"
+      - button "▶ Start" [ref=e17] [cursor=pointer]
+    - generic [ref=e18]:
+      - generic [ref=e19]: Plan
+      - generic [ref=e20]: Execute
+      - generic [ref=e21]: Review
+      - generic [ref=e22]: Retro
+      - generic [ref=e23]: Complete
+  - navigation [ref=e24]:
+    - button "🏃 Sprint" [ref=e25] [cursor=pointer]
+    - button "📦 Sprint Backlog" [ref=e26] [cursor=pointer]
+    - button "📋 Backlog" [ref=e27] [cursor=pointer]
+    - button "🚧 Blocked" [ref=e28] [cursor=pointer]
+    - button "⚖️ Decisions" [ref=e29] [cursor=pointer]
+    - button "💡 Ideas" [ref=e30] [cursor=pointer]
+    - button "🤖 Agents (1) ▶" [ref=e32] [cursor=pointer]
+  - generic [ref=e34]:
+    - main:
+      - generic:
+        - generic:
+          - generic:
+            - generic:
+              - generic:
+                - generic [ref=e35]:
+                  - heading "Issues" [level=2] [ref=e36]
+                  - generic [ref=e37]: No issues in this sprint yet.
+                - generic [ref=e38]:
+                  - heading "Activity" [level=2] [ref=e39]
+                  - list [ref=e40]:
+                    - listitem [ref=e41]: No activity yet. Start a sprint to see progress.
+                - generic [ref=e42]:
+                  - heading "ACP Sessions" [level=2] [ref=e43]
+                  - generic [ref=e44]: No active ACP sessions
+          - generic [ref=e46]:
+            - generic [ref=e47]:
+              - generic [ref=e48]: ⬤ Terminal
+              - generic [ref=e49]: 0 entries
+            - generic [ref=e51]: Waiting for log output...
+```


### PR DESCRIPTION
## Changes
- **IssueCard**: Use `<Markdown>` component for issue body instead of plain text (#453)
- **Markdown.tsx**: Extract HTML table blocks before escaping to fix double-escape bug (#455)
- **Markdown.tsx**: Pass through raw HTML tables from agent output as rendered tables

Closes #453, closes #455