### PR TITLE
feat(dashboard): browser push notifications for sprint events

### DIFF
--- a/src/dashboard/frontend/src/components/Header.css
+++ b/src/dashboard/frontend/src/components/Header.css
@@ -88,3 +88,8 @@
   0%, 100% { opacity: 1; }
   50% { opacity: 0.7; }
 }
+
+.btn-notif-on {
+  background: rgba(46, 160, 67, 0.15);
+  border-color: #3fb950;
+}

--- a/src/dashboard/frontend/src/components/Header.tsx
+++ b/src/dashboard/frontend/src/components/Header.tsx
@@ -1,5 +1,10 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { useDashboardStore } from "../store";
+import {
+  getNotificationsEnabled,
+  setNotificationsEnabled,
+  requestNotificationPermission,
+} from "../notifications";
 import "./Header.css";
 
 const PHASES = ["plan", "execute", "review", "retro", "complete"];
@@ -18,7 +23,21 @@ export function Header() {
   const setViewingSprint = useDashboardStore((s) => s.setViewingSprint);
 
   const [elapsed, setElapsed] = useState("0m 00s");
+  const [notificationsOn, setNotificationsOn] = useState(getNotificationsEnabled);
   const timerRef = useRef<ReturnType<typeof setInterval>>(null);
+
+  const toggleNotifications = useCallback(async () => {
+    if (notificationsOn) {
+      setNotificationsEnabled(false);
+      setNotificationsOn(false);
+    } else {
+      const granted = await requestNotificationPermission();
+      if (granted) {
+        setNotificationsEnabled(true);
+        setNotificationsOn(true);
+      }
+    }
+  }, [notificationsOn]);
 
   const isViewingActive = viewingSprintNumber === activeSprintNumber || viewingSprintNumber === 0;
   const displayNumber = viewingSprintNumber || state.sprintNumber || "—";
@@ -77,6 +96,13 @@ export function Header() {
       </div>
 
       <div className="header-right">
+        <button
+          className={`btn btn-small ${notificationsOn ? "btn-notif-on" : ""}`}
+          onClick={toggleNotifications}
+          title={notificationsOn ? "Disable browser notifications" : "Enable browser notifications"}
+        >
+          {notificationsOn ? "🔔" : "🔕"}
+        </button>
         <span className="issue-count">{doneCount}/{totalCount} done</span>
         <span className="elapsed">{elapsed}</span>
         <span className={`status-dot ${connected ? "status-connected" : "status-disconnected"}`} />

--- a/src/dashboard/frontend/src/notifications.ts
+++ b/src/dashboard/frontend/src/notifications.ts
@@ -1,0 +1,75 @@
+/**
+ * Browser Push Notification utility for sprint events.
+ * Only fires when the tab is not focused.
+ */
+
+const STORAGE_KEY = "sprint-notifications-enabled";
+
+export function getNotificationsEnabled(): boolean {
+  return localStorage.getItem(STORAGE_KEY) === "true";
+}
+
+export function setNotificationsEnabled(enabled: boolean): void {
+  localStorage.setItem(STORAGE_KEY, String(enabled));
+}
+
+export async function requestNotificationPermission(): Promise<boolean> {
+  if (!("Notification" in window)) return false;
+  if (Notification.permission === "granted") return true;
+  if (Notification.permission === "denied") return false;
+  const result = await Notification.requestPermission();
+  return result === "granted";
+}
+
+export function canNotify(): boolean {
+  return (
+    "Notification" in window &&
+    Notification.permission === "granted" &&
+    getNotificationsEnabled() &&
+    document.hidden
+  );
+}
+
+export function notify(title: string, body: string, tag?: string): void {
+  if (!canNotify()) return;
+  try {
+    new Notification(title, { body, tag, icon: "🏃" });
+  } catch {
+    // Silent fail — some environments don't support Notification constructor
+  }
+}
+
+/** Map sprint events to notifications. Called from handleSprintEvent. */
+export function notifySprintEvent(eventName: string, payload: Record<string, unknown> | undefined): void {
+  if (!canNotify()) return;
+
+  const p = payload ?? {};
+
+  switch (eventName) {
+    case "phase:change":
+      notify("Phase Change", `${String(p.from ?? "?")} → ${String(p.to ?? "?")}`, "phase");
+      break;
+
+    case "issue:done":
+      notify("✅ Issue Completed", `#${p.issueNumber} done`, `issue-${p.issueNumber}`);
+      break;
+
+    case "issue:fail":
+      notify("❌ Issue Failed", `#${p.issueNumber}: ${p.reason ?? "unknown error"}`, `issue-${p.issueNumber}`);
+      break;
+
+    case "sprint:complete":
+      notify("🏁 Sprint Complete", `Sprint ${p.sprintNumber} finished`, "sprint-complete");
+      break;
+
+    case "sprint:error":
+      notify("💥 Sprint Error", String(p.error ?? "Unknown error"), "sprint-error");
+      break;
+
+    case "sprint:planned": {
+      const issues = p.issues as Array<{ number: number }> | undefined;
+      notify("📋 Sprint Planned", `${issues?.length ?? 0} issues selected`, "sprint-planned");
+      break;
+    }
+  }
+}

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -8,6 +8,7 @@ import type {
   ClientMessage,
   ServerMessage,
 } from "./types";
+import { notifySprintEvent } from "./notifications";
 
 export interface ChatToolCall {
   toolCallId: string;
@@ -503,6 +504,9 @@ function handleSprintEvent(
 ): void {
   const p = payload as Record<string, unknown> | undefined;
   const store = get();
+
+  // Trigger browser notification (only when tab is hidden)
+  notifySprintEvent(name, p);
 
   switch (name) {
     case "sprint:start":


### PR DESCRIPTION
## Changes

Adds browser push notifications per #370.

**Notifications utility** (`notifications.ts`):
- Uses browser `Notification` API (no service worker needed)
- Only fires when tab is `document.hidden` (no spam when focused)
- Permission + preference persisted in `localStorage`

**Trigger events:**
| Event | Notification |
|-------|-------------|
| `phase:change` | "Planning → Execute" |
| `issue:done` | "✅ #142 completed" |
| `issue:fail` | "❌ #142: lint errors" |
| `sprint:complete` | "🏁 Sprint 3 finished" |
| `sprint:error` | "💥 Sprint error" |
| `sprint:planned` | "📋 5 issues selected" |

**UI:** 🔔/🔕 toggle in Header (green highlight when active)

**Tests:** 573 unit + 13 E2E pass

Closes #370