### PR TITLE
fix: round 3 dashboard bugs — noreferrer, sprint validation, race conditions

### DIFF
--- a/src/dashboard/frontend/src/components/Header.tsx
+++ b/src/dashboard/frontend/src/components/Header.tsx
@@ -78,7 +78,7 @@ export function Header() {
   const currentSprint = availableSprints.find((s) => s.sprintNumber === viewingSprintNumber);
   const milestoneId = currentSprint?.milestoneNumber ?? displayNumber;
   const sprintLabel = repoUrl
-    ? <a href={`${repoUrl}/milestone/${milestoneId}`} target="_blank" rel="noopener">Sprint {displayNumber} ↗</a>
+    ? <a href={`${repoUrl}/milestone/${milestoneId}`} target="_blank" rel="noopener noreferrer">Sprint {displayNumber} ↗</a>
     : `Sprint ${displayNumber}`;
 
   return (

--- a/src/dashboard/frontend/src/components/IssueCard.tsx
+++ b/src/dashboard/frontend/src/components/IssueCard.tsx
@@ -28,7 +28,7 @@ export function IssueCard({ item, actions, extraContent }: IssueCardProps) {
           <a
             href={`${repoUrl}/issues/${item.number}`}
             target="_blank"
-            rel="noopener"
+            rel="noopener noreferrer"
             className="item-number"
             onClick={(e) => e.stopPropagation()}
           >

--- a/src/dashboard/frontend/src/components/IssueList.tsx
+++ b/src/dashboard/frontend/src/components/IssueList.tsx
@@ -37,7 +37,7 @@ export function IssueList() {
         const icon = STATUS_ICON[issue.status] ?? "·";
         const statusClass = issue.status.replace("status:", "");
         const link = repoUrl ? (
-          <a href={`${repoUrl}/issues/${issue.number}`} target="_blank" rel="noopener" className="issue-number">
+          <a href={`${repoUrl}/issues/${issue.number}`} target="_blank" rel="noopener noreferrer" className="issue-number">
             #{issue.number}
           </a>
         ) : (

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -119,6 +119,7 @@ let pendingGeneralCreate = false;
 // Sprint caches (survive navigation between sprints)
 const stateCache = new Map<number, { state: SprintState; issues: SprintIssue[] }>();
 const activityCache = new Map<number, Activity[]>();
+let sprintFetchVersion = 0;
 
 function createWebSocket(set: SetFn, get: GetFn): void {
   if (ws && (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN)) return;
@@ -483,6 +484,15 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
       break;
     }
 
+    case "backlog:removed": {
+      const p = msg.payload as { issueNumber: number } | undefined;
+      if (p) {
+        const store = get();
+        addActivity(set, store, "backlog", `#${p.issueNumber} removed from sprint`, null, "done");
+      }
+      break;
+    }
+
     case "backlog:error": {
       const p = msg.payload as { issueNumber?: number; error: string } | undefined;
       if (p) {
@@ -682,7 +692,7 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
     if (ws && ws.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify(msg));
     } else {
-      pendingMessages.push(msg);
+      if (pendingMessages.length < 100) pendingMessages.push(msg);
     }
   },
 
@@ -746,16 +756,16 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
       store.send({ type: "sprint:switch", sprintNumber: n });
     } else if (!cached) {
       // Historical sprint — load from API
+      const fetchId = ++sprintFetchVersion;
       Promise.all([
         fetch(`/api/sprints/${n}/state`).then((r) => (r.ok ? r.json() : null)),
         fetch(`/api/sprints/${n}/issues`).then((r) => (r.ok ? r.json() : null)),
       ])
         .then(([stateData, issuesData]) => {
-          if (stateData) {
+          if (stateData && fetchId === sprintFetchVersion) {
             const s = stateData as SprintState;
             const iss = Array.isArray(issuesData) ? (issuesData as SprintIssue[]) : [];
             stateCache.set(n, { state: s, issues: iss });
-            // Only update if still viewing this sprint
             if (get().viewingSprintNumber === n) {
               set({ state: s, issues: iss });
             }

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -463,7 +463,7 @@ export class DashboardWebServer {
         this.options.onStart?.();
         break;
       case "sprint:switch":
-        if (msg.sprintNumber) {
+        if (msg.sprintNumber && typeof msg.sprintNumber === "number" && msg.sprintNumber > 0) {
           log.info({ sprintNumber: msg.sprintNumber }, "Dashboard client switched sprint");
           const sprintNum = msg.sprintNumber;
           // Await async callback before re-sending state
@@ -955,6 +955,9 @@ export class DashboardWebServer {
     if (pathname === "/api/sprint-backlog") {
       const requestedSprint = url.searchParams.get("sprint");
       const sprintNum = requestedSprint ? parseInt(requestedSprint, 10) : undefined;
+      if (sprintNum !== undefined && (isNaN(sprintNum) || sprintNum < 1)) {
+        res.writeHead(400); res.end(JSON.stringify({ error: "Invalid sprint number" })); return;
+      }
       this.handleSprintBacklogRequest(res, sprintNum);
       return;
     }

--- a/tests/e2e/round3-verification.spec.ts
+++ b/tests/e2e/round3-verification.spec.ts
@@ -1,0 +1,265 @@
+/**
+ * E2E tests for round 3 bug fixes:
+ * - External link security (noreferrer)
+ * - Sprint number validation
+ * - IssueCard rendering
+ * - Sprint navigation robustness
+ * - Backlog/Sprint Backlog actions
+ */
+import { test, expect } from "@playwright/test";
+
+const BASE = "http://localhost:9200";
+
+async function navigateToTab(page: import("@playwright/test").Page, icon: string, label: string) {
+  await page.waitForSelector(".tab-nav", { timeout: 10_000 });
+  await page.getByRole("button", { name: `${icon} ${label}`, exact: true }).click();
+  await page.waitForTimeout(500);
+}
+
+// ─── External Link Security ────────────────────────────────────
+
+test.describe("External Link Security", () => {
+  test("issue links have noreferrer attribute", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector(".phase-badge", { timeout: 10_000 });
+    await page.waitForTimeout(3000);
+    // Check any issue links in the sprint tab
+    const links = page.locator("a[target='_blank']");
+    const count = await links.count();
+    for (let i = 0; i < Math.min(count, 5); i++) {
+      const rel = await links.nth(i).getAttribute("rel");
+      expect(rel).toContain("noreferrer");
+    }
+  });
+
+  test("header sprint link has noreferrer", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector(".phase-badge", { timeout: 10_000 });
+    const sprintLink = page.locator("#sprint-label a[target='_blank']");
+    if (await sprintLink.count() > 0) {
+      const rel = await sprintLink.getAttribute("rel");
+      expect(rel).toContain("noreferrer");
+    }
+  });
+
+  test("issue card links in backlog have noreferrer", async ({ page }) => {
+    await page.goto("/");
+    await navigateToTab(page, "📋", "Backlog");
+    await page.waitForTimeout(2000);
+    const links = page.locator(".tab-list a[target='_blank']");
+    const count = await links.count();
+    for (let i = 0; i < Math.min(count, 3); i++) {
+      const rel = await links.nth(i).getAttribute("rel");
+      expect(rel).toContain("noreferrer");
+    }
+  });
+});
+
+// ─── Sprint Number Validation ──────────────────────────────────
+
+test.describe("Sprint Number Validation", () => {
+  test("invalid sprint number returns 400", async ({ request }) => {
+    const res = await request.get(`${BASE}/api/sprint-backlog?sprint=abc`);
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBeDefined();
+  });
+
+  test("negative sprint number returns 400", async ({ request }) => {
+    const res = await request.get(`${BASE}/api/sprint-backlog?sprint=-1`);
+    expect(res.status()).toBe(400);
+  });
+
+  test("zero sprint number returns 400", async ({ request }) => {
+    const res = await request.get(`${BASE}/api/sprint-backlog?sprint=0`);
+    expect(res.status()).toBe(400);
+  });
+
+  test("valid sprint number returns 200", async ({ request }) => {
+    const res = await request.get(`${BASE}/api/sprint-backlog?sprint=1`);
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    expect(body).toHaveProperty("items");
+  });
+
+  test("no sprint parameter returns 200 with default", async ({ request }) => {
+    const res = await request.get(`${BASE}/api/sprint-backlog`);
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    expect(body).toHaveProperty("items");
+  });
+});
+
+// ─── IssueCard Rendering ───────────────────────────────────────
+
+test.describe("IssueCard Rendering", () => {
+  test("backlog items render with number and title", async ({ page }) => {
+    await page.goto("/");
+    await navigateToTab(page, "📋", "Backlog");
+    await page.waitForTimeout(2000);
+    const items = page.locator(".tab-list-item");
+    if (await items.count() > 0) {
+      // First item should have a visible number
+      const firstNumber = items.first().locator(".item-number");
+      await expect(firstNumber).toBeVisible();
+      const text = await firstNumber.textContent();
+      expect(text).toMatch(/^#\d+$/);
+      // Should have a title
+      const firstTitle = items.first().locator(".item-title");
+      await expect(firstTitle).toBeVisible();
+      const title = await firstTitle.textContent();
+      expect(title!.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("issue card expand/collapse works", async ({ page }) => {
+    await page.goto("/");
+    await navigateToTab(page, "📋", "Backlog");
+    await page.waitForTimeout(2000);
+    const expandBtn = page.locator(".item-expand-toggle").first();
+    if (await expandBtn.count() > 0) {
+      // Initially collapsed
+      const detail = page.locator(".item-detail").first();
+      await expect(detail).not.toBeVisible();
+      // Click to expand
+      await expandBtn.click();
+      await page.waitForTimeout(300);
+      await expect(detail).toBeVisible();
+      // Click to collapse
+      await expandBtn.click();
+      await page.waitForTimeout(300);
+      await expect(detail).not.toBeVisible();
+    }
+  });
+
+  test("expanded issue card shows body or 'No description'", async ({ page }) => {
+    await page.goto("/");
+    await navigateToTab(page, "📋", "Backlog");
+    await page.waitForTimeout(2000);
+    const expandBtn = page.locator(".item-expand-toggle").first();
+    if (await expandBtn.count() > 0) {
+      await expandBtn.click();
+      await page.waitForTimeout(300);
+      // Should show either body content or empty message
+      const bodyOrEmpty = page.locator(".item-body-full, .item-body-empty").first();
+      await expect(bodyOrEmpty).toBeVisible();
+    }
+  });
+
+  test("issue labels render as badges", async ({ page }) => {
+    await page.goto("/");
+    await navigateToTab(page, "📋", "Backlog");
+    await page.waitForTimeout(2000);
+    const labels = page.locator(".label-badge");
+    if (await labels.count() > 0) {
+      await expect(labels.first()).toBeVisible();
+      const text = await labels.first().textContent();
+      expect(text!.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ─── Sprint Navigation ─────────────────────────────────────────
+
+test.describe("Sprint Navigation", () => {
+  test("sprint navigation buttons exist in header", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector(".phase-badge", { timeout: 10_000 });
+    const prevBtn = page.locator("#btn-prev");
+    const nextBtn = page.locator("#btn-next");
+    await expect(prevBtn).toBeVisible();
+    await expect(nextBtn).toBeVisible();
+  });
+
+  test("sprint badge shows current sprint number", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector(".phase-badge", { timeout: 10_000 });
+    const badge = page.locator("#sprint-label");
+    await expect(badge).toBeVisible();
+    const text = await badge.textContent();
+    expect(text).toMatch(/Sprint \d/);
+  });
+
+  test("sprint tab issue list shows status icons", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector(".phase-badge", { timeout: 10_000 });
+    await page.waitForTimeout(3000);
+    const issueItems = page.locator(".issue-item");
+    if (await issueItems.count() > 0) {
+      const icon = issueItems.first().locator(".issue-icon");
+      await expect(icon).toBeVisible();
+      const text = await icon.textContent();
+      // Should be one of the status icons
+      expect(["○", "◐", "✓", "✗", "⊘", "·"]).toContain(text?.trim());
+    }
+  });
+});
+
+// ─── Sprint Backlog Tab ─────────────────────────────────────────
+
+test.describe("Sprint Backlog Tab", () => {
+  test("shows sprint number in heading", async ({ page }) => {
+    await page.goto("/");
+    await navigateToTab(page, "📦", "Sprint Backlog");
+    await page.waitForTimeout(2000);
+    const heading = page.locator("h2");
+    if (await heading.count() > 0) {
+      const text = await heading.first().textContent();
+      // Either shows "Sprint N Backlog" or empty state
+      if (text?.includes("Sprint")) {
+        expect(text).toMatch(/Sprint \d+ Backlog/);
+      }
+    }
+  });
+
+  test("has refresh button that reloads data", async ({ page }) => {
+    await page.goto("/");
+    await navigateToTab(page, "📦", "Sprint Backlog");
+    await page.waitForTimeout(2000);
+    const refreshBtn = page.locator("button", { hasText: "↻" });
+    if (await refreshBtn.count() > 0) {
+      await refreshBtn.first().click();
+      // Should show loading briefly
+      await page.waitForTimeout(500);
+      // Should return to content or empty state
+      const content = page.locator(".tab-list-container, .tab-empty");
+      await expect(content.first()).toBeVisible({ timeout: 5_000 });
+    }
+  });
+
+  test("remove button exists on sprint backlog items", async ({ page }) => {
+    await page.goto("/");
+    await navigateToTab(page, "📦", "Sprint Backlog");
+    await page.waitForTimeout(2000);
+    const removeBtn = page.locator(".btn-danger", { hasText: "Remove" });
+    if (await removeBtn.count() > 0) {
+      await expect(removeBtn.first()).toBeVisible();
+    }
+  });
+});
+
+// ─── API Edge Cases ─────────────────────────────────────────────
+
+test.describe("API Edge Cases", () => {
+  test("sprints state endpoint handles non-existent sprint", async ({ request }) => {
+    const res = await request.get(`${BASE}/api/sprints/9999/state`);
+    // Should return 200 with null/empty data or 404
+    expect([200, 404]).toContain(res.status());
+  });
+
+  test("PUT /api/config with malformed JSON returns 400", async ({ request }) => {
+    const res = await request.put(`${BASE}/api/config`, {
+      data: "not json",
+      headers: { "Content-Type": "text/plain" },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test("POST /api/roles for non-existent role returns 404", async ({ request }) => {
+    const res = await request.put(`${BASE}/api/roles`, {
+      data: { name: "nonexistent-role-xyz", instructions: "test" },
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(res.status()).toBe(404);
+  });
+});


### PR DESCRIPTION
## Changes

### Security
- Add `noreferrer` to `rel` attribute on external links in IssueCard, IssueList, Header

### Validation
- Sprint number validation in ws-server: reject NaN, negative, and zero values with 400 status

### Store Robustness
- Add missing `backlog:removed` WebSocket handler in Zustand store
- Bound `pendingMessages` queue to 100 entries (prevent memory leak)
- Add `sprintFetchVersion` counter to prevent stale fetch race in `setViewingSprint`

### Tests
- 21 new E2E tests in `round3-verification.spec.ts` (149 total)
- Covers: noreferrer attributes, sprint validation API, issue card rendering, sprint navigation, API edge cases

### Verification
- 573 unit tests pass ✅
- 149 E2E tests pass ✅
- TypeScript: no errors ✅