### PR TITLE
fix: flaky settings save E2E test

### DIFF
--- a/tests/e2e/settings-deep.spec.ts
+++ b/tests/e2e/settings-deep.spec.ts
@@ -70,22 +70,30 @@ test.describe("Settings Save & Reset", () => {
   });
 
   test("save sends config to backend and shows toast", async ({ page }) => {
-    // Make a change
+    // Wait for settings inputs to be fully loaded
     const input = page.locator(".settings-table input[type='number']").first();
+    await expect(input).toBeVisible({ timeout: 5_000 });
     const original = await input.inputValue();
+    // Use a value guaranteed to be different from the current value
+    const newValue = String(parseInt(original, 10) + 1);
     await input.click();
-    await input.fill("42");
-    // Save
+    await input.fill(newValue);
+    // Wait for dirty indicator — confirms React state updated
+    const dirtyBadge = page.locator(".settings-dirty");
+    await expect(dirtyBadge.first()).toBeVisible({ timeout: 3_000 });
+    // Save (should now be enabled)
     const saveBtn = page.locator("button", { hasText: /💾\s*Save/i }).first();
+    await expect(saveBtn).toBeEnabled({ timeout: 2_000 });
     await saveBtn.click();
     // Toast should appear
     const toast = page.locator(".settings-toast");
-    await expect(toast).toBeVisible({ timeout: 3_000 });
-    // Restore
+    await expect(toast).toBeVisible({ timeout: 5_000 });
+    // Restore original value
     await input.click();
     await input.fill(original);
+    await expect(dirtyBadge.first()).toBeVisible({ timeout: 3_000 });
     await saveBtn.click();
-    await page.waitForTimeout(1000);
+    await expect(toast).toBeVisible({ timeout: 5_000 });
   });
 
   test("reset button reverts changes", async ({ page }) => {


### PR DESCRIPTION
## Root Cause

A previous failed test run left `max_parallel_sessions: 42` in `.aiscrum/config.yaml`. When the test ran again and filled '42' into the input, no state change occurred → `isDirty` stayed false → Save button remained disabled → no toast appeared → test timed out.

## Fix

- Use `parseInt(original) + 1` instead of hardcoded '42' — guarantees a different value regardless of current state
- Wait for dirty indicator (`.settings-dirty`) before clicking Save — confirms React state updated
- Wait for Save button to be enabled — prevents clicking a disabled button
- Restore original value with proper dirty/save flow (wait for dirty + enabled before second save)
- Increased toast timeout from 3s to 5s for slower environments

## Verification
- 589 unit tests pass ✅
- 178 E2E tests pass (0 failures) ✅
- Ran the specific test 3 times with retries=2, all green