### PR TITLE
feat(dashboard): editable Settings page with descriptions

### DIFF
--- a/src/dashboard/frontend/src/components/SettingsPage.css
+++ b/src/dashboard/frontend/src/components/SettingsPage.css
@@ -148,3 +148,81 @@
   font-size: 12px;
   color: var(--text-dim);
 }
+
+/* Editable fields */
+.settings-table td:nth-child(2) {
+  width: 200px;
+}
+
+.settings-table td:nth-child(3) {
+  color: var(--text-dim);
+  font-size: 12px;
+  padding-left: 16px;
+}
+
+.settings-input {
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 13px;
+  font-family: inherit;
+  width: 100%;
+  max-width: 300px;
+  box-sizing: border-box;
+}
+
+.settings-input:focus {
+  border-color: #58a6ff;
+  outline: none;
+}
+
+.settings-input-narrow {
+  max-width: 100px;
+}
+
+.settings-toggle {
+  cursor: pointer;
+  user-select: none;
+}
+
+.settings-actions {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 20px;
+  align-items: center;
+}
+
+.settings-actions .settings-dirty {
+  font-size: 12px;
+  color: #d29922;
+  font-weight: 500;
+}
+
+.settings-toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  z-index: 1000;
+  animation: settingsFade 2s ease-in-out forwards;
+}
+
+.settings-toast.success {
+  background: #3fb950;
+  color: #fff;
+}
+
+.settings-toast.error {
+  background: #f85149;
+  color: #fff;
+}
+
+@keyframes settingsFade {
+  0%, 70% { opacity: 1; }
+  100% { opacity: 0; }
+}

--- a/src/dashboard/frontend/src/components/SettingsPage.tsx
+++ b/src/dashboard/frontend/src/components/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import "./SettingsPage.css";
 
 interface McpServer {
@@ -55,11 +55,40 @@ interface Config {
   };
 }
 
-function BoolBadge({ value }: { value: boolean }) {
+// --- Reusable field components ---
+
+function Toggle({ value, onChange }: { value: boolean; onChange: (v: boolean) => void }) {
   return (
-    <span className={`settings-badge ${value ? "on" : "off"}`}>
-      {value ? "Enabled" : "Disabled"}
+    <span
+      className={`settings-badge settings-toggle ${value ? "on" : "off"}`}
+      onClick={() => onChange(!value)}
+    >
+      {value ? "✓ Enabled" : "✗ Disabled"}
     </span>
+  );
+}
+
+function NumInput({ value, onChange, min, max, narrow }: { value: number; onChange: (v: number) => void; min?: number; max?: number; narrow?: boolean }) {
+  return (
+    <input
+      type="number"
+      className={`settings-input ${narrow ? "settings-input-narrow" : ""}`}
+      value={value}
+      min={min}
+      max={max}
+      onChange={(e) => onChange(parseInt(e.target.value, 10) || 0)}
+    />
+  );
+}
+
+function TextInput({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <input
+      type="text"
+      className="settings-input"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
   );
 }
 
@@ -91,15 +120,71 @@ function Section({
   );
 }
 
+/** Row with label, editable value, and description */
+function Row({ label, desc, children }: { label: string; desc: string; children: React.ReactNode }) {
+  return (
+    <tr>
+      <td>{label}</td>
+      <td>{children}</td>
+      <td>{desc}</td>
+    </tr>
+  );
+}
+
 export function SettingsPage() {
   const [config, setConfig] = useState<Config | null>(null);
+  const [savedConfig, setSavedConfig] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<{ msg: string; type: "success" | "error" } | null>(null);
 
   useEffect(() => {
     fetch("/api/config")
       .then((r) => r.json())
-      .then((data) => setConfig(data as Config))
+      .then((data) => {
+        setConfig(data as Config);
+        setSavedConfig(JSON.stringify(data));
+      })
       .catch((e) => setError(String(e)));
+  }, []);
+
+  const isDirty = config ? JSON.stringify(config) !== savedConfig : false;
+
+  const save = useCallback(async () => {
+    if (!config) return;
+    try {
+      const res = await fetch("/api/config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(config),
+      });
+      if (res.ok) {
+        setSavedConfig(JSON.stringify(config));
+        setToast({ msg: "✅ Settings saved", type: "success" });
+      } else {
+        const data = await res.json();
+        setToast({ msg: `❌ ${data.error ?? "Save failed"}`, type: "error" });
+      }
+    } catch (e) {
+      setToast({ msg: `❌ ${String(e)}`, type: "error" });
+    }
+    setTimeout(() => setToast(null), 2500);
+  }, [config]);
+
+  const reset = useCallback(() => {
+    if (savedConfig) setConfig(JSON.parse(savedConfig));
+  }, [savedConfig]);
+
+  // Updater helpers
+  const up = useCallback(<K extends keyof Config>(section: K, patch: Partial<Config[K]>) => {
+    setConfig((prev) => prev ? { ...prev, [section]: { ...prev[section], ...patch } } : prev);
+  }, []);
+
+  const upQg = useCallback((patch: Partial<Config["quality_gates"]>) => up("quality_gates", patch), [up]);
+  const upSprint = useCallback((patch: Partial<Config["sprint"]>) => up("sprint", patch), [up]);
+  const upCopilot = useCallback((patch: Partial<Config["copilot"]>) => up("copilot", patch), [up]);
+  const upGit = useCallback((patch: Partial<Config["git"]>) => up("git", patch), [up]);
+  const upNotif = useCallback((patch: Partial<Config["escalation"]["notifications"]>) => {
+    setConfig((prev) => prev ? { ...prev, escalation: { ...prev.escalation, notifications: { ...prev.escalation.notifications, ...patch } } } : prev);
   }, []);
 
   if (error) return <div className="settings-loading">❌ Failed to load config: {error}</div>;
@@ -109,11 +194,25 @@ export function SettingsPage() {
     <div className="settings-page">
       <h1>⚙️ Settings</h1>
 
+      <div className="settings-actions">
+        <button className="btn btn-primary btn-small" onClick={save} disabled={!isDirty}>
+          💾 Save
+        </button>
+        <button className="btn btn-small" onClick={reset} disabled={!isDirty}>
+          ↩ Reset
+        </button>
+        {isDirty && <span className="settings-dirty">● Unsaved changes</span>}
+      </div>
+
       <Section icon="📁" title="Project" defaultOpen={true}>
         <table className="settings-table">
           <tbody>
-            <tr><td>Name</td><td>{config.project.name}</td></tr>
-            <tr><td>Base Branch</td><td><code>{config.project.base_branch}</code></td></tr>
+            <Row label="Name" desc="Display name for this project">
+              <TextInput value={config.project.name} onChange={(v) => up("project", { name: v })} />
+            </Row>
+            <Row label="Base Branch" desc="Main branch to merge PRs into (e.g. main, develop)">
+              <TextInput value={config.project.base_branch} onChange={(v) => up("project", { base_branch: v })} />
+            </Row>
           </tbody>
         </table>
       </Section>
@@ -121,56 +220,60 @@ export function SettingsPage() {
       <Section icon="🤖" title="Copilot" defaultOpen={true}>
         <table className="settings-table">
           <tbody>
-            <tr><td>Executable</td><td><code>{config.copilot.executable}</code></td></tr>
-            <tr><td>Max Parallel Sessions</td><td>{config.copilot.max_parallel_sessions}</td></tr>
-            <tr><td>Session Timeout</td><td>{Math.round(config.copilot.session_timeout_ms / 1000)}s</td></tr>
-            <tr><td>Auto-approve Tools</td><td><BoolBadge value={config.copilot.auto_approve_tools} /></td></tr>
-            {config.copilot.allow_tool_patterns.length > 0 && (
-              <tr>
-                <td>Tool Patterns</td>
-                <td>
-                  <ul className="settings-list">
-                    {config.copilot.allow_tool_patterns.map((p, i) => <li key={i}><code>{p}</code></li>)}
-                  </ul>
-                </td>
-              </tr>
-            )}
-            {config.copilot.instructions.length > 0 && (
-              <tr>
-                <td>Instructions</td>
-                <td>
-                  <ul className="settings-list">
-                    {config.copilot.instructions.map((inst, i) => <li key={i}>{inst}</li>)}
-                  </ul>
-                </td>
-              </tr>
-            )}
+            <Row label="Executable" desc="Path to the Copilot CLI binary">
+              <TextInput value={config.copilot.executable} onChange={(v) => upCopilot({ executable: v })} />
+            </Row>
+            <Row label="Max Parallel Sessions" desc="How many ACP sessions can run simultaneously (1-20)">
+              <NumInput value={config.copilot.max_parallel_sessions} onChange={(v) => upCopilot({ max_parallel_sessions: v })} min={1} max={20} narrow />
+            </Row>
+            <Row label="Session Timeout" desc="Max time (seconds) before an idle session is killed">
+              <NumInput value={Math.round(config.copilot.session_timeout_ms / 1000)} onChange={(v) => upCopilot({ session_timeout_ms: v * 1000 })} min={0} narrow />
+            </Row>
+            <Row label="Auto-approve Tools" desc="Automatically approve tool calls without human confirmation">
+              <Toggle value={config.copilot.auto_approve_tools} onChange={(v) => upCopilot({ auto_approve_tools: v })} />
+            </Row>
           </tbody>
         </table>
+        {config.copilot.instructions.length > 0 && (
+          <div style={{ marginTop: 8 }}>
+            <span style={{ fontSize: 12, color: "var(--text-dim)" }}>Instructions ({config.copilot.instructions.length})</span>
+            <ul className="settings-list">
+              {config.copilot.instructions.map((inst, i) => <li key={i}>{inst}</li>)}
+            </ul>
+          </div>
+        )}
       </Section>
 
       <Section icon="🏃" title="Sprint">
         <table className="settings-table">
           <tbody>
-            <tr><td>Prefix</td><td>{config.sprint.prefix}</td></tr>
-            <tr><td>Max Issues per Sprint</td><td>{config.sprint.max_issues}</td></tr>
-            <tr><td>Max Issues Created</td><td>{config.sprint.max_issues_created_per_sprint}</td></tr>
-            <tr><td>Max Sprints</td><td>{config.sprint.max_sprints === 0 ? "∞ (unlimited)" : config.sprint.max_sprints}</td></tr>
-            <tr><td>Max Drift Incidents</td><td>{config.sprint.max_drift_incidents}</td></tr>
-            <tr><td>Max Retries</td><td>{config.sprint.max_retries}</td></tr>
-            <tr><td>Challenger</td><td><BoolBadge value={config.sprint.enable_challenger} /></td></tr>
-            <tr><td>TDD</td><td><BoolBadge value={config.sprint.enable_tdd} /></td></tr>
-            <tr><td>Auto-revert Drift</td><td><BoolBadge value={config.sprint.auto_revert_drift} /></td></tr>
-            {config.sprint.backlog_labels.length > 0 && (
-              <tr>
-                <td>Backlog Labels</td>
-                <td>
-                  <ul className="settings-list">
-                    {config.sprint.backlog_labels.map((l, i) => <li key={i}><code>{l}</code></li>)}
-                  </ul>
-                </td>
-              </tr>
-            )}
+            <Row label="Prefix" desc="Milestone title prefix for sprint naming (e.g. 'Sprint' → 'Sprint 1')">
+              <TextInput value={config.sprint.prefix} onChange={(v) => upSprint({ prefix: v })} />
+            </Row>
+            <Row label="Max Issues" desc="Maximum issues to plan per sprint">
+              <NumInput value={config.sprint.max_issues} onChange={(v) => upSprint({ max_issues: v })} min={1} narrow />
+            </Row>
+            <Row label="Max Issues Created" desc="Max issues the agent can auto-create per sprint">
+              <NumInput value={config.sprint.max_issues_created_per_sprint} onChange={(v) => upSprint({ max_issues_created_per_sprint: v })} min={1} narrow />
+            </Row>
+            <Row label="Max Sprints" desc="Number of sprints to run in a loop (0 = unlimited)">
+              <NumInput value={config.sprint.max_sprints} onChange={(v) => upSprint({ max_sprints: v })} min={0} narrow />
+            </Row>
+            <Row label="Max Drift Incidents" desc="How many unplanned issues before escalation">
+              <NumInput value={config.sprint.max_drift_incidents} onChange={(v) => upSprint({ max_drift_incidents: v })} min={0} narrow />
+            </Row>
+            <Row label="Max Retries" desc="Retry attempts for a failed issue before giving up">
+              <NumInput value={config.sprint.max_retries} onChange={(v) => upSprint({ max_retries: v })} min={0} narrow />
+            </Row>
+            <Row label="Challenger" desc="Run adversarial review agent to challenge sprint decisions">
+              <Toggle value={config.sprint.enable_challenger} onChange={(v) => upSprint({ enable_challenger: v })} />
+            </Row>
+            <Row label="TDD" desc="Require test-driven development workflow for all issues">
+              <Toggle value={config.sprint.enable_tdd} onChange={(v) => upSprint({ enable_tdd: v })} />
+            </Row>
+            <Row label="Auto-revert Drift" desc="Automatically revert changes that cause sprint scope drift">
+              <Toggle value={config.sprint.auto_revert_drift} onChange={(v) => upSprint({ auto_revert_drift: v })} />
+            </Row>
           </tbody>
         </table>
       </Section>
@@ -178,16 +281,36 @@ export function SettingsPage() {
       <Section icon="🛡️" title="Quality Gates">
         <table className="settings-table">
           <tbody>
-            <tr><td>Tests</td><td><BoolBadge value={config.quality_gates.require_tests} /></td></tr>
-            <tr><td>Test Command</td><td><code>{cmdStr(config.quality_gates.test_command)}</code></td></tr>
-            <tr><td>Lint</td><td><BoolBadge value={config.quality_gates.require_lint} /></td></tr>
-            <tr><td>Lint Command</td><td><code>{cmdStr(config.quality_gates.lint_command)}</code></td></tr>
-            <tr><td>Type Check</td><td><BoolBadge value={config.quality_gates.require_types} /></td></tr>
-            <tr><td>Type Command</td><td><code>{cmdStr(config.quality_gates.typecheck_command)}</code></td></tr>
-            <tr><td>Build</td><td><BoolBadge value={config.quality_gates.require_build} /></td></tr>
-            <tr><td>Build Command</td><td><code>{cmdStr(config.quality_gates.build_command)}</code></td></tr>
-            <tr><td>Max Diff Lines</td><td>{config.quality_gates.max_diff_lines}</td></tr>
-            <tr><td>Challenger</td><td><BoolBadge value={config.quality_gates.require_challenger} /></td></tr>
+            <Row label="Tests" desc="Require tests to pass before merging">
+              <Toggle value={config.quality_gates.require_tests} onChange={(v) => upQg({ require_tests: v })} />
+            </Row>
+            <Row label="Test Command" desc="Command to run tests">
+              <TextInput value={cmdStr(config.quality_gates.test_command)} onChange={(v) => upQg({ test_command: v })} />
+            </Row>
+            <Row label="Lint" desc="Require linter to pass before merging">
+              <Toggle value={config.quality_gates.require_lint} onChange={(v) => upQg({ require_lint: v })} />
+            </Row>
+            <Row label="Lint Command" desc="Command to run linter">
+              <TextInput value={cmdStr(config.quality_gates.lint_command)} onChange={(v) => upQg({ lint_command: v })} />
+            </Row>
+            <Row label="Type Check" desc="Require type checking to pass before merging">
+              <Toggle value={config.quality_gates.require_types} onChange={(v) => upQg({ require_types: v })} />
+            </Row>
+            <Row label="Type Command" desc="Command to run type checker">
+              <TextInput value={cmdStr(config.quality_gates.typecheck_command)} onChange={(v) => upQg({ typecheck_command: v })} />
+            </Row>
+            <Row label="Build" desc="Require build to succeed before merging">
+              <Toggle value={config.quality_gates.require_build} onChange={(v) => upQg({ require_build: v })} />
+            </Row>
+            <Row label="Build Command" desc="Command to build the project">
+              <TextInput value={cmdStr(config.quality_gates.build_command)} onChange={(v) => upQg({ build_command: v })} />
+            </Row>
+            <Row label="Max Diff Lines" desc="Maximum lines changed per PR (exceeding triggers review)">
+              <NumInput value={config.quality_gates.max_diff_lines} onChange={(v) => upQg({ max_diff_lines: v })} min={1} narrow />
+            </Row>
+            <Row label="Challenger" desc="Require adversarial code review on every PR">
+              <Toggle value={config.quality_gates.require_challenger} onChange={(v) => upQg({ require_challenger: v })} />
+            </Row>
           </tbody>
         </table>
       </Section>
@@ -204,6 +327,9 @@ export function SettingsPage() {
               </div>
             </div>
           ))}
+          <div style={{ fontSize: 12, color: "var(--text-dim)", marginTop: 8 }}>
+            MCP servers connect external tools to Copilot sessions. Edit in <code>.aiscrum/config.yaml</code>.
+          </div>
         </Section>
       )}
 
@@ -214,30 +340,35 @@ export function SettingsPage() {
               <div className="settings-mcp-name">{phase}</div>
               <table className="settings-table">
                 <tbody>
-                  {cfg.model && <tr><td>Model</td><td><code>{cfg.model}</code></td></tr>}
+                  {cfg.model && <tr><td>Model</td><td><code>{cfg.model}</code></td><td>AI model for this phase</td></tr>}
                   {cfg.mcp_servers && cfg.mcp_servers.length > 0 && (
-                    <tr><td>MCP Servers</td><td>{cfg.mcp_servers.map((s) => s.name).join(", ")}</td></tr>
+                    <tr><td>MCP Servers</td><td>{cfg.mcp_servers.map((s) => s.name).join(", ")}</td><td>Additional servers for this phase</td></tr>
                   )}
                   {cfg.instructions && cfg.instructions.length > 0 && (
-                    <tr><td>Instructions</td><td>{cfg.instructions.length} custom</td></tr>
+                    <tr><td>Instructions</td><td>{cfg.instructions.length} custom</td><td>Extra instructions appended for this phase</td></tr>
                   )}
                 </tbody>
               </table>
             </div>
           ))}
+          <div style={{ fontSize: 12, color: "var(--text-dim)", marginTop: 8 }}>
+            Override model, MCP servers, or instructions per sprint phase. Edit in <code>.aiscrum/config.yaml</code>.
+          </div>
         </Section>
       )}
 
       <Section icon="🔔" title="Notifications">
         <table className="settings-table">
           <tbody>
-            <tr><td>ntfy</td><td><BoolBadge value={config.escalation.notifications.ntfy} /></td></tr>
-            {config.escalation.notifications.ntfy && (
-              <>
-                <tr><td>Topic</td><td><code>{config.escalation.notifications.ntfy_topic}</code></td></tr>
-                <tr><td>Server</td><td><code>{config.escalation.notifications.ntfy_server_url}</code></td></tr>
-              </>
-            )}
+            <Row label="ntfy" desc="Send push notifications via ntfy.sh when events occur">
+              <Toggle value={config.escalation.notifications.ntfy} onChange={(v) => upNotif({ ntfy: v })} />
+            </Row>
+            <Row label="Topic" desc="ntfy topic name for push notifications">
+              <TextInput value={config.escalation.notifications.ntfy_topic} onChange={(v) => upNotif({ ntfy_topic: v })} />
+            </Row>
+            <Row label="Server" desc="ntfy server URL (default: https://ntfy.sh)">
+              <TextInput value={config.escalation.notifications.ntfy_server_url} onChange={(v) => upNotif({ ntfy_server_url: v })} />
+            </Row>
           </tbody>
         </table>
       </Section>
@@ -245,14 +376,26 @@ export function SettingsPage() {
       <Section icon="🔀" title="Git">
         <table className="settings-table">
           <tbody>
-            <tr><td>Worktree Base</td><td><code>{config.git.worktree_base}</code></td></tr>
-            <tr><td>Branch Pattern</td><td><code>{config.git.branch_pattern}</code></td></tr>
-            <tr><td>Auto Merge</td><td><BoolBadge value={config.git.auto_merge} /></td></tr>
-            <tr><td>Squash Merge</td><td><BoolBadge value={config.git.squash_merge} /></td></tr>
-            <tr><td>Delete Branch After Merge</td><td><BoolBadge value={config.git.delete_branch_after_merge} /></td></tr>
+            <Row label="Worktree Base" desc="Directory where git worktrees are created for parallel work">
+              <TextInput value={config.git.worktree_base} onChange={(v) => upGit({ worktree_base: v })} />
+            </Row>
+            <Row label="Branch Pattern" desc="Pattern for feature branches. Placeholders: {prefix}, {sprint}, {issue}">
+              <TextInput value={config.git.branch_pattern} onChange={(v) => upGit({ branch_pattern: v })} />
+            </Row>
+            <Row label="Auto Merge" desc="Automatically merge PRs when all quality gates pass">
+              <Toggle value={config.git.auto_merge} onChange={(v) => upGit({ auto_merge: v })} />
+            </Row>
+            <Row label="Squash Merge" desc="Use squash merge instead of regular merge commits">
+              <Toggle value={config.git.squash_merge} onChange={(v) => upGit({ squash_merge: v })} />
+            </Row>
+            <Row label="Delete Branch" desc="Delete feature branch after successful merge">
+              <Toggle value={config.git.delete_branch_after_merge} onChange={(v) => upGit({ delete_branch_after_merge: v })} />
+            </Row>
           </tbody>
         </table>
       </Section>
+
+      {toast && <div className={`settings-toast ${toast.type}`}>{toast.msg}</div>}
     </div>
   );
 }

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -808,7 +808,7 @@ export class DashboardWebServer {
 
     // API routes
     if (url.pathname.startsWith("/api/")) {
-      this.handleApi(url, res);
+      this.handleApi(url, req, res);
       return;
     }
 
@@ -838,7 +838,7 @@ export class DashboardWebServer {
   }
 
   /** Handle REST API requests. */
-  private handleApi(url: URL, res: http.ServerResponse): void {
+  private handleApi(url: URL, req: http.IncomingMessage, res: http.ServerResponse): void {
     const pathname = url.pathname;
     res.setHeader("Content-Type", "application/json");
 
@@ -945,6 +945,31 @@ export class DashboardWebServer {
 
     // /api/config — full project config for the settings page
     if (pathname === "/api/config") {
+      if (req.method === "PUT" || req.method === "POST") {
+        let body = "";
+        req.on("data", (chunk: Buffer) => { body += chunk.toString(); });
+        req.on("end", () => {
+          try {
+            const newConfig = JSON.parse(body);
+            const projectPath = this.options.projectPath ?? process.cwd();
+            const configPath = path.join(projectPath, ".aiscrum", "config.yaml");
+            // Dynamic import to avoid top-level dep
+            import("yaml").then(({ stringify }) => {
+              fs.writeFileSync(configPath, stringify(newConfig, { lineWidth: 120 }), "utf-8");
+              this.options.config = newConfig;
+              res.writeHead(200, { "Content-Type": "application/json" });
+              res.end(JSON.stringify({ ok: true }));
+            }).catch((err) => {
+              res.writeHead(500);
+              res.end(JSON.stringify({ error: String(err) }));
+            });
+          } catch (err) {
+            res.writeHead(400);
+            res.end(JSON.stringify({ error: String(err) }));
+          }
+        });
+        return;
+      }
       const config = this.options.config ?? null;
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(config));


### PR DESCRIPTION
## Changes

Makes the Settings page fully editable with inline descriptions for every setting.

**Editable fields (with descriptions):**
- 📁 Project: name, base branch
- 🤖 Copilot: executable, max sessions, timeout, auto-approve
- 🏃 Sprint: prefix, max issues, drift limits, challenger, TDD, retries
- 🛡️ Quality Gates: test/lint/type/build toggles + commands, max diff, challenger
- 🔔 Notifications: ntfy toggle, topic, server
- 🔀 Git: worktree base, branch pattern, auto/squash merge, branch cleanup

**Save/Reset workflow:**
- 💾 Save → PUT /api/config → writes YAML to `.aiscrum/config.yaml`
- ↩ Reset → reverts to last saved state
- ● Unsaved changes indicator
- Toast on save success/failure

**Read-only sections** (complex config, edit via YAML):
- 🔌 MCP Servers
- 🔄 Phase Overrides

**Tests:** 573 unit + 14 E2E pass