### PR TITLE
feat: /clear slash command to reset chat context (#456)

### DIFF
--- a/src/dashboard/frontend/src/components/ChatPanel.tsx
+++ b/src/dashboard/frontend/src/components/ChatPanel.tsx
@@ -26,6 +26,20 @@ export function ChatPanel() {
 
   const handleSend = () => {
     if (!input.trim()) return;
+
+    // Handle /clear as a client-side command
+    if (input.trim() === "/clear") {
+      if (activeChatId) {
+        const store = useDashboardStore.getState();
+        useDashboardStore.setState({
+          chatMessages: { ...store.chatMessages, [activeChatId]: [] },
+          chatStreaming: { ...store.chatStreaming, [activeChatId]: "" },
+        });
+      }
+      setInput("");
+      return;
+    }
+
     if (!activeChatId) {
       send({ type: "chat:create", role });
     }

--- a/src/dashboard/frontend/src/components/SidePanel.tsx
+++ b/src/dashboard/frontend/src/components/SidePanel.tsx
@@ -40,6 +40,7 @@ const TOOL_KIND_ICONS: Record<string, string> = {
 
 const DEFAULT_COMMANDS: ChatCommand[] = [
   { name: "help", description: "Show available commands and capabilities" },
+  { name: "clear", description: "Clear chat history and reset context" },
   { name: "compact", description: "Summarize conversation to save context" },
   { name: "code-review", description: "Structured code review checklist" },
   { name: "create-pr", description: "Create a PR with conventional title format" },
@@ -125,6 +126,19 @@ export function SidePanel() {
     if (!trimmed) return;
     const chatId = useDashboardStore.getState().activeChatId;
     if (!chatId || chatId === "__global__") return;
+
+    // Handle /clear as a client-side command
+    if (trimmed === "/clear") {
+      const store = useDashboardStore.getState();
+      useDashboardStore.setState({
+        chatMessages: { ...store.chatMessages, [chatId]: [] },
+        chatStreaming: { ...store.chatStreaming, [chatId]: "" },
+      });
+      setInput("");
+      setShowSlashMenu(false);
+      return;
+    }
+
     send({ type: "chat:send", sessionId: chatId, message: trimmed });
     const store = useDashboardStore.getState();
     const msgs = store.chatMessages[chatId] ?? [];


### PR DESCRIPTION
Adds /clear as a client-side slash command that clears chat message history and streaming state.

Closes #456