### PR TITLE
feat(#387): daily error log files with file-based log viewer

### DIFF
--- a/src/ceremonies/execution.ts
+++ b/src/ceremonies/execution.ts
@@ -27,7 +27,7 @@ import { setLabel } from "../github/labels.js";
 import { getChangedFiles } from "../git/diff-analysis.js";
 import { getPRStats } from "../git/merge.js";
 import { substitutePrompt, extractJson, sanitizePromptInput } from "./helpers.js";
-import { logger } from "../logger.js";
+import { logger, appendErrorLog } from "../logger.js";
 import type { SprintEventBus } from "../events.js";
 import { buildBranch, buildQualityGateConfig } from "./quality-retry.js";
 import { sessionController } from "../dashboard/session-control.js";
@@ -721,6 +721,7 @@ export async function executeIssue(
     }
   } catch (err: unknown) {
     errorMessage = err instanceof Error ? err.message : String(err);
+    appendErrorLog("error", `Issue #${issue.number} execution failed: ${errorMessage}`, { issue: issue.number });
     log.error({ err: errorMessage, issue: issue.number }, "issue execution failed");
     status = "failed";
   } finally {

--- a/src/ceremonies/parallel-dispatcher.ts
+++ b/src/ceremonies/parallel-dispatcher.ts
@@ -20,7 +20,7 @@ import { buildQualityGateConfig } from "./quality-retry.js";
 import { escalateToStakeholder } from "../enforcement/escalation.js";
 import { setLabel } from "../github/labels.js";
 import { addComment } from "../github/issues.js";
-import { logger } from "../logger.js";
+import { logger, appendErrorLog } from "../logger.js";
 
 import type { SprintEventBus } from "../events.js";
 
@@ -86,12 +86,14 @@ async function runPreMergeVerification(
     return { passed: true };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    appendErrorLog("error", `Pre-merge verification error: ${msg}`, { tmpDir });
     return { passed: false, reason: `Pre-merge verification error: ${msg}` };
   } finally {
     // 5. Cleanup
     try {
       await removeWorktree(tmpDir);
     } catch {
+      appendErrorLog("warn", "failed to cleanup pre-merge worktree", { tmpDir });
       log.warn({ tmpDir }, "failed to cleanup pre-merge worktree");
     }
   }
@@ -153,6 +155,7 @@ export async function runParallelExecution(
             rebaseSucceeded = false;
             // Rebase failed (conflicts) — abort and let pre-merge catch it
             try { await execFile("git", ["rebase", "--abort"], { cwd: rebaseTmpDir }); } catch { /* ignore */ }
+            appendErrorLog("warn", `rebase on latest main failed — issue #${result.issueNumber}`, { issue: result.issueNumber, err: String(rebaseErr) });
             log.warn({ issue: result.issueNumber, err: String(rebaseErr) }, "rebase on latest main failed — proceeding to pre-merge");
           } finally {
             try { await removeWorktree(rebaseTmpDir); } catch { /* ignore */ }
@@ -196,6 +199,7 @@ export async function runParallelExecution(
                             }, { ntfyEnabled: !!config.ntfy?.enabled, ntfyTopic: config.ntfy?.topic }, eventBus);
                           }
                         } catch (verifyErr: unknown) {
+                          appendErrorLog("error", `post-merge verification failed (retry) — issue #${retryResult.issueNumber}`, { issue: retryResult.issueNumber, err: String(verifyErr) });
                           log.error({ err: verifyErr, issue: retryResult.issueNumber }, "post-merge verification could not run");
                         }
                         continue;
@@ -253,12 +257,14 @@ export async function runParallelExecution(
                   }, { ntfyEnabled: !!config.ntfy?.enabled, ntfyTopic: config.ntfy?.topic }, eventBus);
                 }
               } catch (verifyErr: unknown) {
+                appendErrorLog("error", `post-merge verification FAILED — issue #${result.issueNumber}, halting merges`, { issue: result.issueNumber, err: String(verifyErr) });
                 log.error({ err: verifyErr, issue: result.issueNumber }, "post-merge verification could not run — halting further merges");
                 break;
               }
             }
           } catch (err: unknown) {
             mergeConflicts++;
+            appendErrorLog("error", `merge error — issue #${result.issueNumber}`, { issue: result.issueNumber, err: String(err) });
             log.error({ issue: result.issueNumber, err }, "merge error");
             result.status = "failed";
             result.qualityGatePassed = false;

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -17,7 +17,7 @@ import { holisticDriftCheck } from "../enforcement/drift-control.js";
 import { getNextOpenMilestone } from "../github/milestones.js";
 import { SprintRunner } from "../runner.js";
 import { SprintEventBus } from "../events.js";
-import { logger, redirectLogToFile } from "../logger.js";
+import { logger, redirectLogToFile, initErrorLogFile } from "../logger.js";
 import type { SprintIssue } from "../types.js";
 import {
   buildSprintConfig,
@@ -283,6 +283,7 @@ function registerWeb(program: Command): void {
         }
 
         redirectLogToFile(opts.logFile as string);
+        initErrorLogFile(process.cwd());
         logger.info({ sprint: initialSprint }, "Launching web dashboard");
 
         const eventBus = new SprintEventBus();

--- a/src/dashboard/frontend/src/components/LogTerminal.css
+++ b/src/dashboard/frontend/src/components/LogTerminal.css
@@ -15,6 +15,60 @@
   flex-shrink: 0;
 }
 
+.log-terminal-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.log-mode-toggle {
+  display: flex;
+  gap: 2px;
+  background: #0d1117;
+  border-radius: 6px;
+  padding: 2px;
+}
+
+.log-mode-btn {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.log-mode-btn:hover {
+  background: #21262d;
+}
+
+.log-mode-btn.active {
+  background: #21262d;
+  color: var(--text);
+}
+
+.log-file-select {
+  background: #0d1117;
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 3px 8px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  cursor: pointer;
+}
+
+.log-file-select:focus {
+  outline: none;
+  border-color: var(--blue);
+}
+
+.log-context {
+  color: #484f58;
+  font-size: 11px;
+}
+
 .log-terminal-title {
   font-size: 12px;
   font-weight: 600;

--- a/src/dashboard/frontend/src/components/LogTerminal.tsx
+++ b/src/dashboard/frontend/src/components/LogTerminal.tsx
@@ -1,29 +1,125 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { useDashboardStore } from "../store";
 import "./LogTerminal.css";
 
 type LogLevel = "all" | "error" | "warn" | "info";
+type LogMode = "live" | "files";
+
+interface FileLogEntry {
+  time: string;
+  level: string;
+  message: string;
+  [key: string]: unknown;
+}
+
+interface LogFileInfo {
+  name: string;
+  size: number;
+  modified: string;
+}
 
 export function LogTerminal() {
   const logs = useDashboardStore((s) => s.logs);
   const bottomRef = useRef<HTMLDivElement>(null);
   const [filter, setFilter] = useState<LogLevel>("all");
+  const [mode, setMode] = useState<LogMode>("files");
 
-  const errorCount = logs.filter((l) => l.level === "error").length;
-  const warnCount = logs.filter((l) => l.level === "warn").length;
-  const filtered = filter === "all" ? logs : logs.filter((l) => l.level === filter);
+  // File-based log state
+  const [logFiles, setLogFiles] = useState<LogFileInfo[]>([]);
+  const [selectedFile, setSelectedFile] = useState<string>("");
+  const [fileEntries, setFileEntries] = useState<FileLogEntry[]>([]);
+  const [loadingFiles, setLoadingFiles] = useState(false);
 
+  // Fetch available log files
+  const fetchLogFiles = useCallback(async () => {
+    try {
+      const resp = await fetch("/api/logs");
+      if (!resp.ok) return;
+      const data = await resp.json();
+      setLogFiles(data.files ?? []);
+      // Auto-select today's file if none selected
+      if (!selectedFile && data.files?.length > 0) {
+        setSelectedFile(data.files[0].name);
+      }
+    } catch { /* network error */ }
+  }, [selectedFile]);
+
+  // Fetch entries for selected log file
+  const fetchLogEntries = useCallback(async () => {
+    if (!selectedFile) return;
+    setLoadingFiles(true);
+    try {
+      const resp = await fetch(`/api/logs?file=${encodeURIComponent(selectedFile)}&tail=500`);
+      if (!resp.ok) return;
+      const data = await resp.json();
+      setFileEntries(data.entries ?? []);
+    } catch { /* network error */ }
+    setLoadingFiles(false);
+  }, [selectedFile]);
+
+  // Load files list on mount
+  useEffect(() => { fetchLogFiles(); }, [fetchLogFiles]);
+
+  // Load entries when file changes
+  useEffect(() => { fetchLogEntries(); }, [fetchLogEntries]);
+
+  // Auto-refresh: poll for new entries every 5s when viewing today's file
+  useEffect(() => {
+    if (mode !== "files" || !selectedFile) return;
+    const today = new Date().toISOString().slice(0, 10) + ".log";
+    if (selectedFile !== today) return;
+    const timer = setInterval(() => { fetchLogEntries(); fetchLogFiles(); }, 5000);
+    return () => clearInterval(timer);
+  }, [mode, selectedFile, fetchLogEntries, fetchLogFiles]);
+
+  // Auto-scroll
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [logs, filter]);
+  }, [logs, filter, fileEntries, mode]);
+
+  // Filter logic
+  const liveErrorCount = logs.filter((l) => l.level === "error").length;
+  const liveWarnCount = logs.filter((l) => l.level === "warn").length;
+  const filteredLive = filter === "all" ? logs : logs.filter((l) => l.level === filter);
+
+  const fileErrorCount = fileEntries.filter((e) => e.level === "error").length;
+  const fileWarnCount = fileEntries.filter((e) => e.level === "warn").length;
+  const filteredFile = filter === "all" ? fileEntries : fileEntries.filter((e) => e.level === filter);
+
+  const errorCount = mode === "live" ? liveErrorCount : fileErrorCount;
+  const warnCount = mode === "live" ? liveWarnCount : fileWarnCount;
+  const totalCount = mode === "live" ? logs.length : fileEntries.length;
 
   return (
     <div className="log-terminal">
       <div className="log-terminal-header">
-        <span className="log-terminal-title">⬤ Terminal</span>
+        <div className="log-terminal-left">
+          <span className="log-terminal-title">⬤ Logs</span>
+          <div className="log-mode-toggle">
+            <button className={`log-mode-btn ${mode === "files" ? "active" : ""}`} onClick={() => setMode("files")}>
+              📁 Error Log
+            </button>
+            <button className={`log-mode-btn ${mode === "live" ? "active" : ""}`} onClick={() => setMode("live")}>
+              ⚡ Live
+            </button>
+          </div>
+          {mode === "files" && logFiles.length > 0 && (
+            <select
+              className="log-file-select"
+              value={selectedFile}
+              onChange={(e) => setSelectedFile(e.target.value)}
+            >
+              {logFiles.map((f) => (
+                <option key={f.name} value={f.name}>
+                  {f.name.replace(".log", "")} ({(f.size / 1024).toFixed(1)} KB)
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
         <div className="log-terminal-filters">
           <button className={`log-filter-btn ${filter === "all" ? "active" : ""}`} onClick={() => setFilter("all")}>
-            All ({logs.length})
+            All ({totalCount})
           </button>
           <button className={`log-filter-btn log-filter-error ${filter === "error" ? "active" : ""}`} onClick={() => setFilter("error")}>
             {errorCount > 0 && <span className="log-error-badge">{errorCount}</span>}
@@ -33,23 +129,65 @@ export function LogTerminal() {
             {warnCount > 0 && <span className="log-warn-badge">{warnCount}</span>}
             Warnings
           </button>
+          {mode === "files" && (
+            <button className="log-filter-btn" onClick={fetchLogEntries} title="Refresh">
+              🔄
+            </button>
+          )}
         </div>
       </div>
       <div className="log-terminal-body">
-        {filtered.length === 0 && (
-          <div className="log-terminal-empty">
-            {filter === "all" ? "Waiting for log output..." : `No ${filter} entries`}
-          </div>
+        {mode === "live" ? (
+          <>
+            {filteredLive.length === 0 && (
+              <div className="log-terminal-empty">
+                {filter === "all" ? "Waiting for log output..." : `No ${filter} entries`}
+              </div>
+            )}
+            {filteredLive.map((l, i) => (
+              <div key={i} className={`log-line log-${l.level}`}>
+                <span className="log-ts">
+                  {l.time.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })}
+                </span>
+                <span className={`log-level log-level-${l.level}`}>{l.level.toUpperCase()}</span>
+                <span className="log-text">{l.message}</span>
+              </div>
+            ))}
+          </>
+        ) : (
+          <>
+            {loadingFiles && fileEntries.length === 0 && (
+              <div className="log-terminal-empty">Loading log file...</div>
+            )}
+            {!loadingFiles && filteredFile.length === 0 && logFiles.length === 0 && (
+              <div className="log-terminal-empty">No log files found. Logs are created when errors or warnings occur during sprint execution.</div>
+            )}
+            {!loadingFiles && filteredFile.length === 0 && logFiles.length > 0 && (
+              <div className="log-terminal-empty">
+                {filter === "all" ? "Log file is empty" : `No ${filter} entries in this file`}
+              </div>
+            )}
+            {filteredFile.map((entry, i) => (
+              <div key={i} className={`log-line log-${entry.level}`}>
+                <span className="log-ts">
+                  {entry.time ? new Date(entry.time).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" }) : "--:--:--"}
+                </span>
+                <span className={`log-level log-level-${entry.level}`}>{(entry.level ?? "info").toUpperCase()}</span>
+                <span className="log-text">
+                  {entry.message}
+                  {Object.keys(entry).filter((k) => !["time", "level", "message"].includes(k)).length > 0 && (
+                    <span className="log-context">
+                      {" "}
+                      {JSON.stringify(
+                        Object.fromEntries(Object.entries(entry).filter(([k]) => !["time", "level", "message"].includes(k))),
+                      )}
+                    </span>
+                  )}
+                </span>
+              </div>
+            ))}
+          </>
         )}
-        {filtered.map((l, i) => (
-          <div key={i} className={`log-line log-${l.level}`}>
-            <span className="log-ts">
-              {l.time.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })}
-            </span>
-            <span className={`log-level log-level-${l.level}`}>{l.level.toUpperCase()}</span>
-            <span className="log-text">{l.message}</span>
-          </div>
-        ))}
         <div ref={bottomRef} />
       </div>
     </div>

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -14,7 +14,7 @@ import { WebSocketServer, type WebSocket } from "ws";
 import type { SprintEventBus, SprintEngineEvents } from "../events.js";
 import type { SprintState } from "../runner.js";
 import type { ConfigFile } from "../config.js";
-import { logger } from "../logger.js";
+import { logger, appendErrorLog, getErrorLogDir } from "../logger.js";
 import { ChatManager, type ChatRole } from "./chat-manager.js";
 import { writeSessionLog } from "./session-logger.js";
 import { sessionController } from "./session-control.js";
@@ -370,6 +370,17 @@ export class DashboardWebServer {
         this.eventBuffer.push({ eventName, payload });
         if (this.eventBuffer.length > EVENT_BUFFER_MAX) {
           this.eventBuffer.shift();
+        }
+        // Write errors and warnings to daily log file
+        if (eventName === "sprint:error" || eventName === "issue:fail") {
+          const p = payload as Record<string, unknown>;
+          appendErrorLog("error", `${eventName}: ${p.message ?? p.error ?? JSON.stringify(p)}`, { event: eventName });
+        }
+        if (eventName === "log") {
+          const p = payload as { level: string; message: string };
+          if (p.level === "error" || p.level === "warn") {
+            appendErrorLog(p.level as "error" | "warn", p.message, { event: eventName });
+          }
         }
       });
     }
@@ -808,7 +819,12 @@ export class DashboardWebServer {
 
     // API routes
     if (url.pathname.startsWith("/api/")) {
-      this.handleApi(url, req, res);
+      try {
+        this.handleApi(url, req, res);
+      } catch (err) {
+        appendErrorLog("error", `API error: ${url.pathname} — ${String(err)}`, { path: url.pathname });
+        if (!res.headersSent) { res.writeHead(500); res.end(JSON.stringify({ error: String(err) })); }
+      }
       return;
     }
 
@@ -1140,6 +1156,41 @@ export class DashboardWebServer {
           res.writeHead(200); res.end(JSON.stringify(null));
         }
       } catch (err) { res.writeHead(500); res.end(JSON.stringify({ error: String(err) })); }
+      return;
+    }
+
+    // /api/logs — list log files and read log content
+    if (pathname === "/api/logs") {
+      const logsDir = getErrorLogDir();
+      if (!logsDir || !fs.existsSync(logsDir)) {
+        res.writeHead(200); res.end(JSON.stringify({ files: [], entries: [] }));
+        return;
+      }
+      const file = url.searchParams.get("file");
+      const tail = parseInt(url.searchParams.get("tail") ?? "200", 10);
+      if (file) {
+        // Read specific log file
+        const safeName = path.basename(file);
+        const filePath = path.join(logsDir, safeName);
+        if (!fs.existsSync(filePath)) { res.writeHead(404); res.end(JSON.stringify({ error: "Log file not found" })); return; }
+        const raw = fs.readFileSync(filePath, "utf-8");
+        const lines = raw.trim().split("\n").filter(Boolean);
+        const entries = lines.slice(-tail).map((line) => {
+          try { return JSON.parse(line); } catch { return { time: "", level: "info", message: line }; }
+        });
+        res.writeHead(200); res.end(JSON.stringify({ file: safeName, entries }));
+      } else {
+        // List log files
+        const files = fs.readdirSync(logsDir)
+          .filter((f) => f.endsWith(".log"))
+          .sort()
+          .reverse()
+          .map((f) => {
+            const stat = fs.statSync(path.join(logsDir, f));
+            return { name: f, size: stat.size, modified: stat.mtime.toISOString() };
+          });
+        res.writeHead(200); res.end(JSON.stringify({ files }));
+      }
       return;
     }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,10 +7,6 @@ export type { Logger };
 
 /**
  * Configuration options for creating a pino logger instance.
- *
- * @property level - Log severity threshold. Messages below this level are suppressed.
- * @property name - Logger name included in every log entry.
- * @property pretty - Enable pino-pretty for human-readable output. Defaults to true in non-production.
  */
 export interface LoggerOptions {
   level?: "debug" | "info" | "warn" | "error";
@@ -20,10 +16,6 @@ export interface LoggerOptions {
 
 /**
  * Contextual metadata attached to child loggers for sprint-scoped logging.
- *
- * @property sprint - Sprint number.
- * @property issue - Issue number being worked on.
- * @property ceremony - Active ceremony name (e.g., "planning", "review").
  */
 export interface SprintContext {
   sprint?: number;
@@ -32,6 +24,49 @@ export interface SprintContext {
 }
 
 let logDestination: DestinationStream | undefined;
+let errorLogDir: string | undefined;
+
+/**
+ * Get the directory where daily error logs are stored.
+ */
+export function getErrorLogDir(): string | undefined {
+  return errorLogDir;
+}
+
+/**
+ * Initialize daily error log file. Creates a logs/ directory and writes
+ * errors/warnings to a date-stamped file (e.g. logs/2026-03-03.log).
+ * Call once at startup.
+ */
+export function initErrorLogFile(projectPath: string): void {
+  errorLogDir = path.join(projectPath, "logs");
+  fs.mkdirSync(errorLogDir, { recursive: true });
+}
+
+function getErrorLogPath(): string | undefined {
+  if (!errorLogDir) return undefined;
+  const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  return path.join(errorLogDir, `${date}.log`);
+}
+
+/**
+ * Append a structured log entry to today's error log file.
+ */
+export function appendErrorLog(level: "error" | "warn" | "info", message: string, context?: Record<string, unknown>): void {
+  const logPath = getErrorLogPath();
+  if (!logPath) return;
+  const entry = {
+    time: new Date().toISOString(),
+    level,
+    message,
+    ...context,
+  };
+  try {
+    fs.appendFileSync(logPath, JSON.stringify(entry) + "\n", "utf-8");
+  } catch {
+    // Can't log a logging failure — silently skip
+  }
+}
 
 /**
  * Redirect all logger output to a file. Call this before rendering the TUI
@@ -40,7 +75,6 @@ let logDestination: DestinationStream | undefined;
 export function redirectLogToFile(filePath: string): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   logDestination = pino.destination({ dest: filePath, sync: false });
-  // Recreate the default logger with the new destination
   const opts = {
     name: logger.bindings().name ?? "sprint-runner",
     level: logger.level,
@@ -56,19 +90,11 @@ export function redirectLogToFile(filePath: string): void {
     },
   };
   const newLogger = pino(opts, logDestination);
-  // Copy child loggers will inherit the new destination via the parent
   Object.assign(logger, newLogger);
 }
 
 /**
  * Create a new pino logger with the given options.
- *
- * Sensitive fields (password, token, secret, apiKey, authorization) are
- * automatically redacted. If {@link redirectLogToFile} was called, the
- * logger writes to the file destination instead of stdout.
- *
- * @param options - Logger configuration. Defaults to info level with pretty output in non-production.
- * @returns A configured pino Logger instance.
  */
 export function createLogger(options: LoggerOptions = {}): Logger {
   const {

--- a/tests/ceremonies/ceremony-coverage.test.ts
+++ b/tests/ceremonies/ceremony-coverage.test.ts
@@ -37,7 +37,7 @@ vi.mock("../../src/logger.js", () => {
     debug: vi.fn(),
     child: vi.fn().mockReturnThis(),
   };
-  return { logger: mock };
+  return { logger: mock, appendErrorLog: vi.fn() };
 });
 
 vi.mock("../../src/metrics.js", () => ({

--- a/tests/ceremonies/execution.test.ts
+++ b/tests/ceremonies/execution.test.ts
@@ -53,7 +53,7 @@ vi.mock("../../src/logger.js", () => {
     error: noop,
     child: () => childLogger,
   };
-  return { logger: childLogger };
+  return { logger: childLogger, appendErrorLog: noop };
 });
 
 vi.mock("node:child_process", () => {

--- a/tests/ceremonies/merge-pipeline.test.ts
+++ b/tests/ceremonies/merge-pipeline.test.ts
@@ -28,7 +28,7 @@ vi.mock("../../src/logger.js", () => {
     error: noop,
     child: () => childLogger,
   };
-  return { logger: childLogger };
+  return { logger: childLogger, appendErrorLog: noop };
 });
 
 const { mergeBranch } = await import("../../src/git/merge.js");

--- a/tests/ceremonies/parallel-dispatcher.test.ts
+++ b/tests/ceremonies/parallel-dispatcher.test.ts
@@ -83,6 +83,7 @@ vi.mock("../../src/logger.js", () => {
   });
   return {
     logger: { child },
+    appendErrorLog: noop,
   };
 });
 

--- a/tests/ceremonies/quality-retry.test.ts
+++ b/tests/ceremonies/quality-retry.test.ts
@@ -26,7 +26,7 @@ vi.mock("../../src/logger.js", () => {
     error: noop,
     child: () => childLogger,
   };
-  return { logger: childLogger };
+  return { logger: childLogger, appendErrorLog: noop };
 });
 
 const { runQualityGate } = await import(

--- a/tests/dashboard/session-control.test.ts
+++ b/tests/dashboard/session-control.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("../../src/logger.js", () => {
   const noop = vi.fn();
-  return { logger: { child: () => ({ info: noop, warn: noop, error: noop, debug: noop }) } };
+  return { logger: { child: () => ({ info: noop, warn: noop, error: noop, debug: noop }) }, appendErrorLog: noop, getErrorLogDir: () => undefined };
 });
 
 import { SessionController } from "../../src/dashboard/session-control.js";

--- a/tests/integration/sprint-cycle.test.ts
+++ b/tests/integration/sprint-cycle.test.ts
@@ -61,7 +61,7 @@ vi.mock("../../src/enforcement/escalation.js", () => ({ escalateToStakeholder: v
 vi.mock("../../src/logger.js", () => {
   const noop = vi.fn();
   const childLogger = { info: noop, warn: noop, error: noop, debug: noop, child: vi.fn().mockReturnThis() };
-  return { logger: { info: noop, warn: noop, error: noop, debug: noop, child: vi.fn().mockReturnValue(childLogger) }, createLogger: vi.fn().mockReturnValue(childLogger) };
+  return { logger: { info: noop, warn: noop, error: noop, debug: noop, child: vi.fn().mockReturnValue(childLogger) }, createLogger: vi.fn().mockReturnValue(childLogger), appendErrorLog: noop };
 });
 
 // --- Helpers ---

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -132,6 +132,7 @@ vi.mock("../src/logger.js", () => {
       child: vi.fn().mockReturnValue(childLogger),
     },
     createLogger: vi.fn().mockReturnValue(childLogger),
+    appendErrorLog: noop,
   };
 });
 


### PR DESCRIPTION
## Changes

### Error Logging Infrastructure
- `src/logger.ts`: `initErrorLogFile()`, `appendErrorLog()`, `getErrorLogDir()` — daily rotating JSON-line log files in `logs/YYYY-MM-DD.log`
- `src/cli/commands.ts`: Initialize error log dir on `web` command startup

### API Endpoint
- `GET /api/logs` — lists available log files (name, size, modified)
- `GET /api/logs?file=YYYY-MM-DD.log&tail=500` — returns parsed JSON entries from file

### Dashboard Log Viewer
- **Error Log mode** (📁): Browse log files by date, view structured entries, auto-refresh every 5s for today's file
- **Live mode** (⚡): Real-time WebSocket log stream (existing behavior)
- Filter by All/Errors/Warnings with badge counts
- Manual refresh button

### Error Logging Instrumentation
- `ws-server.ts`: API errors, sprint:error/issue:fail events, warn/error log events
- `execution.ts`: Issue execution failures
- `parallel-dispatcher.ts`: Pre-merge errors, rebase failures, merge errors, post-merge verification failures, worktree cleanup failures

### Test Updates
- Added `appendErrorLog` mock to 8 test files to prevent mock resolution errors

Closes #387