### PR TITLE
fix: sprint backlog respects viewing sprint selection (#450)

### DIFF
--- a/src/dashboard/frontend/src/components/SprintBacklogTab.tsx
+++ b/src/dashboard/frontend/src/components/SprintBacklogTab.tsx
@@ -9,10 +9,12 @@ export function SprintBacklogTab() {
   const [sprintNumber, setSprintNumber] = useState(0);
   const [loading, setLoading] = useState(true);
   const send = useDashboardStore((s) => s.send);
+  const viewingSprintNumber = useDashboardStore((s) => s.viewingSprintNumber);
 
-  const fetchItems = () => {
+  const fetchItems = (sprint?: number) => {
     setLoading(true);
-    fetch("/api/sprint-backlog")
+    const url = sprint && sprint > 0 ? `/api/sprint-backlog?sprint=${sprint}` : "/api/sprint-backlog";
+    fetch(url)
       .then((r) => r.json())
       .then((d) => {
         setSprintNumber(d.sprintNumber ?? 0);
@@ -22,7 +24,7 @@ export function SprintBacklogTab() {
       .finally(() => setLoading(false));
   };
 
-  useEffect(() => { fetchItems(); }, []);
+  useEffect(() => { fetchItems(viewingSprintNumber); }, [viewingSprintNumber]);
 
   const handleRemove = (issueNumber: number) => {
     if (confirm(`Remove #${issueNumber} from Sprint ${sprintNumber}?`)) {
@@ -38,7 +40,7 @@ export function SprintBacklogTab() {
     <div className="tab-list-container">
       <div className="tab-list-header">
         <h2>📦 Sprint {sprintNumber} Backlog ({items.length})</h2>
-        <button className="btn btn-small" onClick={fetchItems}>↻ Refresh</button>
+        <button className="btn btn-small" onClick={() => fetchItems(viewingSprintNumber)}>↻ Refresh</button>
       </div>
       <ul className="tab-list">
         {items.map((item) => (

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -805,7 +805,7 @@ export class DashboardWebServer {
 
     // API routes
     if (url.pathname.startsWith("/api/")) {
-      this.handleApi(url.pathname, res);
+      this.handleApi(url, res);
       return;
     }
 
@@ -835,7 +835,8 @@ export class DashboardWebServer {
   }
 
   /** Handle REST API requests. */
-  private handleApi(pathname: string, res: http.ServerResponse): void {
+  private handleApi(url: URL, res: http.ServerResponse): void {
+    const pathname = url.pathname;
     res.setHeader("Content-Type", "application/json");
 
     if (pathname === "/api/repo") {
@@ -931,9 +932,11 @@ export class DashboardWebServer {
       return;
     }
 
-    // /api/sprint-backlog — issues in the active sprint with full body
+    // /api/sprint-backlog — issues in the active or requested sprint with full body
     if (pathname === "/api/sprint-backlog") {
-      this.handleSprintBacklogRequest(res);
+      const requestedSprint = url.searchParams.get("sprint");
+      const sprintNum = requestedSprint ? parseInt(requestedSprint, 10) : undefined;
+      this.handleSprintBacklogRequest(res, sprintNum);
       return;
     }
 
@@ -1042,9 +1045,9 @@ export class DashboardWebServer {
   }
 
   /** Return issues planned in the active sprint with full body for detail view. */
-  private handleSprintBacklogRequest(res: http.ServerResponse): void {
+  private handleSprintBacklogRequest(res: http.ServerResponse, requestedSprint?: number): void {
     const prefix = this.options.sprintPrefix ?? "Sprint";
-    const sprintNum = this.activeSprintNumber ?? 1;
+    const sprintNum = requestedSprint && requestedSprint > 0 ? requestedSprint : (this.activeSprintNumber ?? 1);
     const milestoneName = `${prefix} ${sprintNum}`;
     import("../github/issues.js").then(async ({ listIssues }) => {
       try {


### PR DESCRIPTION
Sprint Backlog tab always showed active sprint issues. Now respects the header sprint selector.

Closes #450