### PR TITLE
fix: skills overview with collapsible edit

### DIFF
--- a/src/dashboard/frontend/src/components/SettingsPage.css
+++ b/src/dashboard/frontend/src/components/SettingsPage.css
@@ -385,38 +385,8 @@
 }
 
 /* Skills section in role editor */
-.role-skills-section,
 .role-mcp-section {
   padding: 8px 0;
-}
-
-.role-skills-list {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin-top: 4px;
-}
-
-.role-skill-item,
-.role-mcp-item {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  font-size: 12px;
-  padding: 4px 8px;
-  background: var(--bg);
-  border-radius: 4px;
-}
-
-.role-skill-name,
-.role-mcp-name {
-  font-weight: 600;
-  white-space: nowrap;
-}
-
-.role-skill-desc,
-.role-mcp-detail {
-  color: var(--text-dim);
 }
 
 /* Quality Gates grid */
@@ -487,9 +457,50 @@
   color: #d2a8ff;
 }
 
+/* Skill card with collapsible edit */
+.role-skill-card {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin-bottom: 6px;
+  overflow: hidden;
+}
+
+.role-skill-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: var(--bg);
+  cursor: pointer;
+}
+
+.role-skill-card-header:hover {
+  background: #21262d;
+}
+
+.role-skill-info {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.role-skill-name {
+  font-weight: 600;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.role-skill-desc {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
 /* Skill textarea */
 .role-skill-textarea {
-  min-height: 200px !important;
+  min-height: 250px !important;
+  border-top: 1px solid var(--border);
+  border-radius: 0;
+  margin: 0;
 }
 
 /* MCP edit row */

--- a/src/dashboard/frontend/src/components/SettingsPage.tsx
+++ b/src/dashboard/frontend/src/components/SettingsPage.tsx
@@ -300,6 +300,7 @@ function RoleEditor({ role, onSave }: { role: AgentRole; onSave: (r: AgentRole) 
   );
   const [mcpServers, setMcpServers] = useState(role.mcp_servers);
   const [dirty, setDirty] = useState(false);
+  const [skillEditing, setSkillEditing] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
 
   const update = (field: "instructions" | string, value: string) => {
@@ -386,19 +387,27 @@ function RoleEditor({ role, onSave }: { role: AgentRole; onSave: (r: AgentRole) 
             </div>
           </div>
 
-          {/* Skills — editable */}
+          {/* Skills — overview with collapsible edit */}
           <div className="role-section-label">🛠 Skills ({role.skills.length})</div>
           {role.skills.length === 0 && (
-            <div className="role-empty-hint">No skills configured for this agent. Add skill files to <code>.aiscrum/roles/{role.name}/skills/</code></div>
+            <div className="role-empty-hint">No skills configured. Add files to <code>.aiscrum/roles/{role.name}/skills/</code></div>
           )}
           {role.skills.map((s) => (
-            <div key={s.dirName}>
-              <label>{s.name} — <span style={{ fontWeight: 400, color: "var(--text-dim)" }}>{s.description}</span></label>
-              <textarea
-                className="role-skill-textarea"
-                value={skills[s.dirName] ?? s.content}
-                onChange={(e) => updateSkill(s.dirName, e.target.value)}
-              />
+            <div key={s.dirName} className="role-skill-card">
+              <div className="role-skill-card-header" onClick={() => setSkillEditing(skillEditing === s.dirName ? null : s.dirName)}>
+                <div className="role-skill-info">
+                  <span className="role-skill-name">🛠 {s.name}</span>
+                  <span className="role-skill-desc">{s.description}</span>
+                </div>
+                <button className="btn btn-small">{skillEditing === s.dirName ? "▾ Close" : "✎ Edit"}</button>
+              </div>
+              {skillEditing === s.dirName && (
+                <textarea
+                  className="role-skill-textarea"
+                  value={skills[s.dirName] ?? s.content}
+                  onChange={(e) => updateSkill(s.dirName, e.target.value)}
+                />
+              )}
             </div>
           ))}
 


### PR DESCRIPTION
Skills show as compact overview cards (name + description). Click ✎ Edit to expand the SKILL.md textarea below. Click Close to collapse.