### PR TITLE
feat: min_issues config, agent role editor, quality gates UI (#377, #378)

### DIFF
--- a/.aiscrum/roles/planner/prompts/planning.md
+++ b/.aiscrum/roles/planner/prompts/planning.md
@@ -8,6 +8,7 @@ You are the **Sprint Planning Agent** for the AI-Scrum autonomous sprint runner.
 - **Repository**: {{REPO_OWNER}}/{{REPO_NAME}}
 - **Sprint**: {{SPRINT_NUMBER}}
 - **Max issues per sprint**: {{MAX_ISSUES}}
+- **Min issues per sprint**: {{MIN_ISSUES}} (0 = no minimum)
 - **Base branch**: {{BASE_BRANCH}}
 
 ## Data Sources
@@ -87,6 +88,7 @@ Before finalizing the plan:
 - [ ] Each issue has `acceptanceCriteria` summarizing what must be true when done
 - [ ] Dependency order is consistent (no circular dependencies)
 - [ ] Sprint size ≤ {{MAX_ISSUES}} issues
+- [ ] Sprint size ≥ {{MIN_ISSUES}} issues (if enough eligible issues exist)
 - [ ] If >{{MAX_ISSUES}} eligible issues, defer lowest-ICE issues to backlog
 
 ## Constraints

--- a/src/ceremonies/planning.ts
+++ b/src/ceremonies/planning.ts
@@ -32,6 +32,7 @@ export async function runSprintPlanning(
     REPO_OWNER: config.repoOwner,
     REPO_NAME: config.repoName,
     SPRINT_NUMBER: String(config.sprintNumber),
+    MIN_ISSUES: String(config.minIssuesPerSprint),
     MAX_ISSUES: String(config.maxIssuesPerSprint),
     BASE_BRANCH: config.baseBranch,
   });

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -37,6 +37,7 @@ export function buildSprintConfig(config: ConfigFile, sprintNumber: number): Spr
     worktreeBase: config.git.worktree_base,
     branchPattern: config.git.branch_pattern,
     maxParallelSessions: config.copilot.max_parallel_sessions,
+    minIssuesPerSprint: config.sprint.min_issues,
     maxIssuesPerSprint: config.sprint.max_issues,
     maxDriftIncidents: config.sprint.max_drift_incidents,
     maxRetries: config.sprint.max_retries,

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,6 +64,7 @@ const CopilotSchema = z.object({
 
 const SprintSchema = z.object({
   prefix: z.string().min(1).default("Sprint"),
+  min_issues: z.number().int().min(0).default(0),
   max_issues: z.number().int().min(1).default(8),
   max_issues_created_per_sprint: z.number().int().min(1).default(10),
   max_sprints: z.number().int().min(0).default(0), // 0 = infinite

--- a/src/dashboard/frontend/src/components/SettingsPage.css
+++ b/src/dashboard/frontend/src/components/SettingsPage.css
@@ -226,3 +226,74 @@
   0%, 70% { opacity: 1; }
   100% { opacity: 0; }
 }
+
+/* Role Editor */
+.role-editor {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin-bottom: 12px;
+  overflow: hidden;
+}
+
+.role-editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  background: var(--bg);
+  cursor: pointer;
+  user-select: none;
+}
+
+.role-editor-header h4 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.role-editor-desc {
+  font-size: 12px;
+  color: var(--text-dim);
+  font-weight: 400;
+}
+
+.role-editor-body {
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.role-editor-body label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-dim);
+  margin-bottom: 4px;
+  display: block;
+}
+
+.role-editor-body textarea {
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px;
+  font-size: 12px;
+  font-family: "SF Mono", "Fira Code", monospace;
+  resize: vertical;
+  min-height: 120px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.role-editor-body textarea:focus {
+  border-color: #58a6ff;
+  outline: none;
+}
+
+.role-editor-save {
+  align-self: flex-end;
+}

--- a/src/dashboard/frontend/src/components/SettingsPage.tsx
+++ b/src/dashboard/frontend/src/components/SettingsPage.tsx
@@ -23,6 +23,7 @@ interface Config {
   };
   sprint: {
     prefix: string;
+    min_issues: number;
     max_issues: number;
     max_issues_created_per_sprint: number;
     max_sprints: number;
@@ -131,23 +132,115 @@ function Row({ label, desc, children }: { label: string; desc: string; children:
   );
 }
 
+interface AgentRole {
+  name: string;
+  instructions: string;
+  prompts: Record<string, string>;
+}
+
+interface QualityGates {
+  checks: {
+    tests: { enabled: boolean; command?: string | string[] };
+    lint: { enabled: boolean; command?: string | string[] };
+    types: { enabled: boolean; command?: string | string[] };
+    build: { enabled: boolean; command?: string | string[] };
+  };
+  limits: { max_diff_lines: number };
+  review: { require_challenger: boolean };
+}
+
+const ROLE_DESCRIPTIONS: Record<string, string> = {
+  planner: "Sprint planning — selects and sequences backlog issues",
+  general: "Issue execution — implements code changes for each issue",
+  reviewer: "Code review — reviews PRs for quality and correctness",
+  "quality-reviewer": "Acceptance review — validates acceptance criteria",
+  "test-engineer": "TDD — generates tests before implementation",
+  refiner: "Refinement — enriches idea issues with details and ICE scores",
+  retro: "Retrospective — analyzes sprint and suggests improvements",
+  researcher: "Research — investigates technical topics and options",
+};
+
+function RoleEditor({ role, onSave }: { role: AgentRole; onSave: (r: AgentRole) => void }) {
+  const [instructions, setInstructions] = useState(role.instructions);
+  const [prompts, setPrompts] = useState(role.prompts);
+  const [dirty, setDirty] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  const update = (field: "instructions" | string, value: string) => {
+    if (field === "instructions") {
+      setInstructions(value);
+    } else {
+      setPrompts((prev) => ({ ...prev, [field]: value }));
+    }
+    setDirty(true);
+  };
+
+  const save = () => {
+    onSave({ ...role, instructions, prompts });
+    setDirty(false);
+  };
+
+  return (
+    <div className="role-editor">
+      <div className="role-editor-header" onClick={() => setOpen(!open)}>
+        <h4>
+          <span>{open ? "▾" : "▸"}</span>
+          {role.name}
+          <span className="role-editor-desc">{ROLE_DESCRIPTIONS[role.name] ?? "Agent role"}</span>
+        </h4>
+        {dirty && <button className="btn btn-primary btn-small role-editor-save" onClick={(e) => { e.stopPropagation(); save(); }}>💾 Save</button>}
+      </div>
+      {open && (
+        <div className="role-editor-body">
+          <div>
+            <label>Instructions (copilot-instructions.md)</label>
+            <textarea value={instructions} onChange={(e) => update("instructions", e.target.value)} />
+          </div>
+          {Object.entries(prompts).map(([fname, content]) => (
+            <div key={fname}>
+              <label>Prompt: {fname}</label>
+              <textarea
+                style={{ minHeight: 180 }}
+                value={content}
+                onChange={(e) => update(fname, e.target.value)}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function SettingsPage() {
   const [config, setConfig] = useState<Config | null>(null);
   const [savedConfig, setSavedConfig] = useState<string>("");
+  const [roles, setRoles] = useState<AgentRole[]>([]);
+  const [qualityGates, setQualityGates] = useState<QualityGates | null>(null);
+  const [savedQg, setSavedQg] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<{ msg: string; type: "success" | "error" } | null>(null);
 
   useEffect(() => {
-    fetch("/api/config")
-      .then((r) => r.json())
-      .then((data) => {
-        setConfig(data as Config);
-        setSavedConfig(JSON.stringify(data));
-      })
-      .catch((e) => setError(String(e)));
+    Promise.all([
+      fetch("/api/config").then((r) => r.json()),
+      fetch("/api/roles").then((r) => r.json()),
+      fetch("/api/quality-gates").then((r) => r.json()),
+    ]).then(([cfg, rls, qg]) => {
+      setConfig(cfg as Config);
+      setSavedConfig(JSON.stringify(cfg));
+      setRoles((rls as AgentRole[]) ?? []);
+      if (qg) { setQualityGates(qg as QualityGates); setSavedQg(JSON.stringify(qg)); }
+    }).catch((e) => setError(String(e)));
   }, []);
 
   const isDirty = config ? JSON.stringify(config) !== savedConfig : false;
+  const qgDirty = qualityGates ? JSON.stringify(qualityGates) !== savedQg : false;
+
+  const showToast = useCallback((msg: string, type: "success" | "error") => {
+    setToast({ msg, type });
+    setTimeout(() => setToast(null), 2500);
+  }, []);
 
   const save = useCallback(async () => {
     if (!config) return;
@@ -159,20 +252,47 @@ export function SettingsPage() {
       });
       if (res.ok) {
         setSavedConfig(JSON.stringify(config));
-        setToast({ msg: "✅ Settings saved", type: "success" });
+        // Also save quality gates if dirty
+        if (qualityGates && qgDirty) {
+          const qgRes = await fetch("/api/quality-gates", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(qualityGates),
+          });
+          if (qgRes.ok) setSavedQg(JSON.stringify(qualityGates));
+        }
+        showToast("✅ Settings saved", "success");
       } else {
         const data = await res.json();
-        setToast({ msg: `❌ ${data.error ?? "Save failed"}`, type: "error" });
+        showToast(`❌ ${data.error ?? "Save failed"}`, "error");
       }
     } catch (e) {
-      setToast({ msg: `❌ ${String(e)}`, type: "error" });
+      showToast(`❌ ${String(e)}`, "error");
     }
-    setTimeout(() => setToast(null), 2500);
-  }, [config]);
+  }, [config, qualityGates, qgDirty, showToast]);
 
   const reset = useCallback(() => {
     if (savedConfig) setConfig(JSON.parse(savedConfig));
-  }, [savedConfig]);
+    if (savedQg) setQualityGates(JSON.parse(savedQg));
+  }, [savedConfig, savedQg]);
+
+  const saveRole = useCallback(async (role: AgentRole) => {
+    try {
+      const res = await fetch("/api/roles", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(role),
+      });
+      if (res.ok) {
+        setRoles((prev) => prev.map((r) => r.name === role.name ? role : r));
+        showToast(`✅ ${role.name} saved`, "success");
+      } else {
+        showToast(`❌ Failed to save ${role.name}`, "error");
+      }
+    } catch (e) {
+      showToast(`❌ ${String(e)}`, "error");
+    }
+  }, [showToast]);
 
   // Updater helpers
   const up = useCallback(<K extends keyof Config>(section: K, patch: Partial<Config[K]>) => {
@@ -186,6 +306,15 @@ export function SettingsPage() {
   const upNotif = useCallback((patch: Partial<Config["escalation"]["notifications"]>) => {
     setConfig((prev) => prev ? { ...prev, escalation: { ...prev.escalation, notifications: { ...prev.escalation.notifications, ...patch } } } : prev);
   }, []);
+  const upQgCheck = useCallback((check: keyof QualityGates["checks"], patch: Partial<{ enabled: boolean; command: string | string[] }>) => {
+    setQualityGates((prev) => prev ? { ...prev, checks: { ...prev.checks, [check]: { ...prev.checks[check], ...patch } } } : prev);
+  }, []);
+  const upQgLimits = useCallback((patch: Partial<QualityGates["limits"]>) => {
+    setQualityGates((prev) => prev ? { ...prev, limits: { ...prev.limits, ...patch } } : prev);
+  }, []);
+  const upQgReview = useCallback((patch: Partial<QualityGates["review"]>) => {
+    setQualityGates((prev) => prev ? { ...prev, review: { ...prev.review, ...patch } } : prev);
+  }, []);
 
   if (error) return <div className="settings-loading">❌ Failed to load config: {error}</div>;
   if (!config) return <div className="settings-loading">Loading configuration…</div>;
@@ -195,13 +324,13 @@ export function SettingsPage() {
       <h1>⚙️ Settings</h1>
 
       <div className="settings-actions">
-        <button className="btn btn-primary btn-small" onClick={save} disabled={!isDirty}>
+        <button className="btn btn-primary btn-small" onClick={save} disabled={!isDirty && !qgDirty}>
           💾 Save
         </button>
-        <button className="btn btn-small" onClick={reset} disabled={!isDirty}>
+        <button className="btn btn-small" onClick={reset} disabled={!isDirty && !qgDirty}>
           ↩ Reset
         </button>
-        {isDirty && <span className="settings-dirty">● Unsaved changes</span>}
+        {(isDirty || qgDirty) && <span className="settings-dirty">● Unsaved changes</span>}
       </div>
 
       <Section icon="📁" title="Project" defaultOpen={true}>
@@ -250,6 +379,9 @@ export function SettingsPage() {
             <Row label="Prefix" desc="Milestone title prefix for sprint naming (e.g. 'Sprint' → 'Sprint 1')">
               <TextInput value={config.sprint.prefix} onChange={(v) => upSprint({ prefix: v })} />
             </Row>
+            <Row label="Min Issues" desc="Minimum issues to plan per sprint (0 = no minimum)">
+              <NumInput value={config.sprint.min_issues} onChange={(v) => upSprint({ min_issues: v })} min={0} narrow />
+            </Row>
             <Row label="Max Issues" desc="Maximum issues to plan per sprint">
               <NumInput value={config.sprint.max_issues} onChange={(v) => upSprint({ max_issues: v })} min={1} narrow />
             </Row>
@@ -279,40 +411,77 @@ export function SettingsPage() {
       </Section>
 
       <Section icon="🛡️" title="Quality Gates">
-        <table className="settings-table">
-          <tbody>
-            <Row label="Tests" desc="Require tests to pass before merging">
-              <Toggle value={config.quality_gates.require_tests} onChange={(v) => upQg({ require_tests: v })} />
-            </Row>
-            <Row label="Test Command" desc="Command to run tests">
-              <TextInput value={cmdStr(config.quality_gates.test_command)} onChange={(v) => upQg({ test_command: v })} />
-            </Row>
-            <Row label="Lint" desc="Require linter to pass before merging">
-              <Toggle value={config.quality_gates.require_lint} onChange={(v) => upQg({ require_lint: v })} />
-            </Row>
-            <Row label="Lint Command" desc="Command to run linter">
-              <TextInput value={cmdStr(config.quality_gates.lint_command)} onChange={(v) => upQg({ lint_command: v })} />
-            </Row>
-            <Row label="Type Check" desc="Require type checking to pass before merging">
-              <Toggle value={config.quality_gates.require_types} onChange={(v) => upQg({ require_types: v })} />
-            </Row>
-            <Row label="Type Command" desc="Command to run type checker">
-              <TextInput value={cmdStr(config.quality_gates.typecheck_command)} onChange={(v) => upQg({ typecheck_command: v })} />
-            </Row>
-            <Row label="Build" desc="Require build to succeed before merging">
-              <Toggle value={config.quality_gates.require_build} onChange={(v) => upQg({ require_build: v })} />
-            </Row>
-            <Row label="Build Command" desc="Command to build the project">
-              <TextInput value={cmdStr(config.quality_gates.build_command)} onChange={(v) => upQg({ build_command: v })} />
-            </Row>
-            <Row label="Max Diff Lines" desc="Maximum lines changed per PR (exceeding triggers review)">
-              <NumInput value={config.quality_gates.max_diff_lines} onChange={(v) => upQg({ max_diff_lines: v })} min={1} narrow />
-            </Row>
-            <Row label="Challenger" desc="Require adversarial code review on every PR">
-              <Toggle value={config.quality_gates.require_challenger} onChange={(v) => upQg({ require_challenger: v })} />
-            </Row>
-          </tbody>
-        </table>
+        {qualityGates ? (
+          <table className="settings-table">
+            <tbody>
+              <Row label="Tests" desc="Require tests to pass before merging">
+                <Toggle value={qualityGates.checks.tests.enabled} onChange={(v) => upQgCheck("tests", { enabled: v })} />
+              </Row>
+              <Row label="Test Command" desc="Shell command to run tests">
+                <TextInput value={cmdStr(qualityGates.checks.tests.command ?? "")} onChange={(v) => upQgCheck("tests", { command: v })} />
+              </Row>
+              <Row label="Lint" desc="Require linter to pass before merging">
+                <Toggle value={qualityGates.checks.lint.enabled} onChange={(v) => upQgCheck("lint", { enabled: v })} />
+              </Row>
+              <Row label="Lint Command" desc="Shell command to run linter">
+                <TextInput value={cmdStr(qualityGates.checks.lint.command ?? "")} onChange={(v) => upQgCheck("lint", { command: v })} />
+              </Row>
+              <Row label="Type Check" desc="Require type checking to pass before merging">
+                <Toggle value={qualityGates.checks.types.enabled} onChange={(v) => upQgCheck("types", { enabled: v })} />
+              </Row>
+              <Row label="Type Command" desc="Shell command to run type checker">
+                <TextInput value={cmdStr(qualityGates.checks.types.command ?? "")} onChange={(v) => upQgCheck("types", { command: v })} />
+              </Row>
+              <Row label="Build" desc="Require build to succeed before merging">
+                <Toggle value={qualityGates.checks.build.enabled} onChange={(v) => upQgCheck("build", { enabled: v })} />
+              </Row>
+              <Row label="Build Command" desc="Shell command to build the project">
+                <TextInput value={cmdStr(qualityGates.checks.build.command ?? "")} onChange={(v) => upQgCheck("build", { command: v })} />
+              </Row>
+              <Row label="Max Diff Lines" desc="Maximum lines changed per PR before extra review is triggered">
+                <NumInput value={qualityGates.limits.max_diff_lines} onChange={(v) => upQgLimits({ max_diff_lines: v })} min={1} narrow />
+              </Row>
+              <Row label="Challenger" desc="Require adversarial review agent to challenge every PR">
+                <Toggle value={qualityGates.review.require_challenger} onChange={(v) => upQgReview({ require_challenger: v })} />
+              </Row>
+            </tbody>
+          </table>
+        ) : (
+          <table className="settings-table">
+            <tbody>
+              <Row label="Tests" desc="Require tests to pass before merging">
+                <Toggle value={config.quality_gates.require_tests} onChange={(v) => upQg({ require_tests: v })} />
+              </Row>
+              <Row label="Test Command" desc="Command to run tests">
+                <TextInput value={cmdStr(config.quality_gates.test_command)} onChange={(v) => upQg({ test_command: v })} />
+              </Row>
+              <Row label="Lint" desc="Require linter to pass before merging">
+                <Toggle value={config.quality_gates.require_lint} onChange={(v) => upQg({ require_lint: v })} />
+              </Row>
+              <Row label="Lint Command" desc="Command to run linter">
+                <TextInput value={cmdStr(config.quality_gates.lint_command)} onChange={(v) => upQg({ lint_command: v })} />
+              </Row>
+              <Row label="Type Check" desc="Require type checking to pass before merging">
+                <Toggle value={config.quality_gates.require_types} onChange={(v) => upQg({ require_types: v })} />
+              </Row>
+              <Row label="Type Command" desc="Command to run type checker">
+                <TextInput value={cmdStr(config.quality_gates.typecheck_command)} onChange={(v) => upQg({ typecheck_command: v })} />
+              </Row>
+              <Row label="Build" desc="Require build to succeed before merging">
+                <Toggle value={config.quality_gates.require_build} onChange={(v) => upQg({ require_build: v })} />
+              </Row>
+              <Row label="Build Command" desc="Command to build the project">
+                <TextInput value={cmdStr(config.quality_gates.build_command)} onChange={(v) => upQg({ build_command: v })} />
+              </Row>
+              <Row label="Max Diff Lines" desc="Maximum lines changed per PR">
+                <NumInput value={config.quality_gates.max_diff_lines} onChange={(v) => upQg({ max_diff_lines: v })} min={1} narrow />
+              </Row>
+              <Row label="Challenger" desc="Require adversarial code review on every PR">
+                <Toggle value={config.quality_gates.require_challenger} onChange={(v) => upQg({ require_challenger: v })} />
+              </Row>
+            </tbody>
+          </table>
+        )}
       </Section>
 
       {config.copilot.mcp_servers.length > 0 && (
@@ -394,6 +563,17 @@ export function SettingsPage() {
           </tbody>
         </table>
       </Section>
+
+      {roles.length > 0 && (
+        <Section icon="🤖" title={`Agent Roles (${roles.length})`}>
+          <div style={{ fontSize: 13, color: "var(--text-dim)", marginBottom: 12 }}>
+            Each agent role has system instructions and prompt templates. Edit the content below and save per role.
+          </div>
+          {roles.map((role) => (
+            <RoleEditor key={role.name} role={role} onSave={saveRole} />
+          ))}
+        </Section>
+      )}
 
       {toast && <div className={`settings-toast ${toast.type}`}>{toast.msg}</div>}
     </div>

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -976,6 +976,93 @@ export class DashboardWebServer {
       return;
     }
 
+    // /api/roles — list agent roles with instructions and prompts
+    if (pathname === "/api/roles") {
+      const projectPath = this.options.projectPath ?? process.cwd();
+      const rolesDir = path.join(projectPath, ".aiscrum", "roles");
+      if (req.method === "PUT" || req.method === "POST") {
+        let body = "";
+        req.on("data", (chunk: Buffer) => { body += chunk.toString(); });
+        req.on("end", () => {
+          try {
+            const { name, instructions, prompts } = JSON.parse(body) as {
+              name: string;
+              instructions?: string;
+              prompts?: Record<string, string>;
+            };
+            const roleDir = path.join(rolesDir, name);
+            if (!fs.existsSync(roleDir)) { res.writeHead(404); res.end(JSON.stringify({ error: "Role not found" })); return; }
+            if (instructions !== undefined) {
+              fs.writeFileSync(path.join(roleDir, "copilot-instructions.md"), instructions, "utf-8");
+            }
+            if (prompts) {
+              const promptsDir = path.join(roleDir, "prompts");
+              for (const [fname, content] of Object.entries(prompts)) {
+                const target = path.join(promptsDir, fname);
+                if (fs.existsSync(target)) fs.writeFileSync(target, content, "utf-8");
+              }
+            }
+            res.writeHead(200); res.end(JSON.stringify({ ok: true }));
+          } catch (err) { res.writeHead(400); res.end(JSON.stringify({ error: String(err) })); }
+        });
+        return;
+      }
+      // GET: list all roles
+      try {
+        const roles: Array<{ name: string; instructions: string; prompts: Record<string, string> }> = [];
+        if (fs.existsSync(rolesDir)) {
+          for (const entry of fs.readdirSync(rolesDir, { withFileTypes: true })) {
+            if (!entry.isDirectory()) continue;
+            const roleDir = path.join(rolesDir, entry.name);
+            const instrPath = path.join(roleDir, "copilot-instructions.md");
+            const instructions = fs.existsSync(instrPath) ? fs.readFileSync(instrPath, "utf-8") : "";
+            const prompts: Record<string, string> = {};
+            const promptsDir = path.join(roleDir, "prompts");
+            if (fs.existsSync(promptsDir)) {
+              for (const pf of fs.readdirSync(promptsDir)) {
+                if (pf.endsWith(".md")) prompts[pf] = fs.readFileSync(path.join(promptsDir, pf), "utf-8");
+              }
+            }
+            roles.push({ name: entry.name, instructions, prompts });
+          }
+        }
+        res.writeHead(200); res.end(JSON.stringify(roles));
+      } catch (err) { res.writeHead(500); res.end(JSON.stringify({ error: String(err) })); }
+      return;
+    }
+
+    // /api/quality-gates — read/write quality-gates.yaml
+    if (pathname === "/api/quality-gates") {
+      const projectPath = this.options.projectPath ?? process.cwd();
+      const qgPath = path.join(projectPath, ".aiscrum", "quality-gates.yaml");
+      if (req.method === "PUT" || req.method === "POST") {
+        let body = "";
+        req.on("data", (chunk: Buffer) => { body += chunk.toString(); });
+        req.on("end", () => {
+          try {
+            const data = JSON.parse(body);
+            import("yaml").then(({ stringify }) => {
+              fs.writeFileSync(qgPath, stringify(data, { lineWidth: 120 }), "utf-8");
+              res.writeHead(200); res.end(JSON.stringify({ ok: true }));
+            }).catch((err) => { res.writeHead(500); res.end(JSON.stringify({ error: String(err) })); });
+          } catch (err) { res.writeHead(400); res.end(JSON.stringify({ error: String(err) })); }
+        });
+        return;
+      }
+      // GET
+      try {
+        if (fs.existsSync(qgPath)) {
+          const raw = fs.readFileSync(qgPath, "utf-8");
+          import("yaml").then(({ parse: parseYaml }) => {
+            res.writeHead(200); res.end(JSON.stringify(parseYaml(raw)));
+          }).catch((err) => { res.writeHead(500); res.end(JSON.stringify({ error: String(err) })); });
+        } else {
+          res.writeHead(200); res.end(JSON.stringify(null));
+        }
+      } catch (err) { res.writeHead(500); res.end(JSON.stringify({ error: String(err) })); }
+      return;
+    }
+
     res.writeHead(404);
     res.end(JSON.stringify({ error: "Not found" }));
   }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -55,6 +55,7 @@ export interface SessionConfig {
 }
 
 export interface ExecutionLimits {
+  minIssuesPerSprint: number;
   maxIssuesPerSprint: number;
   maxIssuesCreatedPerSprint?: number;
   maxRetries: number;


### PR DESCRIPTION
## Changes

### min_issues per sprint (#377)
- Added `min_issues` to sprint config Zod schema (default: 0)
- Mapped to `minIssuesPerSprint` in ExecutionLimits type
- Added `MIN_ISSUES` substitution to planning prompt template
- Editable in Settings UI

### Agent Role Editor (#377)
- `/api/roles` GET — lists all agent roles with instructions + prompt files
- `/api/roles` PUT — saves instructions/prompts back to disk
- Collapsible role editor cards in Settings with monospace textareas
- Covers all 8 roles: planner, general, reviewer, quality-reviewer, test-engineer, refiner, retro, researcher

### Quality Gates Editor (#378)
- `/api/quality-gates` GET/PUT — reads/writes `.aiscrum/quality-gates.yaml`
- Quality Gates section now edits the dedicated YAML file when available
- Toggle enable/disable per gate, edit commands, max diff lines, challenger toggle
- Falls back to config.yaml quality_gates section if no quality-gates.yaml exists

### Tests
- 573 unit tests pass ✅
- Build succeeds ✅
- Type check clean ✅

Closes #377, Closes #378