### PR TITLE
feat(dashboard): Sprint Report view with review/retro and export

### DIFF
--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -6,9 +6,10 @@ import { SprintBacklogTab } from "./components/SprintBacklogTab";
 import { BacklogTab, BlockedTab, DecisionsTab, IdeasTab } from "./components/Tabs";
 import { SidePanel } from "./components/SidePanel";
 import { SettingsPage } from "./components/SettingsPage";
+import { SprintReport } from "./components/SprintReport";
 import "./index.css";
 
-type Tab = "sprint" | "sprint-backlog" | "backlog" | "blocked" | "decisions" | "ideas" | "settings";
+type Tab = "sprint" | "sprint-backlog" | "backlog" | "blocked" | "decisions" | "ideas" | "report" | "settings";
 
 const TABS: { id: Tab; label: string; icon: string }[] = [
   { id: "sprint", label: "Sprint", icon: "🏃" },
@@ -17,6 +18,7 @@ const TABS: { id: Tab; label: string; icon: string }[] = [
   { id: "blocked", label: "Blocked", icon: "🚧" },
   { id: "decisions", label: "Decisions", icon: "⚖️" },
   { id: "ideas", label: "Ideas", icon: "💡" },
+  { id: "report", label: "Report", icon: "📊" },
   { id: "settings", label: "Settings", icon: "⚙️" },
 ];
 
@@ -109,6 +111,7 @@ export default function App() {
           {activeTab === "blocked" && <BlockedTab />}
           {activeTab === "decisions" && <DecisionsTab />}
           {activeTab === "ideas" && <IdeasTab />}
+          {activeTab === "report" && <SprintReport />}
           {activeTab === "settings" && <SettingsPage />}
         </div>
         {chatPanelOpen && activeTab !== "sprint" && activeTab !== "settings" && (

--- a/src/dashboard/frontend/src/components/SprintReport.css
+++ b/src/dashboard/frontend/src/components/SprintReport.css
@@ -1,0 +1,228 @@
+.sprint-report {
+  padding: 24px 32px;
+  overflow-y: auto;
+  height: 100%;
+  max-width: 1000px;
+}
+
+.sprint-report h1 {
+  font-size: 20px;
+  font-weight: 700;
+  margin-bottom: 8px;
+  color: var(--text);
+}
+
+.report-subtitle {
+  font-size: 13px;
+  color: var(--text-dim);
+  margin-bottom: 20px;
+}
+
+.report-actions {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+/* Summary cards */
+.report-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.summary-card {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px 16px;
+  text-align: center;
+}
+
+.summary-card .value {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.summary-card .label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-dim);
+  margin-top: 4px;
+}
+
+.summary-card.success .value { color: #3fb950; }
+.summary-card.danger .value { color: #f85149; }
+.summary-card.info .value { color: #58a6ff; }
+
+/* Sections */
+.report-section {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 16px;
+  overflow: hidden;
+}
+
+.report-section-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  user-select: none;
+}
+
+.report-section-header:hover {
+  background: var(--bg-hover);
+}
+
+.report-section-header .chevron {
+  font-size: 10px;
+  transition: transform 0.15s;
+  color: var(--text-dim);
+}
+
+.report-section-header .chevron.open {
+  transform: rotate(90deg);
+}
+
+.report-section-body {
+  padding: 12px 16px;
+}
+
+/* Issue results table */
+.report-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.report-table th {
+  text-align: left;
+  padding: 8px;
+  font-weight: 600;
+  color: var(--text-dim);
+  border-bottom: 2px solid var(--border);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.report-table td {
+  padding: 8px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+
+.report-table tr:last-child td {
+  border-bottom: none;
+}
+
+.report-table tr:hover {
+  background: var(--bg-hover);
+}
+
+.quality-checks {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.quality-check {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.quality-check.pass {
+  background: rgba(46, 160, 67, 0.15);
+  color: #3fb950;
+}
+
+.quality-check.fail {
+  background: rgba(248, 81, 73, 0.15);
+  color: #f85149;
+}
+
+/* Retro lists */
+.retro-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.retro-list li {
+  padding: 6px 0;
+  font-size: 13px;
+  color: var(--text);
+  border-bottom: 1px solid var(--border);
+}
+
+.retro-list li:last-child {
+  border-bottom: none;
+}
+
+.retro-list li::before {
+  margin-right: 8px;
+}
+
+.retro-list.well li::before { content: "✅"; }
+.retro-list.bad li::before { content: "⚠️"; }
+.retro-list.improve li::before { content: "💡"; }
+
+/* Sprint selector */
+.report-sprint-select {
+  font-size: 13px;
+  padding: 4px 8px;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
+.report-empty {
+  text-align: center;
+  padding: 48px;
+  color: var(--text-dim);
+  font-size: 14px;
+}
+
+.report-loading {
+  text-align: center;
+  padding: 48px;
+  color: var(--text-dim);
+}
+
+.duration-cell {
+  font-variant-numeric: tabular-nums;
+}
+
+.copied-toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  background: #3fb950;
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  z-index: 1000;
+  animation: fadeOut 2s ease-in-out forwards;
+}
+
+@keyframes fadeOut {
+  0%, 70% { opacity: 1; }
+  100% { opacity: 0; }
+}

--- a/src/dashboard/frontend/src/components/SprintReport.tsx
+++ b/src/dashboard/frontend/src/components/SprintReport.tsx
@@ -1,0 +1,410 @@
+import { useEffect, useState, useCallback } from "react";
+import { useDashboardStore } from "../store";
+import "./SprintReport.css";
+
+interface QualityCheck {
+  name: string;
+  passed: boolean;
+  details?: string;
+}
+
+interface IssueResult {
+  issueNumber: number;
+  status: string;
+  qualityGatePassed?: boolean;
+  qualityDetails?: { checks?: QualityCheck[] };
+  codeReview?: { approved?: boolean; feedback?: string };
+  branch?: string;
+  duration_ms?: number;
+  filesChanged?: string[];
+  retryCount?: number;
+  points?: number;
+}
+
+interface SprintPlan {
+  sprintNumber: number;
+  sprint_issues: Array<{ number: number; title: string; ice_score?: number; points?: number }>;
+  rationale?: string;
+}
+
+interface ReviewResult {
+  summary?: string;
+  demoItems?: string[];
+  velocityUpdate?: string;
+  openItems?: string[];
+}
+
+interface RetroResult {
+  wentWell?: string[];
+  wentBadly?: string[];
+  improvements?: Array<{ title: string; description?: string }>;
+}
+
+interface SprintStateData {
+  sprintNumber: number;
+  phase: string;
+  startedAt?: string;
+  plan?: SprintPlan;
+  result?: { results: IssueResult[]; parallelizationRatio?: number; mergeConflicts?: number };
+  review?: ReviewResult;
+  retro?: RetroResult;
+  error?: string;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  const mins = Math.floor(ms / 60_000);
+  const secs = Math.round((ms % 60_000) / 1000);
+  return `${mins}m ${String(secs).padStart(2, "0")}s`;
+}
+
+function Section({
+  icon,
+  title,
+  children,
+  defaultOpen = false,
+}: {
+  icon: string;
+  title: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="report-section">
+      <div className="report-section-header" onClick={() => setOpen(!open)}>
+        <span className={`chevron ${open ? "open" : ""}`}>▶</span>
+        <span>{icon}</span>
+        <span>{title}</span>
+      </div>
+      {open && <div className="report-section-body">{children}</div>}
+    </div>
+  );
+}
+
+function generateMarkdown(data: SprintStateData): string {
+  const lines: string[] = [];
+  lines.push(`# Sprint ${data.sprintNumber} Report`);
+  lines.push("");
+
+  if (data.startedAt) {
+    lines.push(`**Date:** ${new Date(data.startedAt).toLocaleDateString()}`);
+  }
+  lines.push(`**Phase:** ${data.phase}`);
+  lines.push("");
+
+  // Summary
+  const results = data.result?.results ?? [];
+  const completed = results.filter((r) => r.status === "completed").length;
+  const failed = results.filter((r) => r.status === "failed").length;
+  const totalDuration = results.reduce((sum, r) => sum + (r.duration_ms ?? 0), 0);
+  const firstPass = results.filter((r) => r.qualityGatePassed && (r.retryCount ?? 0) === 0).length;
+
+  lines.push("## Summary");
+  lines.push("");
+  lines.push(`| Metric | Value |`);
+  lines.push(`|--------|-------|`);
+  lines.push(`| Planned | ${data.plan?.sprint_issues?.length ?? 0} |`);
+  lines.push(`| Completed | ${completed} |`);
+  lines.push(`| Failed | ${failed} |`);
+  lines.push(`| Total Duration | ${formatDuration(totalDuration)} |`);
+  lines.push(`| First-pass Rate | ${results.length > 0 ? Math.round((firstPass / results.length) * 100) : 0}% |`);
+  lines.push("");
+
+  // Issue results
+  if (results.length > 0) {
+    lines.push("## Issue Results");
+    lines.push("");
+    lines.push(`| Issue | Status | Quality | Duration | Files |`);
+    lines.push(`|-------|--------|---------|----------|-------|`);
+    for (const r of results) {
+      const status = r.status === "completed" ? "✅" : "❌";
+      const quality = r.qualityGatePassed ? "Pass" : "Fail";
+      const duration = r.duration_ms ? formatDuration(r.duration_ms) : "—";
+      const files = r.filesChanged?.length ?? 0;
+      lines.push(`| #${r.issueNumber} | ${status} ${r.status} | ${quality} | ${duration} | ${files} |`);
+    }
+    lines.push("");
+  }
+
+  // Review
+  if (data.review) {
+    lines.push("## Review");
+    lines.push("");
+    if (data.review.summary) lines.push(data.review.summary);
+    if (data.review.demoItems?.length) {
+      lines.push("");
+      lines.push("### Demo Items");
+      for (const item of data.review.demoItems) lines.push(`- ${item}`);
+    }
+    if (data.review.openItems?.length) {
+      lines.push("");
+      lines.push("### Open Items");
+      for (const item of data.review.openItems) lines.push(`- ${item}`);
+    }
+    lines.push("");
+  }
+
+  // Retro
+  if (data.retro) {
+    lines.push("## Retrospective");
+    lines.push("");
+    if (data.retro.wentWell?.length) {
+      lines.push("### What Went Well");
+      for (const item of data.retro.wentWell) lines.push(`- ${item}`);
+      lines.push("");
+    }
+    if (data.retro.wentBadly?.length) {
+      lines.push("### What Could Improve");
+      for (const item of data.retro.wentBadly) lines.push(`- ${item}`);
+      lines.push("");
+    }
+    if (data.retro.improvements?.length) {
+      lines.push("### Improvements");
+      for (const imp of data.retro.improvements) {
+        lines.push(`- **${imp.title}**: ${imp.description ?? ""}`);
+      }
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function SprintReport() {
+  const viewingSprintNumber = useDashboardStore((s) => s.viewingSprintNumber);
+  const availableSprints = useDashboardStore((s) => s.availableSprints);
+  const [sprintNum, setSprintNum] = useState(viewingSprintNumber || 1);
+  const [data, setData] = useState<SprintStateData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (viewingSprintNumber > 0) setSprintNum(viewingSprintNumber);
+  }, [viewingSprintNumber]);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/sprints/${sprintNum}/state`)
+      .then((r) => r.json())
+      .then((d) => setData(d as SprintStateData))
+      .catch(() => setData(null))
+      .finally(() => setLoading(false));
+  }, [sprintNum]);
+
+  const copyMarkdown = useCallback(() => {
+    if (!data) return;
+    navigator.clipboard.writeText(generateMarkdown(data)).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [data]);
+
+  const downloadMarkdown = useCallback(() => {
+    if (!data) return;
+    const md = generateMarkdown(data);
+    const blob = new Blob([md], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `sprint-${data.sprintNumber}-report.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [data]);
+
+  if (loading) return <div className="report-loading">Loading sprint report…</div>;
+
+  const results = data?.result?.results ?? [];
+  const planned = data?.plan?.sprint_issues ?? [];
+  const completed = results.filter((r) => r.status === "completed").length;
+  const failed = results.filter((r) => r.status === "failed").length;
+  const totalDuration = results.reduce((sum, r) => sum + (r.duration_ms ?? 0), 0);
+  const firstPass = results.filter((r) => r.qualityGatePassed && (r.retryCount ?? 0) === 0).length;
+  const firstPassRate = results.length > 0 ? Math.round((firstPass / results.length) * 100) : 0;
+
+  return (
+    <div className="sprint-report">
+      <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 4 }}>
+        <h1>📋 Sprint Report</h1>
+        <select
+          className="report-sprint-select"
+          value={sprintNum}
+          onChange={(e) => setSprintNum(parseInt(e.target.value, 10))}
+        >
+          {availableSprints.map((s) => (
+            <option key={s.sprintNumber} value={s.sprintNumber}>
+              Sprint {s.sprintNumber}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {data?.startedAt && (
+        <div className="report-subtitle">
+          Started {new Date(data.startedAt).toLocaleString()} · Phase: {data.phase?.toUpperCase()}
+          {data.error && <> · ⚠️ {data.error}</>}
+        </div>
+      )}
+
+      {results.length === 0 && planned.length === 0 ? (
+        <div className="report-empty">
+          No data available for Sprint {sprintNum}.<br />
+          The sprint may not have been executed yet.
+        </div>
+      ) : (
+        <>
+          <div className="report-actions">
+            <button className="btn btn-small" onClick={copyMarkdown}>📋 Copy Markdown</button>
+            <button className="btn btn-small" onClick={downloadMarkdown}>⬇ Download .md</button>
+          </div>
+
+          <div className="report-summary">
+            <div className="summary-card">
+              <div className="value">{planned.length}</div>
+              <div className="label">Planned</div>
+            </div>
+            <div className="summary-card success">
+              <div className="value">{completed}</div>
+              <div className="label">Completed</div>
+            </div>
+            {failed > 0 && (
+              <div className="summary-card danger">
+                <div className="value">{failed}</div>
+                <div className="label">Failed</div>
+              </div>
+            )}
+            <div className="summary-card info">
+              <div className="value">{firstPassRate}%</div>
+              <div className="label">First-pass</div>
+            </div>
+            <div className="summary-card">
+              <div className="value">{totalDuration > 0 ? formatDuration(totalDuration) : "—"}</div>
+              <div className="label">Total Duration</div>
+            </div>
+            {data?.result?.mergeConflicts != null && data.result.mergeConflicts > 0 && (
+              <div className="summary-card danger">
+                <div className="value">{data.result.mergeConflicts}</div>
+                <div className="label">Merge Conflicts</div>
+              </div>
+            )}
+          </div>
+
+          {results.length > 0 && (
+            <Section icon="📋" title={`Issue Results (${results.length})`} defaultOpen={true}>
+              <table className="report-table">
+                <thead>
+                  <tr>
+                    <th>Issue</th>
+                    <th>Status</th>
+                    <th>Quality</th>
+                    <th>Duration</th>
+                    <th>Files</th>
+                    <th>Retries</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {results.map((r) => (
+                    <tr key={r.issueNumber}>
+                      <td><strong>#{r.issueNumber}</strong></td>
+                      <td>{r.status === "completed" ? "✅" : "❌"} {r.status}</td>
+                      <td>
+                        {r.qualityDetails?.checks ? (
+                          <div className="quality-checks">
+                            {r.qualityDetails.checks.map((c, i) => (
+                              <span key={i} className={`quality-check ${c.passed ? "pass" : "fail"}`}>
+                                {c.passed ? "✓" : "✗"} {c.name}
+                              </span>
+                            ))}
+                          </div>
+                        ) : (
+                          r.qualityGatePassed ? "✅ Pass" : "❌ Fail"
+                        )}
+                      </td>
+                      <td className="duration-cell">
+                        {r.duration_ms ? formatDuration(r.duration_ms) : "—"}
+                      </td>
+                      <td>{r.filesChanged?.length ?? 0}</td>
+                      <td>{r.retryCount ?? 0}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </Section>
+          )}
+
+          {data?.plan?.rationale && (
+            <Section icon="🎯" title="Planning Rationale">
+              <p style={{ fontSize: 13, color: "var(--text)", lineHeight: 1.5, margin: 0 }}>
+                {data.plan.rationale}
+              </p>
+            </Section>
+          )}
+
+          {data?.review && (
+            <Section icon="🔍" title="Review" defaultOpen={true}>
+              {data.review.summary && (
+                <p style={{ fontSize: 13, color: "var(--text)", lineHeight: 1.5, marginBottom: 12 }}>
+                  {data.review.summary}
+                </p>
+              )}
+              {data.review.demoItems && data.review.demoItems.length > 0 && (
+                <>
+                  <strong style={{ fontSize: 12, color: "var(--text-dim)" }}>Demo Items</strong>
+                  <ul className="retro-list" style={{ marginBottom: 12 }}>
+                    {data.review.demoItems.map((item, i) => <li key={i}>{item}</li>)}
+                  </ul>
+                </>
+              )}
+              {data.review.velocityUpdate && (
+                <p style={{ fontSize: 13, color: "var(--text-dim)", marginTop: 8 }}>
+                  📈 {data.review.velocityUpdate}
+                </p>
+              )}
+              {data.review.openItems && data.review.openItems.length > 0 && (
+                <>
+                  <strong style={{ fontSize: 12, color: "var(--text-dim)" }}>Open Items</strong>
+                  <ul className="retro-list">
+                    {data.review.openItems.map((item, i) => <li key={i}>{item}</li>)}
+                  </ul>
+                </>
+              )}
+            </Section>
+          )}
+
+          {data?.retro && (
+            <Section icon="🔄" title="Retrospective" defaultOpen={true}>
+              {data.retro.wentWell && data.retro.wentWell.length > 0 && (
+                <>
+                  <strong style={{ fontSize: 12, color: "var(--text-dim)" }}>What Went Well</strong>
+                  <ul className="retro-list well">
+                    {data.retro.wentWell.map((item, i) => <li key={i}>{item}</li>)}
+                  </ul>
+                </>
+              )}
+              {data.retro.wentBadly && data.retro.wentBadly.length > 0 && (
+                <div style={{ marginTop: 12 }}>
+                  <strong style={{ fontSize: 12, color: "var(--text-dim)" }}>What Could Improve</strong>
+                  <ul className="retro-list bad">
+                    {data.retro.wentBadly.map((item, i) => <li key={i}>{item}</li>)}
+                  </ul>
+                </div>
+              )}
+              {data.retro.improvements && data.retro.improvements.length > 0 && (
+                <div style={{ marginTop: 12 }}>
+                  <strong style={{ fontSize: 12, color: "var(--text-dim)" }}>Improvements</strong>
+                  <ul className="retro-list improve">
+                    {data.retro.improvements.map((imp, i) => (
+                      <li key={i}><strong>{imp.title}</strong>{imp.description ? `: ${imp.description}` : ""}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </Section>
+          )}
+        </>
+      )}
+
+      {copied && <div className="copied-toast">✅ Copied to clipboard</div>}
+    </div>
+  );
+}

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -122,3 +122,14 @@ test.describe("Dashboard Settings Page", () => {
     await expect(heading).toContainText("Settings", { timeout: 5000 });
   });
 });
+
+test.describe("Dashboard Sprint Report", () => {
+  test("report tab shows sprint report", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector(".tab-nav", { timeout: 10_000 });
+    const reportTab = page.locator("button.tab-btn", { hasText: "Report" });
+    await reportTab.click();
+    const heading = page.locator(".sprint-report h1");
+    await expect(heading).toContainText("Sprint Report", { timeout: 5000 });
+  });
+});


### PR DESCRIPTION
## Changes

Adds a Sprint Report view per #371.

**Report sections:**
| Section | Content |
|---------|---------|
| 📊 Summary Cards | Planned, Completed, Failed, First-pass rate, Duration, Merge conflicts |
| 📋 Issue Results | Table with status, quality gate checks (tests/lint/types/build), duration, files, retries |
| 🎯 Planning Rationale | Why these issues were selected |
| 🔍 Review | Summary, demo items, velocity update, open items |
| 🔄 Retrospective | What went well, what could improve, improvement actions |

**Features:**
- Sprint selector to view reports for any past sprint
- 📋 Copy Markdown — one-click copy to clipboard
- ⬇ Download .md — saves `sprint-N-report.md` file
- All sections collapsible
- Quality gate checks shown as colored badges per issue

**Data source:** `/api/sprints/:number/state` (already existed)

**Tests:** 573 unit + 14 E2E pass

Closes #371