### PR TITLE
fix: Settings UI overhaul — editable skills, MCP, QG commands, Logs tab

### DIFF
--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -7,9 +7,10 @@ import { BacklogTab, BlockedTab, DecisionsTab, IdeasTab } from "./components/Tab
 import { SidePanel } from "./components/SidePanel";
 import { SettingsPage } from "./components/SettingsPage";
 import { SprintReport } from "./components/SprintReport";
+import { LogTerminal } from "./components/LogTerminal";
 import "./index.css";
 
-type Tab = "sprint" | "sprint-backlog" | "backlog" | "blocked" | "decisions" | "ideas" | "report" | "settings";
+type Tab = "sprint" | "sprint-backlog" | "backlog" | "blocked" | "decisions" | "ideas" | "report" | "settings" | "logs";
 
 const TABS: { id: Tab; label: string; icon: string }[] = [
   { id: "sprint", label: "Sprint", icon: "🏃" },
@@ -19,6 +20,7 @@ const TABS: { id: Tab; label: string; icon: string }[] = [
   { id: "decisions", label: "Decisions", icon: "⚖️" },
   { id: "ideas", label: "Ideas", icon: "💡" },
   { id: "report", label: "Report", icon: "📊" },
+  { id: "logs", label: "Logs", icon: "📜" },
   { id: "settings", label: "Settings", icon: "⚙️" },
 ];
 
@@ -92,7 +94,7 @@ export default function App() {
           </button>
         ))}
         <div className="tab-nav-spacer" />
-        {activeTab !== "sprint" && activeTab !== "settings" && (
+        {activeTab !== "sprint" && activeTab !== "settings" && activeTab !== "logs" && (
           <button
             className={`tab-btn agent-toggle-btn ${chatPanelOpen ? "tab-active" : ""}`}
             onClick={toggleAgentPanel}
@@ -112,9 +114,10 @@ export default function App() {
           {activeTab === "decisions" && <DecisionsTab />}
           {activeTab === "ideas" && <IdeasTab />}
           {activeTab === "report" && <SprintReport />}
+          {activeTab === "logs" && <div style={{ height: "100%", display: "flex", flexDirection: "column" }}><LogTerminal /></div>}
           {activeTab === "settings" && <SettingsPage />}
         </div>
-        {chatPanelOpen && activeTab !== "sprint" && activeTab !== "settings" && (
+        {chatPanelOpen && activeTab !== "sprint" && activeTab !== "settings" && activeTab !== "logs" && (
           <>
             <div className="app-resize-handle" onMouseDown={onMouseDown} />
             <div className="app-side" style={{ width: sideWidth }}>

--- a/src/dashboard/frontend/src/components/SettingsPage.css
+++ b/src/dashboard/frontend/src/components/SettingsPage.css
@@ -284,13 +284,13 @@
   font-size: 12px;
   font-family: "SF Mono", "Fira Code", monospace;
   resize: vertical;
-  min-height: 200px;
+  min-height: 350px;
   width: 100%;
   box-sizing: border-box;
 }
 
 .role-editor-body textarea.role-prompt-textarea {
-  min-height: 300px;
+  min-height: 500px;
 }
 
 .role-editor-body textarea:focus {
@@ -417,4 +417,99 @@
 .role-skill-desc,
 .role-mcp-detail {
   color: var(--text-dim);
+}
+
+/* Quality Gates grid */
+.qg-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  padding: 4px;
+}
+
+.qg-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px;
+}
+
+.qg-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.qg-card-title {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.qg-command-textarea {
+  width: 100%;
+  min-height: 60px;
+  background: #0d1117;
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px;
+  font-family: "SF Mono", "Fira Code", monospace;
+  font-size: 12px;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.qg-command-textarea:focus {
+  border-color: #58a6ff;
+  outline: none;
+}
+
+/* Role section labels */
+.role-section-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin-top: 8px;
+  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+}
+
+.role-empty-hint {
+  font-size: 12px;
+  color: var(--text-dim);
+  font-style: italic;
+  margin-bottom: 8px;
+}
+
+.role-empty-hint code {
+  color: #d2a8ff;
+}
+
+/* Skill textarea */
+.role-skill-textarea {
+  min-height: 200px !important;
+}
+
+/* MCP edit row */
+.role-mcp-edit-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 6px;
+  align-items: center;
+}
+
+.role-mcp-edit-row .settings-input {
+  flex: 1;
+}
+
+.btn-danger {
+  background: rgba(248, 81, 73, 0.15);
+  color: #f85149;
+  border: 1px solid rgba(248, 81, 73, 0.3);
+}
+
+.btn-danger:hover {
+  background: rgba(248, 81, 73, 0.3);
 }

--- a/src/dashboard/frontend/src/components/SettingsPage.tsx
+++ b/src/dashboard/frontend/src/components/SettingsPage.tsx
@@ -142,8 +142,8 @@ interface AgentRole {
   prompts: Record<string, string>;
   model?: string;
   mode?: string;
-  skills: Array<{ name: string; description: string }>;
-  mcp_servers: Array<{ name: string; type: string; command?: string; url?: string }>;
+  skills: Array<{ name: string; description: string; content: string; dirName: string }>;
+  mcp_servers: Array<{ name: string; type: string; command?: string; url?: string; args?: string[] }>;
 }
 
 interface QualityGates {
@@ -295,6 +295,10 @@ function RoleEditor({ role, onSave }: { role: AgentRole; onSave: (r: AgentRole) 
   const [prompts, setPrompts] = useState(role.prompts);
   const [model, setModel] = useState(role.model ?? "");
   const [mode, setMode] = useState(role.mode ?? "autonomous");
+  const [skills, setSkills] = useState<Record<string, string>>(
+    Object.fromEntries(role.skills.map((s) => [s.dirName, s.content]))
+  );
+  const [mcpServers, setMcpServers] = useState(role.mcp_servers);
   const [dirty, setDirty] = useState(false);
   const [open, setOpen] = useState(false);
 
@@ -307,8 +311,36 @@ function RoleEditor({ role, onSave }: { role: AgentRole; onSave: (r: AgentRole) 
     setDirty(true);
   };
 
+  const updateSkill = (dirName: string, content: string) => {
+    setSkills((prev) => ({ ...prev, [dirName]: content }));
+    setDirty(true);
+  };
+
+  const addMcp = () => {
+    setMcpServers((prev) => [...prev, { name: "", type: "stdio", command: "" }]);
+    setDirty(true);
+  };
+
+  const removeMcp = (idx: number) => {
+    setMcpServers((prev) => prev.filter((_, i) => i !== idx));
+    setDirty(true);
+  };
+
+  const updateMcp = (idx: number, patch: Partial<AgentRole["mcp_servers"][0]>) => {
+    setMcpServers((prev) => prev.map((m, i) => i === idx ? { ...m, ...patch } : m));
+    setDirty(true);
+  };
+
   const save = () => {
-    onSave({ ...role, instructions, prompts, model: model || undefined, mode: mode || undefined });
+    onSave({
+      ...role,
+      instructions,
+      prompts,
+      model: model || undefined,
+      mode: mode || undefined,
+      skills: role.skills.map((s) => ({ ...s, content: skills[s.dirName] ?? s.content })),
+      mcp_servers: mcpServers,
+    });
     setDirty(false);
   };
 
@@ -323,6 +355,8 @@ function RoleEditor({ role, onSave }: { role: AgentRole; onSave: (r: AgentRole) 
         <div className="role-editor-badges">
           {model && <span className="role-badge">🧠 {model}</span>}
           {mode === "manual" && <span className="role-badge">🖐 manual</span>}
+          {role.skills.length > 0 && <span className="role-badge">🛠 {role.skills.length} skills</span>}
+          {mcpServers.length > 0 && <span className="role-badge">🔌 {mcpServers.length} MCP</span>}
           {dirty && <button className="btn btn-primary btn-small role-editor-save" onClick={(e) => { e.stopPropagation(); save(); }}>💾 Save</button>}
         </div>
       </div>
@@ -351,30 +385,47 @@ function RoleEditor({ role, onSave }: { role: AgentRole; onSave: (r: AgentRole) 
               </select>
             </div>
           </div>
-          {role.skills.length > 0 && (
-            <div className="role-skills-section">
-              <label>Skills ({role.skills.length})</label>
-              <div className="role-skills-list">
-                {role.skills.map((s) => (
-                  <div key={s.name} className="role-skill-item">
-                    <span className="role-skill-name">🛠 {s.name}</span>
-                    <span className="role-skill-desc">{s.description}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
+
+          {/* Skills — editable */}
+          <div className="role-section-label">🛠 Skills ({role.skills.length})</div>
+          {role.skills.length === 0 && (
+            <div className="role-empty-hint">No skills configured for this agent. Add skill files to <code>.aiscrum/roles/{role.name}/skills/</code></div>
           )}
-          {role.mcp_servers.length > 0 && (
-            <div className="role-mcp-section">
-              <label>MCP Servers ({role.mcp_servers.length})</label>
-              {role.mcp_servers.map((m, i) => (
-                <div key={i} className="role-mcp-item">
-                  <span className="role-mcp-name">🔌 {m.name}</span>
-                  <span className="role-mcp-detail">{m.type}{m.command ? ` · ${m.command}` : ""}{m.url ? ` · ${m.url}` : ""}</span>
-                </div>
-              ))}
+          {role.skills.map((s) => (
+            <div key={s.dirName}>
+              <label>{s.name} — <span style={{ fontWeight: 400, color: "var(--text-dim)" }}>{s.description}</span></label>
+              <textarea
+                className="role-skill-textarea"
+                value={skills[s.dirName] ?? s.content}
+                onChange={(e) => updateSkill(s.dirName, e.target.value)}
+              />
             </div>
+          ))}
+
+          {/* MCP Servers — editable */}
+          <div className="role-section-label">🔌 MCP Servers ({mcpServers.length})
+            <button className="btn btn-small" style={{ marginLeft: 8 }} onClick={addMcp}>+ Add</button>
+          </div>
+          {mcpServers.length === 0 && (
+            <div className="role-empty-hint">No MCP servers configured for this agent.</div>
           )}
+          {mcpServers.map((m, i) => (
+            <div key={i} className="role-mcp-edit-row">
+              <input className="settings-input" placeholder="Name" value={m.name} onChange={(e) => updateMcp(i, { name: e.target.value })} />
+              <select className="settings-input" value={m.type} onChange={(e) => updateMcp(i, { type: e.target.value })}>
+                <option value="stdio">stdio</option>
+                <option value="sse">sse</option>
+                <option value="streamable-http">streamable-http</option>
+              </select>
+              {m.type === "stdio" ? (
+                <input className="settings-input" style={{ flex: 2 }} placeholder="Command (e.g. npx server)" value={m.command ?? ""} onChange={(e) => updateMcp(i, { command: e.target.value })} />
+              ) : (
+                <input className="settings-input" style={{ flex: 2 }} placeholder="URL" value={m.url ?? ""} onChange={(e) => updateMcp(i, { url: e.target.value })} />
+              )}
+              <button className="btn btn-small btn-danger" onClick={() => removeMcp(i)}>✕</button>
+            </div>
+          ))}
+
           <PlaceholderHelp roleName={role.name} />
           <div>
             <label>Instructions (copilot-instructions.md)</label>
@@ -462,10 +513,20 @@ export function SettingsPage() {
 
   const saveRole = useCallback(async (role: AgentRole) => {
     try {
+      const skillsMap: Record<string, string> = {};
+      for (const s of role.skills) skillsMap[s.dirName] = s.content;
       const res = await fetch("/api/roles", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(role),
+        body: JSON.stringify({
+          name: role.name,
+          instructions: role.instructions,
+          prompts: role.prompts,
+          model: role.model,
+          mode: role.mode,
+          skills: skillsMap,
+          mcp_servers: role.mcp_servers,
+        }),
       });
       if (res.ok) {
         setRoles((prev) => prev.map((r) => r.name === role.name ? role : r));
@@ -596,40 +657,37 @@ export function SettingsPage() {
 
       <Section icon="🛡️" title="Quality Gates">
         {qualityGates ? (
-          <table className="settings-table">
-            <tbody>
-              <Row label="Tests" desc="Require tests to pass before merging">
-                <Toggle value={qualityGates.checks.tests.enabled} onChange={(v) => upQgCheck("tests", { enabled: v })} />
-              </Row>
-              <Row label="Test Command" desc="Shell command to run tests">
-                <TextInput value={cmdStr(qualityGates.checks.tests.command ?? "")} onChange={(v) => upQgCheck("tests", { command: cmdArr(v) })} />
-              </Row>
-              <Row label="Lint" desc="Require linter to pass before merging">
-                <Toggle value={qualityGates.checks.lint.enabled} onChange={(v) => upQgCheck("lint", { enabled: v })} />
-              </Row>
-              <Row label="Lint Command" desc="Shell command to run linter">
-                <TextInput value={cmdStr(qualityGates.checks.lint.command ?? "")} onChange={(v) => upQgCheck("lint", { command: cmdArr(v) })} />
-              </Row>
-              <Row label="Type Check" desc="Require type checking to pass before merging">
-                <Toggle value={qualityGates.checks.types.enabled} onChange={(v) => upQgCheck("types", { enabled: v })} />
-              </Row>
-              <Row label="Type Command" desc="Shell command to run type checker">
-                <TextInput value={cmdStr(qualityGates.checks.types.command ?? "")} onChange={(v) => upQgCheck("types", { command: cmdArr(v) })} />
-              </Row>
-              <Row label="Build" desc="Require build to succeed before merging">
-                <Toggle value={qualityGates.checks.build.enabled} onChange={(v) => upQgCheck("build", { enabled: v })} />
-              </Row>
-              <Row label="Build Command" desc="Shell command to build the project">
-                <TextInput value={cmdStr(qualityGates.checks.build.command ?? "")} onChange={(v) => upQgCheck("build", { command: cmdArr(v) })} />
-              </Row>
-              <Row label="Max Diff Lines" desc="Maximum lines changed per PR before extra review is triggered">
-                <NumInput value={qualityGates.limits.max_diff_lines} onChange={(v) => upQgLimits({ max_diff_lines: v })} min={1} narrow />
-              </Row>
-              <Row label="Challenger" desc="Require adversarial review agent to challenge every PR">
+          <div className="qg-grid">
+            {(["tests", "lint", "types", "build"] as const).map((check) => (
+              <div key={check} className="qg-card">
+                <div className="qg-card-header">
+                  <Toggle value={qualityGates.checks[check].enabled} onChange={(v) => upQgCheck(check, { enabled: v })} />
+                  <span className="qg-card-title">{check.charAt(0).toUpperCase() + check.slice(1)}</span>
+                </div>
+                <label>Command</label>
+                <textarea
+                  className="qg-command-textarea"
+                  value={cmdStr(qualityGates.checks[check].command ?? "")}
+                  onChange={(e) => upQgCheck(check, { command: cmdArr(e.target.value) })}
+                  placeholder={`e.g. npm run ${check}`}
+                />
+              </div>
+            ))}
+            <div className="qg-card">
+              <div className="qg-card-header">
+                <span className="qg-card-title">Max Diff Lines</span>
+              </div>
+              <NumInput value={qualityGates.limits.max_diff_lines} onChange={(v) => upQgLimits({ max_diff_lines: v })} min={1} narrow />
+              <div style={{ fontSize: 12, color: "var(--text-dim)", marginTop: 4 }}>Lines changed per PR before extra review</div>
+            </div>
+            <div className="qg-card">
+              <div className="qg-card-header">
                 <Toggle value={qualityGates.review.require_challenger} onChange={(v) => upQgReview({ require_challenger: v })} />
-              </Row>
-            </tbody>
-          </table>
+                <span className="qg-card-title">Challenger Review</span>
+              </div>
+              <div style={{ fontSize: 12, color: "var(--text-dim)" }}>Adversarial review agent challenges every PR</div>
+            </div>
+          </div>
         ) : (
           <table className="settings-table">
             <tbody>

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -986,12 +986,14 @@ export class DashboardWebServer {
         req.on("data", (chunk: Buffer) => { body += chunk.toString(); });
         req.on("end", () => {
           try {
-            const { name, instructions, prompts, model, mode } = JSON.parse(body) as {
+            const { name, instructions, prompts, model, mode, skills, mcp_servers: mcpServers } = JSON.parse(body) as {
               name: string;
               instructions?: string;
               prompts?: Record<string, string>;
               model?: string;
               mode?: string;
+              skills?: Record<string, string>;
+              mcp_servers?: Array<{ name: string; type: string; command?: string; args?: string[]; url?: string }>;
             };
             const roleDir = path.join(rolesDir, name);
             if (!fs.existsSync(roleDir)) { res.writeHead(404); res.end(JSON.stringify({ error: "Role not found" })); return; }
@@ -1005,8 +1007,16 @@ export class DashboardWebServer {
                 if (fs.existsSync(target)) fs.writeFileSync(target, content, "utf-8");
               }
             }
-            // Save model/mode to config phases
-            if (model !== undefined || mode !== undefined) {
+            // Save skills content
+            if (skills) {
+              const skillsDir = path.join(roleDir, "skills");
+              for (const [skillName, content] of Object.entries(skills)) {
+                const skillFile = path.join(skillsDir, skillName, "SKILL.md");
+                if (fs.existsSync(skillFile)) fs.writeFileSync(skillFile, content, "utf-8");
+              }
+            }
+            // Save model/mode/mcp to config phases
+            if (model !== undefined || mode !== undefined || mcpServers !== undefined) {
               const configPath = path.join(projectPath, ".aiscrum", "config.yaml");
               if (fs.existsSync(configPath)) {
                 import("yaml").then(({ parse: parseYaml, stringify }) => {
@@ -1017,9 +1027,10 @@ export class DashboardWebServer {
                   if (!phasesObj[name]) phasesObj[name] = {};
                   if (model !== undefined) phasesObj[name].model = model || undefined;
                   if (mode !== undefined) phasesObj[name].mode = mode || undefined;
-                  // Clean empty values
+                  if (mcpServers !== undefined) phasesObj[name].mcp_servers = mcpServers.length > 0 ? mcpServers : undefined;
                   if (!phasesObj[name].model) delete phasesObj[name].model;
                   if (!phasesObj[name].mode) delete phasesObj[name].mode;
+                  if (!phasesObj[name].mcp_servers || (phasesObj[name].mcp_servers as unknown[]).length === 0) delete phasesObj[name].mcp_servers;
                   if (Object.keys(phasesObj[name]).length === 0) delete phasesObj[name];
                   copilot.phases = phasesObj;
                   cfg.copilot = copilot;
@@ -1039,8 +1050,8 @@ export class DashboardWebServer {
         const roles: Array<{
           name: string; instructions: string; prompts: Record<string, string>;
           model?: string; mode?: string;
-          skills: Array<{ name: string; description: string }>;
-          mcp_servers: Array<{ name: string; type: string; command?: string; url?: string }>;
+          skills: Array<{ name: string; description: string; content: string; dirName: string }>;
+          mcp_servers: Array<{ name: string; type: string; command?: string; url?: string; args?: string[] }>;
         }> = [];
         if (fs.existsSync(rolesDir)) {
           for (const entry of fs.readdirSync(rolesDir, { withFileTypes: true })) {
@@ -1055,8 +1066,8 @@ export class DashboardWebServer {
                 if (pf.endsWith(".md")) prompts[pf] = fs.readFileSync(path.join(promptsDir, pf), "utf-8");
               }
             }
-            // Read skills
-            const skills: Array<{ name: string; description: string }> = [];
+            // Read skills with full content
+            const skills: Array<{ name: string; description: string; content: string; dirName: string }> = [];
             const skillsDir = path.join(roleDir, "skills");
             if (fs.existsSync(skillsDir)) {
               for (const sd of fs.readdirSync(skillsDir, { withFileTypes: true })) {
@@ -1065,13 +1076,15 @@ export class DashboardWebServer {
                 if (fs.existsSync(skillFile)) {
                   const raw = fs.readFileSync(skillFile, "utf-8");
                   const fmMatch = raw.match(/^---\n([\s\S]*?)\n---/);
+                  let skillName = sd.name;
+                  let desc = "";
                   if (fmMatch) {
                     const nameMatch = fmMatch[1].match(/name:\s*["']?(.+?)["']?\s*$/m);
                     const descMatch = fmMatch[1].match(/description:\s*["']?(.+?)["']?\s*$/m);
-                    skills.push({ name: nameMatch?.[1] ?? sd.name, description: descMatch?.[1] ?? "" });
-                  } else {
-                    skills.push({ name: sd.name, description: "" });
+                    skillName = nameMatch?.[1] ?? sd.name;
+                    desc = descMatch?.[1] ?? "";
                   }
+                  skills.push({ name: skillName, description: desc, content: raw, dirName: sd.name });
                 }
               }
             }


### PR DESCRIPTION
## Fixes

1. **TextAreas much bigger** — Instructions 350px, prompts 500px, skills 200px
2. **Skills editable per agent** — Each skill shows full SKILL.md content in a textarea, saves back to disk
3. **MCP servers editable per agent** — Add/remove/edit MCP servers (name, type, command/url), saved to config phases
4. **Quality Gates commands editable** — Command fields are now proper textareas (not tiny inputs), card-based layout
5. **Logs tab** — New 📜 Logs tab in nav for full-page error/warning log viewer with filtering

## Tests
- 573 unit tests ✅
- Build clean ✅