### PR TITLE
fix(cli): web command starts without open milestone

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -274,12 +274,12 @@ function registerWeb(program: Command): void {
         let initialSprint = opts.sprint as number | undefined;
         if (!initialSprint) {
           const next = await getNextOpenMilestone(config.sprint.prefix);
-          if (!next) {
-            console.error(`❌ No open sprint milestones found (prefix: "${config.sprint.prefix}").`);
-            console.error(`   Create a milestone named '${config.sprint.prefix} N' in GitHub, or use --sprint <number>.`);
-            process.exit(1);
+          if (next) {
+            initialSprint = next.sprintNumber;
+          } else {
+            initialSprint = 1;
+            console.warn(`⚠️  No open sprint milestones found — defaulting to Sprint 1.`);
           }
-          initialSprint = next.sprintNumber;
         }
 
         redirectLogToFile(opts.logFile as string);


### PR DESCRIPTION
The `web` command crashed with `process.exit(1)` when no open milestone was found. Now it defaults to Sprint 1 with a warning, so the dashboard is always accessible for browsing past sprints and settings.

**Tests:** 573 pass

