### PR TITLE
feat: ACP sessions in SidePanel + activity feed

### DIFF
--- a/src/dashboard/frontend/src/components/SessionPanel.css
+++ b/src/dashboard/frontend/src/components/SessionPanel.css
@@ -46,6 +46,20 @@
 }
 
 .session-ended { opacity: 0.5; }
+.session-viewing { background: var(--bg-hover); border-left: 2px solid var(--blue); }
+.session-viewing-badge {
+  font-size: 10px;
+  color: var(--blue);
+  background: rgba(var(--blue-rgb, 66, 133, 244), 0.15);
+  padding: 1px 5px;
+  border-radius: 3px;
+  margin-left: auto;
+}
+.btn-tiny {
+  padding: 2px 6px;
+  font-size: 10px;
+  line-height: 1.2;
+}
 
 /* Session viewer */
 .session-viewer {

--- a/src/dashboard/frontend/src/components/SessionPanel.tsx
+++ b/src/dashboard/frontend/src/components/SessionPanel.tsx
@@ -1,90 +1,11 @@
-import { useEffect, useRef, useState } from "react";
 import { useDashboardStore } from "../store";
-import { Markdown } from "./Markdown";
 import "./SessionPanel.css";
 
 export function SessionPanel() {
   const sessions = useDashboardStore((s) => s.acpSessions);
   const viewingSessionId = useDashboardStore((s) => s.viewingSessionId);
-  const sessionOutput = useDashboardStore((s) => s.sessionOutput);
   const openSession = useDashboardStore((s) => s.openSession);
-  const closeSession = useDashboardStore((s) => s.closeSession);
   const send = useDashboardStore((s) => s.send);
-  const bottomRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-  const [inputText, setInputText] = useState("");
-
-  const output = viewingSessionId ? (sessionOutput.get(viewingSessionId) ?? "") : "";
-
-  // Auto-scroll to bottom when output updates
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [output]);
-
-  const sendMessage = () => {
-    const text = inputText.trim();
-    if (!text || !viewingSessionId) return;
-    send({ type: "session:send-message", sessionId: viewingSessionId, message: text });
-    setInputText("");
-    inputRef.current?.focus();
-  };
-
-  if (viewingSessionId) {
-    const session = sessions.find((s) => s.sessionId === viewingSessionId);
-    const isActive = session && !session.endedAt;
-
-    return (
-      <div className="session-viewer">
-        <div className="session-viewer-header">
-          <button className="btn btn-small" onClick={closeSession}>← Back</button>
-          <span className="session-viewer-title">
-            {session?.role ?? "Session"} {session?.issueNumber ? `#${session.issueNumber}` : ""}
-          </span>
-          {isActive && (
-            <button
-              className="btn btn-danger btn-small"
-              onClick={() => {
-                if (confirm("Stop this session?")) {
-                  send({ type: "session:stop", sessionId: viewingSessionId });
-                }
-              }}
-            >
-              Stop
-            </button>
-          )}
-        </div>
-        <div className="session-output">
-          <Markdown text={output || "Waiting for output..."} />
-          <div ref={bottomRef} />
-        </div>
-        {isActive && (
-          <div className="session-input">
-            <textarea
-              ref={inputRef}
-              className="session-input-field"
-              placeholder="Send context or instructions to this session..."
-              value={inputText}
-              onChange={(e) => setInputText(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && !e.shiftKey) {
-                  e.preventDefault();
-                  sendMessage();
-                }
-              }}
-              rows={2}
-            />
-            <button
-              className="btn btn-primary btn-small"
-              onClick={sendMessage}
-              disabled={!inputText.trim()}
-            >
-              Send
-            </button>
-          </div>
-        )}
-      </div>
-    );
-  }
 
   // Group sessions by issue
   const grouped = new Map<string, typeof sessions>();
@@ -105,13 +26,14 @@ export function SessionPanel() {
           <span className="session-group-label">{group}</span>
           {items.map((s) => {
             const isActive = !s.endedAt;
+            const isViewing = viewingSessionId === s.sessionId;
             const elapsed = isActive
               ? Math.floor((Date.now() - new Date(s.startedAt).getTime()) / 1000)
               : 0;
             return (
               <div
                 key={s.sessionId}
-                className={`session-item ${isActive ? "session-active" : "session-ended"}`}
+                className={`session-item ${isActive ? "session-active" : "session-ended"}${isViewing ? " session-viewing" : ""}`}
                 onClick={() => openSession(s.sessionId)}
               >
                 <span className="session-icon">{isActive ? "⚡" : "✅"}</span>
@@ -119,6 +41,20 @@ export function SessionPanel() {
                 {s.model && <span className="session-model">{s.model}</span>}
                 {isActive && elapsed > 0 && (
                   <span className="session-elapsed">{elapsed}s</span>
+                )}
+                {isViewing && <span className="session-viewing-badge">viewing</span>}
+                {isActive && isViewing && (
+                  <button
+                    className="btn btn-danger btn-tiny"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (confirm("Stop this session?")) {
+                        send({ type: "session:stop", sessionId: s.sessionId });
+                      }
+                    }}
+                  >
+                    Stop
+                  </button>
                 )}
               </div>
             );

--- a/src/dashboard/frontend/src/components/SidePanel.css
+++ b/src/dashboard/frontend/src/components/SidePanel.css
@@ -97,6 +97,28 @@
   opacity: 1;
 }
 
+.session-tab-acp {
+  border-left: 2px solid var(--yellow, #e5c07b);
+}
+
+.acp-session-model {
+  font-size: 11px;
+  color: var(--text-dim);
+  background: var(--bg-hover);
+  padding: 1px 6px;
+  border-radius: 3px;
+  margin-left: auto;
+}
+
+.acp-output {
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.activity-panel {
+  overflow-y: auto;
+}
+
 .side-panel-close {
   margin-left: auto;
   font-size: 12px;

--- a/src/dashboard/frontend/src/components/SidePanel.tsx
+++ b/src/dashboard/frontend/src/components/SidePanel.tsx
@@ -65,6 +65,17 @@ export function SidePanel() {
   const sidePanelRole = useDashboardStore((s) => s.sidePanelRole);
   const send = useDashboardStore((s) => s.send);
 
+  // ACP session viewer state
+  const acpSessions = useDashboardStore((s) => s.acpSessions);
+  const viewingSessionId = useDashboardStore((s) => s.viewingSessionId);
+  const sessionOutput = useDashboardStore((s) => s.sessionOutput);
+  const closeAcpSession = useDashboardStore((s) => s.closeSession);
+
+  const isAcpView = activeChatId?.startsWith("acp:") ?? false;
+  const acpSessionId = isAcpView ? activeChatId!.slice(4) : null;
+  const acpSession = acpSessionId ? acpSessions.find((s) => s.sessionId === acpSessionId) : null;
+  const acpOutput = acpSessionId ? (sessionOutput.get(acpSessionId) ?? "") : "";
+
   const [input, setInput] = useState("");
   const [showSlashMenu, setShowSlashMenu] = useState(false);
   const [slashFilter, setSlashFilter] = useState("");
@@ -89,14 +100,14 @@ export function SidePanel() {
   })();
   const configs = activeChatId ? chatConfig[activeChatId] : undefined;
   const activeSession = chatSessions.find((s) => s.id === activeChatId);
-  const isLoading = !activeSession && activeChatId !== "__global__" && activeChatId !== null;
+  const isLoading = !activeSession && !isAcpView && activeChatId !== "__global__" && activeChatId !== null;
 
   const role = activeSession?.role ?? sidePanelRole ?? "agent";
   const meta = ROLE_META[role] ?? { icon: "🤖", label: role };
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [activeMessages, streaming, thinking, toolCalls, plan]);
+  }, [activeMessages, streaming, thinking, toolCalls, plan, acpOutput]);
 
   const switchToSession = (sessionId: string) => {
     const session = chatSessions.find((s) => s.id === sessionId);
@@ -218,8 +229,83 @@ export function SidePanel() {
             </div>
           );
         })}
+        {/* ACP session tab */}
+        {acpSession && (
+          <div
+            className={`session-tab session-tab-acp${isAcpView ? " session-tab-active" : ""}`}
+            onClick={() => useDashboardStore.setState({ activeChatId: `acp:${acpSession.sessionId}` })}
+          >
+            <span className="session-tab-label">
+              ⚡ {(ROLE_META[acpSession.role] ?? { label: acpSession.role }).label}
+              {acpSession.issueNumber ? ` #${acpSession.issueNumber}` : ""}
+            </span>
+            <button
+              className="session-tab-close"
+              onClick={(e) => { e.stopPropagation(); closeAcpSession(); }}
+            >
+              ✕
+            </button>
+          </div>
+        )}
       </div>
 
+      {/* ACP session output view */}
+      {isAcpView ? (
+        <>
+          <div className="side-panel-header">
+            <span className="side-panel-status connected">
+              {acpSession && !acpSession.endedAt ? "⚡ Running" : "✅ Completed"}
+            </span>
+            {acpSession?.model && (
+              <span className="acp-session-model">{acpSession.model}</span>
+            )}
+          </div>
+          <div className="side-panel-messages acp-output">
+            {acpOutput ? (
+              <Markdown text={acpOutput} />
+            ) : (
+              <div className="side-panel-empty">Waiting for output…</div>
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+          {acpSession && !acpSession.endedAt && (
+            <div className="side-panel-input-row">
+              <textarea
+                ref={inputRef}
+                className="side-panel-input"
+                placeholder="Send context or instructions to this session…"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    const text = input.trim();
+                    if (text && acpSessionId) {
+                      send({ type: "session:send-message", sessionId: acpSessionId, message: text });
+                      setInput("");
+                    }
+                  }
+                }}
+                rows={2}
+              />
+              <button
+                className="btn btn-primary btn-icon"
+                onClick={() => {
+                  const text = input.trim();
+                  if (text && acpSessionId) {
+                    send({ type: "session:send-message", sessionId: acpSessionId, message: text });
+                    setInput("");
+                  }
+                }}
+                title="Send"
+              >
+                ▶
+              </button>
+            </div>
+          )}
+        </>
+      ) : (
+      <>
       {/* Status bar */}
       <div className="side-panel-header">
         {isLoading && <span className="side-panel-status loading">Connecting…</span>}
@@ -499,6 +585,8 @@ export function SidePanel() {
           })()}
           <span className="mode-hint">Shift+Tab</span>
         </div>
+      )}
+      </>
       )}
     </div>
   );

--- a/src/dashboard/frontend/src/components/SprintTab.tsx
+++ b/src/dashboard/frontend/src/components/SprintTab.tsx
@@ -2,7 +2,7 @@ import { Allotment } from "allotment";
 import "allotment/dist/style.css";
 import { IssueList } from "./IssueList";
 import { SessionPanel } from "./SessionPanel";
-import { LogTerminal } from "./LogTerminal";
+import { ActivityFeed } from "./ActivityFeed";
 import { SidePanel } from "./SidePanel";
 import "./SprintTab.css";
 
@@ -10,7 +10,7 @@ export function SprintTab() {
   return (
     <main className="sprint-main">
       <Allotment>
-        {/* Left + Center: Issues, Sessions, Log */}
+        {/* Left + Center: Issues, Sessions, Activity */}
         <Allotment.Pane minSize={400}>
           <Allotment vertical>
             <Allotment.Pane minSize={150}>
@@ -32,7 +32,9 @@ export function SprintTab() {
             </Allotment.Pane>
 
             <Allotment.Pane minSize={80} preferredSize={180}>
-              <LogTerminal />
+              <div className="panel activity-panel">
+                <ActivityFeed />
+              </div>
             </Allotment.Pane>
           </Allotment>
         </Allotment.Pane>

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -785,7 +785,7 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
   },
 
   openSession: (id: string) => {
-    set({ viewingSessionId: id });
+    set({ viewingSessionId: id, activeChatId: `acp:${id}` });
     const store = get();
     store.send({ type: "session:subscribe", sessionId: id });
   },
@@ -795,6 +795,6 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
     if (store.viewingSessionId) {
       store.send({ type: "session:unsubscribe", sessionId: store.viewingSessionId });
     }
-    set({ viewingSessionId: null });
+    set({ viewingSessionId: null, activeChatId: store.generalChatId });
   },
 }));


### PR DESCRIPTION
## Changes

### ACP Sessions → SidePanel
- Clicking an ACP session in the center SessionPanel now opens it as a tab in the SidePanel (right side)
- SidePanel renders ACP session output with markdown formatting
- Active ACP sessions show input bar for sending messages
- SessionPanel simplified to list-only with viewing indicator and inline stop button

### Activity Feed replaces Error Log
- Sprint tab bottom panel now shows ActivityFeed instead of LogTerminal
- Shows real-time sprint events: phase changes, issue starts/completions, errors
- Error logs still accessible via the Logs tab

### Tests
- 573 unit tests pass ✅
- 149 E2E tests pass ✅