### PR TITLE
feat: sequential execution option to prevent merge conflicts

### DIFF
--- a/src/ceremonies/parallel-dispatcher.ts
+++ b/src/ceremonies/parallel-dispatcher.ts
@@ -118,9 +118,9 @@ export async function runParallelExecution(
   const issueMap = new Map(plan.sprint_issues.map((i) => [i.number, i]));
 
   for (const group of groups) {
-    log.info({ group: group.group, issues: group.issues }, "executing group");
-
-    const limit = pLimit(config.maxParallelSessions);
+    const concurrency = config.sequentialExecution ? 1 : config.maxParallelSessions;
+    const limit = pLimit(concurrency);
+    log.info({ group: group.group, issues: group.issues, concurrency }, "executing group");
 
     const settled = await Promise.allSettled(
       group.issues.map((issueNumber) =>

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -43,6 +43,7 @@ export function buildSprintConfig(config: ConfigFile, sprintNumber: number): Spr
     maxRetries: config.sprint.max_retries,
     enableChallenger: config.sprint.enable_challenger,
     enableTdd: config.sprint.enable_tdd,
+    sequentialExecution: config.sprint.sequential_execution,
     autoRevertDrift: config.sprint.auto_revert_drift,
     backlogLabels: config.sprint.backlog_labels,
     autoMerge: config.git.auto_merge,

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,6 +74,7 @@ const SprintSchema = z.object({
   enable_challenger: z.boolean().default(true),
   enable_tdd: z.boolean().default(false),
   auto_revert_drift: z.boolean().default(false),
+  sequential_execution: z.boolean().default(true),
   backlog_labels: z.array(z.string()).default([]),
 });
 

--- a/src/dashboard/frontend/src/components/SettingsPage.tsx
+++ b/src/dashboard/frontend/src/components/SettingsPage.tsx
@@ -31,6 +31,7 @@ interface Config {
     max_retries: number;
     enable_challenger: boolean;
     enable_tdd: boolean;
+    sequential_execution: boolean;
     auto_revert_drift: boolean;
     backlog_labels: string[];
   };
@@ -679,6 +680,9 @@ export function SettingsPage() {
             </Row>
             <Row label="TDD" desc="Require test-driven development workflow for all issues">
               <Toggle value={config.sprint.enable_tdd} onChange={(v) => upSprint({ enable_tdd: v })} />
+            </Row>
+            <Row label="Sequential Execution" desc="Run developer agents one at a time to avoid merge conflicts">
+              <Toggle value={config.sprint.sequential_execution} onChange={(v) => upSprint({ sequential_execution: v })} />
             </Row>
             <Row label="Auto-revert Drift" desc="Automatically revert changes that cause sprint scope drift">
               <Toggle value={config.sprint.auto_revert_drift} onChange={(v) => upSprint({ auto_revert_drift: v })} />

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -62,6 +62,7 @@ export interface ExecutionLimits {
   maxDriftIncidents: number;
   enableChallenger: boolean;
   enableTdd: boolean;
+  sequentialExecution: boolean;
   autoRevertDrift: boolean;
   backlogLabels: string[];
 }


### PR DESCRIPTION
## Problem
Parallel developer agents frequently cause merge conflicts when editing overlapping files.

## Solution
New config option `sprint.sequential_execution` (default: **true**) forces issue execution to run one at a time (`concurrency=1`).

When disabled, uses `max_parallel_sessions` as before for parallel execution.

## Config
```yaml
sprint:
  sequential_execution: true  # default — one issue at a time
```

Toggle available in Settings → Sprint → Sequential Execution.

## Testing
- 589 unit tests pass
- Type check clean
- Build clean