### PR TITLE
fix: allow Start after Stop and release stale locks

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -361,6 +361,15 @@ function registerWeb(program: Command): void {
         // Start/loop functions
         let sprintLimit = (opts.maxSprints as number | undefined) ?? config.sprint.max_sprints ?? 0;
         let activeRunner: SprintRunner = runner;
+
+        // Create a fresh runner for each start (the previous one may be aborted/stopped)
+        const createFreshRunner = () => {
+          const fresh = new SprintRunner(buildSprintConfig(config, initialSprint), eventBus);
+          fresh.loadSavedState();
+          activeRunner = fresh;
+          return fresh;
+        };
+
         const startLoop = () => {
           SprintRunner.sprintLoop(
             (sprintNumber) => buildSprintConfig(config, sprintNumber),
@@ -375,8 +384,8 @@ function registerWeb(program: Command): void {
         };
 
         const startOnce = () => {
-          activeRunner = runner;
-          runner.fullCycle().catch((err: unknown) => {
+          const fresh = createFreshRunner();
+          fresh.fullCycle().catch((err: unknown) => {
             const msg = err instanceof Error ? err.message : String(err);
             eventBus.emitTyped("sprint:error", { error: msg });
             eventBus.emitTyped("log", { level: "error", message: `Sprint crashed: ${msg}` });

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -481,6 +481,8 @@ export class SprintRunner {
       this.state.error = "Sprint stopped by user";
       this.persistState();
       this.events.emitTyped("sprint:stopped", { sprintNumber: this.config.sprintNumber });
+      // Release the lock in case no fullCycle() is running to do it
+      try { releaseLock(this.config); } catch { /* may not be locked */ }
     }
   }
 


### PR DESCRIPTION
Two bugs prevented the Start→Stop→Start cycle from working:

1. **Stale runner instance**: `startOnce` reused the same `runner` after Stop. Since `aborted=true` is permanent on a runner, the next `fullCycle()` immediately threw `SprintAbortedError`. Fix: create a fresh `SprintRunner` on each Start click.

2. **Stale lock file**: When `stop()` is called on a stale sprint (no `fullCycle()` running), the lock file was never released because `fullCycle()`'s `finally` block never ran. Fix: `stop()` now releases the lock itself.

575 unit tests ✅, build ✅