### PR TITLE
fix: SidePanel missing elements on initial page load

### DIFF
--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -254,6 +254,7 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
             ...prev,
             chatSessions: [...prev.chatSessions, p],
             generalChatId: p.id,
+            activeChatId: prev.activeChatId ?? p.id,
             chatMessages: { ...prev.chatMessages, [p.id]: [] },
           }));
           break;


### PR DESCRIPTION
## Bug
On initial page load (Sprint tab), the side panel shows bare 'General Agent' text without:
- Connected badge
- Session tabs
- Mode/model selector buttons

Navigating to another tab and back would fix it.

## Root Cause
When the general session is auto-created on WebSocket connect, `generalChatId` was set but `activeChatId` remained `null`. All conditional UI elements depend on `activeChatId`.

## Fix
Set `activeChatId` to the general session ID when no other session is active (1-line change in store.ts).

## Tests
- 573 unit tests pass ✅
- 149 E2E tests pass ✅