### PR TITLE
feat(dashboard): add Settings page with config viewer

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -428,6 +428,7 @@ function registerWeb(program: Command): void {
           sprintPrefix: config.sprint.prefix,
           sprintSlug: prefixToSlug(config.sprint.prefix),
           maxIssuesPerSprint: config.sprint.max_issues,
+          config,
         });
         dashboardServer.sprintLimit = sprintLimit;
 

--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -5,9 +5,10 @@ import { SprintTab } from "./components/SprintTab";
 import { SprintBacklogTab } from "./components/SprintBacklogTab";
 import { BacklogTab, BlockedTab, DecisionsTab, IdeasTab } from "./components/Tabs";
 import { SidePanel } from "./components/SidePanel";
+import { SettingsPage } from "./components/SettingsPage";
 import "./index.css";
 
-type Tab = "sprint" | "sprint-backlog" | "backlog" | "blocked" | "decisions" | "ideas";
+type Tab = "sprint" | "sprint-backlog" | "backlog" | "blocked" | "decisions" | "ideas" | "settings";
 
 const TABS: { id: Tab; label: string; icon: string }[] = [
   { id: "sprint", label: "Sprint", icon: "🏃" },
@@ -16,6 +17,7 @@ const TABS: { id: Tab; label: string; icon: string }[] = [
   { id: "blocked", label: "Blocked", icon: "🚧" },
   { id: "decisions", label: "Decisions", icon: "⚖️" },
   { id: "ideas", label: "Ideas", icon: "💡" },
+  { id: "settings", label: "Settings", icon: "⚙️" },
 ];
 
 const MIN_SIDE_WIDTH = 320;
@@ -88,7 +90,7 @@ export default function App() {
           </button>
         ))}
         <div className="tab-nav-spacer" />
-        {activeTab !== "sprint" && (
+        {activeTab !== "sprint" && activeTab !== "settings" && (
           <button
             className={`tab-btn agent-toggle-btn ${chatPanelOpen ? "tab-active" : ""}`}
             onClick={toggleAgentPanel}
@@ -107,8 +109,9 @@ export default function App() {
           {activeTab === "blocked" && <BlockedTab />}
           {activeTab === "decisions" && <DecisionsTab />}
           {activeTab === "ideas" && <IdeasTab />}
+          {activeTab === "settings" && <SettingsPage />}
         </div>
-        {chatPanelOpen && activeTab !== "sprint" && (
+        {chatPanelOpen && activeTab !== "sprint" && activeTab !== "settings" && (
           <>
             <div className="app-resize-handle" onMouseDown={onMouseDown} />
             <div className="app-side" style={{ width: sideWidth }}>

--- a/src/dashboard/frontend/src/components/SettingsPage.css
+++ b/src/dashboard/frontend/src/components/SettingsPage.css
@@ -1,0 +1,150 @@
+.settings-page {
+  padding: 24px 32px;
+  overflow-y: auto;
+  height: 100%;
+  max-width: 960px;
+}
+
+.settings-page h1 {
+  font-size: 20px;
+  font-weight: 700;
+  margin-bottom: 24px;
+  color: var(--text);
+}
+
+.settings-section {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 16px;
+  overflow: hidden;
+}
+
+.settings-section-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  user-select: none;
+}
+
+.settings-section-header:hover {
+  background: var(--bg-hover);
+}
+
+.settings-section-header .chevron {
+  font-size: 10px;
+  transition: transform 0.15s;
+  color: var(--text-dim);
+}
+
+.settings-section-header .chevron.open {
+  transform: rotate(90deg);
+}
+
+.settings-section-body {
+  padding: 12px 16px;
+}
+
+.settings-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.settings-table tr {
+  border-bottom: 1px solid var(--border);
+}
+
+.settings-table tr:last-child {
+  border-bottom: none;
+}
+
+.settings-table td {
+  padding: 6px 8px;
+  vertical-align: top;
+}
+
+.settings-table td:first-child {
+  font-weight: 500;
+  color: var(--text-dim);
+  white-space: nowrap;
+  width: 200px;
+}
+
+.settings-table td:last-child {
+  color: var(--text);
+  word-break: break-word;
+}
+
+.settings-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.settings-badge.on {
+  background: rgba(46, 160, 67, 0.2);
+  color: #3fb950;
+}
+
+.settings-badge.off {
+  background: rgba(139, 148, 158, 0.2);
+  color: var(--text-dim);
+}
+
+.settings-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.settings-list li {
+  padding: 4px 0;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.settings-list li::before {
+  content: "•";
+  margin-right: 8px;
+  color: var(--text-dim);
+}
+
+.settings-loading {
+  text-align: center;
+  padding: 48px;
+  color: var(--text-dim);
+  font-size: 14px;
+}
+
+.settings-mcp-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin-bottom: 8px;
+}
+
+.settings-mcp-card:last-child {
+  margin-bottom: 0;
+}
+
+.settings-mcp-name {
+  font-weight: 600;
+  font-size: 13px;
+  margin-bottom: 4px;
+}
+
+.settings-mcp-detail {
+  font-size: 12px;
+  color: var(--text-dim);
+}

--- a/src/dashboard/frontend/src/components/SettingsPage.tsx
+++ b/src/dashboard/frontend/src/components/SettingsPage.tsx
@@ -1,0 +1,258 @@
+import { useEffect, useState } from "react";
+import "./SettingsPage.css";
+
+interface McpServer {
+  type: string;
+  name: string;
+  command?: string;
+  args?: string[];
+  url?: string;
+}
+
+interface Config {
+  project: { name: string; base_branch: string };
+  copilot: {
+    executable: string;
+    max_parallel_sessions: number;
+    session_timeout_ms: number;
+    auto_approve_tools: boolean;
+    allow_tool_patterns: string[];
+    mcp_servers: McpServer[];
+    instructions: string[];
+    phases: Record<string, { model?: string; mcp_servers?: McpServer[]; instructions?: string[] }>;
+  };
+  sprint: {
+    prefix: string;
+    max_issues: number;
+    max_issues_created_per_sprint: number;
+    max_sprints: number;
+    max_drift_incidents: number;
+    max_retries: number;
+    enable_challenger: boolean;
+    enable_tdd: boolean;
+    auto_revert_drift: boolean;
+    backlog_labels: string[];
+  };
+  quality_gates: {
+    require_tests: boolean;
+    require_lint: boolean;
+    require_types: boolean;
+    require_build: boolean;
+    max_diff_lines: number;
+    test_command: string | string[];
+    lint_command: string | string[];
+    typecheck_command: string | string[];
+    build_command: string | string[];
+    require_challenger: boolean;
+  };
+  escalation: { notifications: { ntfy: boolean; ntfy_topic: string; ntfy_server_url: string } };
+  git: {
+    worktree_base: string;
+    branch_pattern: string;
+    auto_merge: boolean;
+    squash_merge: boolean;
+    delete_branch_after_merge: boolean;
+  };
+}
+
+function BoolBadge({ value }: { value: boolean }) {
+  return (
+    <span className={`settings-badge ${value ? "on" : "off"}`}>
+      {value ? "Enabled" : "Disabled"}
+    </span>
+  );
+}
+
+function cmdStr(cmd: string | string[]): string {
+  return Array.isArray(cmd) ? cmd.join(" ") : cmd;
+}
+
+function Section({
+  icon,
+  title,
+  children,
+  defaultOpen = false,
+}: {
+  icon: string;
+  title: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="settings-section">
+      <div className="settings-section-header" onClick={() => setOpen(!open)}>
+        <span className={`chevron ${open ? "open" : ""}`}>▶</span>
+        <span>{icon}</span>
+        <span>{title}</span>
+      </div>
+      {open && <div className="settings-section-body">{children}</div>}
+    </div>
+  );
+}
+
+export function SettingsPage() {
+  const [config, setConfig] = useState<Config | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/config")
+      .then((r) => r.json())
+      .then((data) => setConfig(data as Config))
+      .catch((e) => setError(String(e)));
+  }, []);
+
+  if (error) return <div className="settings-loading">❌ Failed to load config: {error}</div>;
+  if (!config) return <div className="settings-loading">Loading configuration…</div>;
+
+  return (
+    <div className="settings-page">
+      <h1>⚙️ Settings</h1>
+
+      <Section icon="📁" title="Project" defaultOpen={true}>
+        <table className="settings-table">
+          <tbody>
+            <tr><td>Name</td><td>{config.project.name}</td></tr>
+            <tr><td>Base Branch</td><td><code>{config.project.base_branch}</code></td></tr>
+          </tbody>
+        </table>
+      </Section>
+
+      <Section icon="🤖" title="Copilot" defaultOpen={true}>
+        <table className="settings-table">
+          <tbody>
+            <tr><td>Executable</td><td><code>{config.copilot.executable}</code></td></tr>
+            <tr><td>Max Parallel Sessions</td><td>{config.copilot.max_parallel_sessions}</td></tr>
+            <tr><td>Session Timeout</td><td>{Math.round(config.copilot.session_timeout_ms / 1000)}s</td></tr>
+            <tr><td>Auto-approve Tools</td><td><BoolBadge value={config.copilot.auto_approve_tools} /></td></tr>
+            {config.copilot.allow_tool_patterns.length > 0 && (
+              <tr>
+                <td>Tool Patterns</td>
+                <td>
+                  <ul className="settings-list">
+                    {config.copilot.allow_tool_patterns.map((p, i) => <li key={i}><code>{p}</code></li>)}
+                  </ul>
+                </td>
+              </tr>
+            )}
+            {config.copilot.instructions.length > 0 && (
+              <tr>
+                <td>Instructions</td>
+                <td>
+                  <ul className="settings-list">
+                    {config.copilot.instructions.map((inst, i) => <li key={i}>{inst}</li>)}
+                  </ul>
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </Section>
+
+      <Section icon="🏃" title="Sprint">
+        <table className="settings-table">
+          <tbody>
+            <tr><td>Prefix</td><td>{config.sprint.prefix}</td></tr>
+            <tr><td>Max Issues per Sprint</td><td>{config.sprint.max_issues}</td></tr>
+            <tr><td>Max Issues Created</td><td>{config.sprint.max_issues_created_per_sprint}</td></tr>
+            <tr><td>Max Sprints</td><td>{config.sprint.max_sprints === 0 ? "∞ (unlimited)" : config.sprint.max_sprints}</td></tr>
+            <tr><td>Max Drift Incidents</td><td>{config.sprint.max_drift_incidents}</td></tr>
+            <tr><td>Max Retries</td><td>{config.sprint.max_retries}</td></tr>
+            <tr><td>Challenger</td><td><BoolBadge value={config.sprint.enable_challenger} /></td></tr>
+            <tr><td>TDD</td><td><BoolBadge value={config.sprint.enable_tdd} /></td></tr>
+            <tr><td>Auto-revert Drift</td><td><BoolBadge value={config.sprint.auto_revert_drift} /></td></tr>
+            {config.sprint.backlog_labels.length > 0 && (
+              <tr>
+                <td>Backlog Labels</td>
+                <td>
+                  <ul className="settings-list">
+                    {config.sprint.backlog_labels.map((l, i) => <li key={i}><code>{l}</code></li>)}
+                  </ul>
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </Section>
+
+      <Section icon="🛡️" title="Quality Gates">
+        <table className="settings-table">
+          <tbody>
+            <tr><td>Tests</td><td><BoolBadge value={config.quality_gates.require_tests} /></td></tr>
+            <tr><td>Test Command</td><td><code>{cmdStr(config.quality_gates.test_command)}</code></td></tr>
+            <tr><td>Lint</td><td><BoolBadge value={config.quality_gates.require_lint} /></td></tr>
+            <tr><td>Lint Command</td><td><code>{cmdStr(config.quality_gates.lint_command)}</code></td></tr>
+            <tr><td>Type Check</td><td><BoolBadge value={config.quality_gates.require_types} /></td></tr>
+            <tr><td>Type Command</td><td><code>{cmdStr(config.quality_gates.typecheck_command)}</code></td></tr>
+            <tr><td>Build</td><td><BoolBadge value={config.quality_gates.require_build} /></td></tr>
+            <tr><td>Build Command</td><td><code>{cmdStr(config.quality_gates.build_command)}</code></td></tr>
+            <tr><td>Max Diff Lines</td><td>{config.quality_gates.max_diff_lines}</td></tr>
+            <tr><td>Challenger</td><td><BoolBadge value={config.quality_gates.require_challenger} /></td></tr>
+          </tbody>
+        </table>
+      </Section>
+
+      {config.copilot.mcp_servers.length > 0 && (
+        <Section icon="🔌" title={`MCP Servers (${config.copilot.mcp_servers.length})`}>
+          {config.copilot.mcp_servers.map((srv, i) => (
+            <div className="settings-mcp-card" key={i}>
+              <div className="settings-mcp-name">{srv.name}</div>
+              <div className="settings-mcp-detail">
+                Type: <code>{srv.type}</code>
+                {srv.command && <> · Command: <code>{srv.command} {srv.args?.join(" ")}</code></>}
+                {srv.url && <> · URL: <code>{srv.url}</code></>}
+              </div>
+            </div>
+          ))}
+        </Section>
+      )}
+
+      {Object.keys(config.copilot.phases).length > 0 && (
+        <Section icon="🔄" title="Phase Overrides">
+          {Object.entries(config.copilot.phases).map(([phase, cfg]) => (
+            <div className="settings-mcp-card" key={phase}>
+              <div className="settings-mcp-name">{phase}</div>
+              <table className="settings-table">
+                <tbody>
+                  {cfg.model && <tr><td>Model</td><td><code>{cfg.model}</code></td></tr>}
+                  {cfg.mcp_servers && cfg.mcp_servers.length > 0 && (
+                    <tr><td>MCP Servers</td><td>{cfg.mcp_servers.map((s) => s.name).join(", ")}</td></tr>
+                  )}
+                  {cfg.instructions && cfg.instructions.length > 0 && (
+                    <tr><td>Instructions</td><td>{cfg.instructions.length} custom</td></tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          ))}
+        </Section>
+      )}
+
+      <Section icon="🔔" title="Notifications">
+        <table className="settings-table">
+          <tbody>
+            <tr><td>ntfy</td><td><BoolBadge value={config.escalation.notifications.ntfy} /></td></tr>
+            {config.escalation.notifications.ntfy && (
+              <>
+                <tr><td>Topic</td><td><code>{config.escalation.notifications.ntfy_topic}</code></td></tr>
+                <tr><td>Server</td><td><code>{config.escalation.notifications.ntfy_server_url}</code></td></tr>
+              </>
+            )}
+          </tbody>
+        </table>
+      </Section>
+
+      <Section icon="🔀" title="Git">
+        <table className="settings-table">
+          <tbody>
+            <tr><td>Worktree Base</td><td><code>{config.git.worktree_base}</code></td></tr>
+            <tr><td>Branch Pattern</td><td><code>{config.git.branch_pattern}</code></td></tr>
+            <tr><td>Auto Merge</td><td><BoolBadge value={config.git.auto_merge} /></td></tr>
+            <tr><td>Squash Merge</td><td><BoolBadge value={config.git.squash_merge} /></td></tr>
+            <tr><td>Delete Branch After Merge</td><td><BoolBadge value={config.git.delete_branch_after_merge} /></td></tr>
+          </tbody>
+        </table>
+      </Section>
+    </div>
+  );
+}

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -13,6 +13,7 @@ import { promisify } from "node:util";
 import { WebSocketServer, type WebSocket } from "ws";
 import type { SprintEventBus, SprintEngineEvents } from "../events.js";
 import type { SprintState } from "../runner.js";
+import type { ConfigFile } from "../config.js";
 import { logger } from "../logger.js";
 import { ChatManager, type ChatRole } from "./chat-manager.js";
 import { writeSessionLog } from "./session-logger.js";
@@ -85,6 +86,8 @@ export interface DashboardServerOptions {
   sprintSlug?: string;
   /** Max issues per sprint for capacity display (default: 8). */
   maxIssuesPerSprint?: number;
+  /** Full config for the settings page. */
+  config?: ConfigFile;
 }
 
 export interface TrackedSession {
@@ -937,6 +940,14 @@ export class DashboardWebServer {
       const requestedSprint = url.searchParams.get("sprint");
       const sprintNum = requestedSprint ? parseInt(requestedSprint, 10) : undefined;
       this.handleSprintBacklogRequest(res, sprintNum);
+      return;
+    }
+
+    // /api/config — full project config for the settings page
+    if (pathname === "/api/config") {
+      const config = this.options.config ?? null;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(config));
       return;
     }
 

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -101,4 +101,24 @@ test.describe("Dashboard API Endpoints", () => {
     const data = await res.json();
     expect(Array.isArray(data)).toBe(true);
   });
+
+  test("/api/config returns config object", async ({ request }) => {
+    const res = await request.get("/api/config");
+    expect(res.status()).toBe(200);
+    const data = (await res.json()) as Record<string, unknown>;
+    expect(data).toHaveProperty("project");
+    expect(data).toHaveProperty("sprint");
+    expect(data).toHaveProperty("quality_gates");
+  });
+});
+
+test.describe("Dashboard Settings Page", () => {
+  test("settings tab navigates to settings page", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector(".tab-nav", { timeout: 10_000 });
+    const settingsTab = page.locator("button.tab-btn", { hasText: "Settings" });
+    await settingsTab.click();
+    const heading = page.locator(".settings-page h1");
+    await expect(heading).toContainText("Settings", { timeout: 5000 });
+  });
 });


### PR DESCRIPTION
## Changes

Adds a dedicated Settings page per #367.

**Backend:**
- `/api/config` endpoint serves the full project config from `.aiscrum/config.yaml`

**Frontend — SettingsPage component:**
| Section | Content |
|---------|---------|
| 📁 Project | Name, base branch |
| 🤖 Copilot | Executable, parallelism, timeout, auto-approve, tool patterns, instructions |
| 🏃 Sprint | Max issues, drift limits, challenger, TDD, backlog labels |
| 🛡️ Quality Gates | Test/lint/type/build requirements + commands, max diff, challenger |
| 🔌 MCP Servers | Configured server connections (type, command/URL) |
| 🔄 Phase Overrides | Per-phase model, MCP servers, instructions |
| 🔔 Notifications | ntfy config |
| 🔀 Git | Worktree, branch pattern, merge strategy |

All sections are collapsible. Read-only for now.

**Navigation:**
- ⚙️ Settings tab added to top nav bar
- Agents toggle hidden on Settings tab

**Tests:** 573 unit + 13 E2E pass (including /api/config + settings navigation)

Closes #367