### PR TITLE
fix: use milestone ID for sprint GitHub links (#457)

### DIFF
--- a/src/dashboard/frontend/src/components/Header.tsx
+++ b/src/dashboard/frontend/src/components/Header.tsx
@@ -48,8 +48,10 @@ export function Header() {
     return () => { if (timerRef.current) clearInterval(timerRef.current); };
   }, [state.startedAt, state.finalElapsed]);
 
+  const currentSprint = availableSprints.find((s) => s.sprintNumber === viewingSprintNumber);
+  const milestoneId = currentSprint?.milestoneNumber ?? displayNumber;
   const sprintLabel = repoUrl
-    ? <a href={`${repoUrl}/milestone/${displayNumber}`} target="_blank" rel="noopener">Sprint {displayNumber} ↗</a>
+    ? <a href={`${repoUrl}/milestone/${milestoneId}`} target="_blank" rel="noopener">Sprint {displayNumber} ↗</a>
     : `Sprint ${displayNumber}`;
 
   return (

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -46,7 +46,7 @@ export interface DashboardStore {
   issues: SprintIssue[];
   activeSprintNumber: number;
   viewingSprintNumber: number;
-  availableSprints: { sprintNumber: number }[];
+  availableSprints: { sprintNumber: number; milestoneNumber?: number }[];
   repoUrl: string | null;
 
   // Activities & logs
@@ -688,7 +688,7 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
       .catch(() => {});
     fetch("/api/sprints")
       .then((r) => r.json())
-      .then((d: { sprintNumber: number }[]) => {
+      .then((d: { sprintNumber: number; milestoneNumber?: number }[]) => {
         if (Array.isArray(d)) set({ availableSprints: d });
       })
       .catch(() => {});
@@ -752,7 +752,7 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
     // Refresh sprint list
     fetch("/api/sprints")
       .then((r) => r.json())
-      .then((d: { sprintNumber: number }[]) => {
+      .then((d: { sprintNumber: number; milestoneNumber?: number }[]) => {
         if (Array.isArray(d)) set({ availableSprints: d });
       })
       .catch(() => {});

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -116,7 +116,7 @@ export class DashboardWebServer {
   private readonly options: DashboardServerOptions;
   private readonly publicDir: string;
   private eventBuffer: BufferedEvent[] = [];
-  private knownMilestones: { sprintNumber: number; title: string; state: string }[] = [];
+  private knownMilestones: { sprintNumber: number; milestoneNumber: number; title: string; state: string }[] = [];
   private executionMode: "autonomous" | "hitl" = "autonomous";
   private activeSprintNumberOverride: number | undefined;
   public sprintLimit = 0;
@@ -1276,10 +1276,10 @@ export class DashboardWebServer {
   }
 
   /** List available sprints by scanning state files, log files, and filling gaps. */
-  private listSprints(): { sprintNumber: number; phase: string; isActive: boolean }[] {
+  private listSprints(): { sprintNumber: number; milestoneNumber?: number; phase: string; isActive: boolean }[] {
     const projectPath = this.options.projectPath ?? process.cwd();
     const sprintsDir = path.join(projectPath, "docs", "sprints");
-    const sprintMap = new Map<number, { phase: string; isActive: boolean }>();
+    const sprintMap = new Map<number, { milestoneNumber?: number; phase: string; isActive: boolean }>();
     const slug = this.options.sprintSlug ?? "sprint";
     const stateRegex = new RegExp(`^${slug}-(\\d+)-state\\.json$`);
     const logRegex = new RegExp(`^${slug}-(\\d+)-log\\.md$`);
@@ -1328,9 +1328,16 @@ export class DashboardWebServer {
     for (const ms of this.knownMilestones) {
       if (!sprintMap.has(ms.sprintNumber)) {
         sprintMap.set(ms.sprintNumber, {
+          milestoneNumber: ms.milestoneNumber,
           phase: ms.state === "closed" ? "complete" : "init",
           isActive: ms.sprintNumber === activeNum,
         });
+      } else {
+        // Enrich existing entry with milestoneNumber
+        const existing = sprintMap.get(ms.sprintNumber)!;
+        if (!existing.milestoneNumber) {
+          existing.milestoneNumber = ms.milestoneNumber;
+        }
       }
     }
 

--- a/src/github/milestones.ts
+++ b/src/github/milestones.ts
@@ -138,7 +138,7 @@ export async function closeMilestone(title: string): Promise<void> {
 }
 
 /** List all milestones matching the given prefix (e.g. "Sprint" → "Sprint 1", "Sprint 2"). */
-export async function listSprintMilestones(prefix: string = "Sprint"): Promise<{ sprintNumber: number; title: string; state: string }[]> {
+export async function listSprintMilestones(prefix: string = "Sprint"): Promise<{ sprintNumber: number; milestoneNumber: number; title: string; state: string }[]> {
   const allMilestones: GitHubMilestone[] = [];
 
   // Query both open and closed milestones (GitHub API only allows one state at a time)
@@ -169,7 +169,7 @@ export async function listSprintMilestones(prefix: string = "Sprint"): Promise<{
   }
 
   return allMilestones
-    .map((m) => ({ sprintNumber: parseSprintFromTitle(m.title, prefix), title: m.title, state: m.state }))
-    .filter((x): x is { sprintNumber: number; title: string; state: string } => x.sprintNumber !== undefined)
+    .map((m) => ({ sprintNumber: parseSprintFromTitle(m.title, prefix), milestoneNumber: m.number, title: m.title, state: m.state }))
+    .filter((x): x is { sprintNumber: number; milestoneNumber: number; title: string; state: string } => x.sprintNumber !== undefined)
     .sort((a, b) => a.sprintNumber - b.sprintNumber);
 }


### PR DESCRIPTION
Sprint link in header used sprint number (e.g., 1) instead of GitHub milestone ID. Now passes milestoneNumber through the full stack.

Closes #457