### PR TITLE
feat(dashboard): redesign Sprint Overview layout

### DIFF
--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -88,14 +88,16 @@ export default function App() {
           </button>
         ))}
         <div className="tab-nav-spacer" />
-        <button
-          className={`tab-btn agent-toggle-btn ${chatPanelOpen ? "tab-active" : ""}`}
-          onClick={toggleAgentPanel}
-          title={chatPanelOpen ? "Hide Agent Panel" : "Show Agent Panel"}
-        >
-          🤖 Agents{sessionCount > 0 ? ` (${sessionCount})` : ""}
-          {chatPanelOpen ? " ◀" : " ▶"}
-        </button>
+        {activeTab !== "sprint" && (
+          <button
+            className={`tab-btn agent-toggle-btn ${chatPanelOpen ? "tab-active" : ""}`}
+            onClick={toggleAgentPanel}
+            title={chatPanelOpen ? "Hide Agent Panel" : "Show Agent Panel"}
+          >
+            🤖 Agents{sessionCount > 0 ? ` (${sessionCount})` : ""}
+            {chatPanelOpen ? " ◀" : " ▶"}
+          </button>
+        )}
       </nav>
       <div className="app-layout">
         <div className="app-main">
@@ -106,7 +108,7 @@ export default function App() {
           {activeTab === "decisions" && <DecisionsTab />}
           {activeTab === "ideas" && <IdeasTab />}
         </div>
-        {chatPanelOpen && (
+        {chatPanelOpen && activeTab !== "sprint" && (
           <>
             <div className="app-resize-handle" onMouseDown={onMouseDown} />
             <div className="app-side" style={{ width: sideWidth }}>

--- a/src/dashboard/frontend/src/components/SprintTab.css
+++ b/src/dashboard/frontend/src/components/SprintTab.css
@@ -20,3 +20,9 @@
   margin-bottom: 12px;
   flex-shrink: 0;
 }
+
+.sprint-chat-pane {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}

--- a/src/dashboard/frontend/src/components/SprintTab.tsx
+++ b/src/dashboard/frontend/src/components/SprintTab.tsx
@@ -1,42 +1,47 @@
 import { Allotment } from "allotment";
 import "allotment/dist/style.css";
 import { IssueList } from "./IssueList";
-import { ActivityFeed } from "./ActivityFeed";
 import { SessionPanel } from "./SessionPanel";
 import { LogTerminal } from "./LogTerminal";
+import { SidePanel } from "./SidePanel";
 import "./SprintTab.css";
 
 export function SprintTab() {
   return (
     <main className="sprint-main">
-      <Allotment vertical>
-        <Allotment.Pane minSize={150}>
-          <Allotment>
-            <Allotment.Pane minSize={200} preferredSize={360}>
-              <div className="panel">
-                <h2 className="panel-title">Issues</h2>
-                <IssueList />
-              </div>
+      <Allotment>
+        {/* Left + Center: Issues, Sessions, Log */}
+        <Allotment.Pane minSize={400}>
+          <Allotment vertical>
+            <Allotment.Pane minSize={150}>
+              <Allotment>
+                <Allotment.Pane minSize={200} preferredSize={300}>
+                  <div className="panel">
+                    <h2 className="panel-title">Issues</h2>
+                    <IssueList />
+                  </div>
+                </Allotment.Pane>
+
+                <Allotment.Pane minSize={250}>
+                  <div className="panel">
+                    <h2 className="panel-title">Sessions</h2>
+                    <SessionPanel />
+                  </div>
+                </Allotment.Pane>
+              </Allotment>
             </Allotment.Pane>
 
-            <Allotment.Pane minSize={250}>
-              <div className="panel">
-                <h2 className="panel-title">Activity</h2>
-                <ActivityFeed />
-              </div>
-            </Allotment.Pane>
-
-            <Allotment.Pane minSize={200} preferredSize={380}>
-              <div className="panel">
-                <h2 className="panel-title">ACP Sessions</h2>
-                <SessionPanel />
-              </div>
+            <Allotment.Pane minSize={80} preferredSize={180}>
+              <LogTerminal />
             </Allotment.Pane>
           </Allotment>
         </Allotment.Pane>
 
-        <Allotment.Pane minSize={80} preferredSize={180}>
-          <LogTerminal />
+        {/* Right: Chat Panel (full height) */}
+        <Allotment.Pane minSize={300} preferredSize={400}>
+          <div className="sprint-chat-pane">
+            <SidePanel />
+          </div>
         </Allotment.Pane>
       </Allotment>
     </main>

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -64,9 +64,9 @@ test.describe("Dashboard Sprint Navigation", () => {
     expect(["INIT", "PLAN", "EXECUTE", "REVIEW", "RETRO", "COMPLETE", "FAILED", "PAUSED"]).toContain(text);
   });
 
-  test("activity log exists in DOM", async ({ page }) => {
-    const activityList = page.locator("#activity-list");
-    await expect(activityList).toHaveCount(1);
+  test("chat panel exists in sprint view", async ({ page }) => {
+    const sidePanel = page.locator(".sprint-chat-pane .side-panel");
+    await expect(sidePanel).toHaveCount(1, { timeout: 5000 });
   });
 });
 


### PR DESCRIPTION
## Changes

Redesigns the Sprint Overview tab layout per #366:

**Layout:**
```
┌─────────────┬──────────────┬──────────────┐
│   Issues    │  Sessions    │  Chat Panel  │
│  (compact)  │  (ACP list)  │  (SidePanel) │
│             │              │              │
├─────────────┴──────────────┤              │
│       Log Terminal         │              │
└────────────────────────────┴──────────────┘
```

- **Left pane**: IssueList (compact, scrollable)
- **Center pane**: SessionPanel (ACP sessions, clickable)
- **Right pane**: SidePanel chat (full height, extends below log)
- **Bottom** (left+center only): LogTerminal
- Global Agents toggle hidden on Sprint tab (chat already embedded)

**Tests:** 573 unit + 11 E2E pass

Closes #366