### PR TITLE
fix: accept null ice_score and points from planning agent

### DIFF
--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -7,11 +7,11 @@ export const SprintPlanSchema = z.object({
       z.object({
         number: z.coerce.number(),
         title: z.string().default(""),
-        ice_score: z.number().default(0),
+        ice_score: z.number().nullable().default(0).transform((v) => v ?? 0),
         depends_on: z.array(z.coerce.number()).default([]),
         acceptanceCriteria: z.string().default(""),
         expectedFiles: z.array(z.string()).default([]),
-        points: z.number().default(0),
+        points: z.number().nullable().default(0).transform((v) => v ?? 0),
       }),
     )
     .min(1),


### PR DESCRIPTION
## Problem
The planning agent sometimes returns `ice_score: null` and `points: null` in sprint plan output. The Zod schema used `.default(0)` which only handles `undefined`, not `null`, causing a validation error:

```
invalid_type: expected number, received null — path: sprint_issues.0.ice_score
```

## Fix
Added `.nullable().transform(v => v ?? 0)` to both fields so `null` is coerced to `0`.

## Testing
- 589 unit tests pass
- Type check clean