### PR TITLE
fix(milestones): return undefined instead of throwing when no milestone found

### DIFF
--- a/src/github/milestones.ts
+++ b/src/github/milestones.ts
@@ -50,7 +50,7 @@ export async function getNextOpenMilestone(prefix: string = "Sprint"): Promise<{
     .sort((a, b) => a.sprintNumber - b.sprintNumber);
 
   if (sprintMilestones.length === 0) {
-    throw new Error(`No open milestone found matching sprint prefix. Create a milestone like "${prefix} 5" in GitHub.`);
+    return undefined;
   }
 
   logger.info({ sprint: sprintMilestones[0].sprintNumber, title: sprintMilestones[0].milestone.title }, "Found next open sprint milestone");


### PR DESCRIPTION
Root cause: `getNextOpenMilestone()` threw an error on line 53 instead of returning `undefined`. The fix in PR #374 added a null-check in commands.ts but the function never reached it because it threw first.

Now returns `undefined` — callers already handle this correctly (`commands.ts` defaults to Sprint 1, `runner.ts` breaks the loop gracefully).