### PR TITLE
fix: session outcome visibility — icons, activity log, review loop

### DIFF
--- a/src/ceremonies/execution.ts
+++ b/src/ceremonies/execution.ts
@@ -124,15 +124,13 @@ async function planPhase(ctx: ExecutionContext): Promise<string> {
   } catch (err: unknown) {
     log.warn({ err }, "plan mode failed — proceeding with direct execution");
   } finally {
-    eventBus?.emitTyped("session:end", { sessionId });
+    eventBus?.emitTyped("session:end", { sessionId, outcome: "completed" });
     await client.endSession(sessionId);
   }
 
   return implementationPlan;
 }
 
-// ---------------------------------------------------------------------------
-// Sub-phase: TDD — Test-Engineer writes tests before implementation
 // ---------------------------------------------------------------------------
 
 /** Create ACP session for Test-Engineer to write failing tests based on the plan. */
@@ -180,7 +178,7 @@ async function tddPhase(ctx: ExecutionContext, implementationPlan: string): Prom
 
     log.info("TDD tests written");
   } finally {
-    eventBus?.emitTyped("session:end", { sessionId });
+    eventBus?.emitTyped("session:end", { sessionId, outcome: "completed" });
     await client.endSession(sessionId);
   }
 }
@@ -254,7 +252,7 @@ async function implementPhase(ctx: ExecutionContext, implementationPlan: string)
   } catch (err: unknown) {
     // On error, close session before re-throwing
     acpOutputLines = client.getSessionOutput(sessionId, 50);
-    eventBus?.emitTyped("session:end", { sessionId });
+    eventBus?.emitTyped("session:end", { sessionId, outcome: "failed" });
     await client.endSession(sessionId);
     throw err;
   }
@@ -322,6 +320,8 @@ async function acceptanceCriteriaReview(ctx: ExecutionContext, qualityResult: Qu
     model: reviewerConfig.model,
   });
 
+  let acOutcome: "approved" | "changes_requested" | "completed" = "completed";
+
   try {
     if (reviewerConfig.model) {
       await client.setModel(sessionId, reviewerConfig.model);
@@ -341,9 +341,10 @@ async function acceptanceCriteriaReview(ctx: ExecutionContext, qualityResult: Qu
     );
 
     log.info({ approved: acResult.approved }, "acceptance criteria review completed");
+    acOutcome = acResult.approved ? "approved" : "changes_requested";
     return acResult;
   } finally {
-    eventBus?.emitTyped("session:end", { sessionId });
+    eventBus?.emitTyped("session:end", { sessionId, outcome: acOutcome });
     await client.endSession(sessionId);
   }
 }
@@ -393,6 +394,7 @@ async function qualityAndReviewPhase(ctx: ExecutionContext, devSessionId: string
       codeReview = await runCodeReview(client, config, issue, branch, worktreePath, ctx.eventBus);
 
       if (!codeReview.approved) {
+        progress("review rejected — fixing");
         const fixResult = await attemptCodeReviewFix(ctx, codeReview, devSessionId);
         qualityResult = fixResult.qualityResult;
         codeReview = fixResult.codeReview;
@@ -409,6 +411,7 @@ async function qualityAndReviewPhase(ctx: ExecutionContext, devSessionId: string
       progress("acceptance review");
       const acReview = await acceptanceCriteriaReview(ctx, qualityResult);
       if (!acReview.approved) {
+        progress("acceptance failed — fixing");
         const feedback = acReview.feedback ?? "Acceptance criteria not met";
         await client.sendPrompt(devSessionId,
           `## Acceptance Criteria Review Failed\n\n${feedback}\n\nPlease fix the issues and ensure all acceptance criteria are met.`,
@@ -481,9 +484,10 @@ async function attemptCodeReviewFix(
   codeReview: CodeReviewResult,
   devSessionId: string,
 ): Promise<{ qualityResult: QualityResult; codeReview?: CodeReviewResult }> {
-  const { client, config, issue, log, worktreePath, branch } = ctx;
+  const { client, config, issue, log, worktreePath, branch, progress } = ctx;
 
   log.warn("code review rejected — attempting fix in same session");
+  progress("developer fixing review issues");
 
   const fixPrompt = [
     "The automated code review found issues with your implementation.",
@@ -499,6 +503,7 @@ async function attemptCodeReviewFix(
 
   let newReview: CodeReviewResult | undefined = codeReview;
   if (newQuality.passed) {
+    progress("re-reviewing code");
     newReview = await runCodeReview(client, config, issue, branch, worktreePath, ctx.eventBus);
     log.info({ approved: newReview.approved }, "code review re-run after fix");
   }
@@ -727,7 +732,7 @@ export async function executeIssue(
   } finally {
     // Close developer session after all retries are done
     if (devSessionId) {
-      eventBus?.emitTyped("session:end", { sessionId: devSessionId });
+      eventBus?.emitTyped("session:end", { sessionId: devSessionId, outcome: status === "completed" ? "completed" : "failed" });
       await client.endSession(devSessionId).catch((err) => {
         log.warn({ err, sessionId: devSessionId, issue: issue.number }, "failed to end developer session — possible session leak");
       });

--- a/src/dashboard/frontend/src/components/SessionPanel.css
+++ b/src/dashboard/frontend/src/components/SessionPanel.css
@@ -30,6 +30,13 @@
 .session-item:hover { background: var(--bg-hover); }
 
 .session-icon { flex-shrink: 0; font-size: 14px; }
+.session-icon-active {
+  animation: pulse-icon 1.5s ease-in-out infinite;
+}
+@keyframes pulse-icon {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
 .session-role { font-weight: 500; }
 .session-model {
   font-size: 11px;
@@ -46,6 +53,7 @@
 }
 
 .session-ended { opacity: 0.5; }
+.session-active { background: rgba(var(--green-rgb, 46, 160, 67), 0.08); }
 .session-viewing { background: var(--bg-hover); border-left: 2px solid var(--blue); }
 .session-viewing-badge {
   font-size: 10px;

--- a/src/dashboard/frontend/src/components/SessionPanel.tsx
+++ b/src/dashboard/frontend/src/components/SessionPanel.tsx
@@ -1,6 +1,17 @@
 import { useState, useEffect } from "react";
 import { useDashboardStore } from "../store";
+import type { AcpSession } from "../types";
 import "./SessionPanel.css";
+
+function sessionIcon(s: AcpSession): string {
+  if (!s.endedAt) return "⚡";
+  switch (s.outcome) {
+    case "approved": return "✅";
+    case "changes_requested": return "🔄";
+    case "failed": return "❌";
+    default: return "✅";
+  }
+}
 
 export function SessionPanel() {
   const sessions = useDashboardStore((s) => s.acpSessions);
@@ -46,7 +57,7 @@ export function SessionPanel() {
                 className={`session-item ${isActive ? "session-active" : "session-ended"}${isViewing ? " session-viewing" : ""}`}
                 onClick={() => openSession(s.sessionId)}
               >
-                <span className="session-icon">{isActive ? "⚡" : "✅"}</span>
+                <span className={`session-icon${isActive ? " session-icon-active" : ""}`}>{sessionIcon(s)}</span>
                 <span className="session-role">{s.role}</span>
                 {s.model && <span className="session-model">{s.model}</span>}
                 {isActive && elapsed > 0 && (

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -652,6 +652,7 @@ function handleSprintEvent(
         planner: "Planning implementation",
         "test-engineer": "Writing tests (TDD)",
         developer: "Implementing changes",
+        reviewer: "Code review",
         "quality-reviewer": "Reviewing acceptance criteria",
         review: "Sprint review",
         retro: "Sprint retrospective",
@@ -671,13 +672,19 @@ function handleSprintEvent(
     }
 
     case "session:end": {
-      // Mark the most recent active session activity as done
+      const outcome = (p?.outcome as string) ?? "completed";
       const acts = get().activities;
       const idx = [...acts].reverse().findIndex((a) => a.type === "session" && a.status === "active");
       if (idx >= 0) {
         const realIdx = acts.length - 1 - idx;
         const updated = [...acts];
-        updated[realIdx] = { ...updated[realIdx]!, status: "done" };
+        const endStatus = outcome === "failed" || outcome === "changes_requested" ? "failed" : "done";
+        const suffix = outcome === "changes_requested" ? " — changes requested" : outcome === "failed" ? " — failed" : "";
+        updated[realIdx] = {
+          ...updated[realIdx]!,
+          status: endStatus,
+          label: updated[realIdx]!.label + suffix,
+        };
         set({ activities: updated });
       }
       break;

--- a/src/dashboard/frontend/src/types.ts
+++ b/src/dashboard/frontend/src/types.ts
@@ -96,6 +96,7 @@ export interface AcpSession {
   model?: string;
   startedAt: string;
   endedAt?: string | null;
+  outcome?: "completed" | "approved" | "changes_requested" | "failed" | null;
 }
 
 /** Chat session. */

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -98,6 +98,7 @@ export interface TrackedSession {
   model?: string;
   startedAt: number;
   endedAt?: number;
+  outcome?: "completed" | "approved" | "changes_requested" | "failed";
   output: string[];
 }
 
@@ -349,6 +350,7 @@ export class DashboardWebServer {
       model: s.model,
       startedAt: s.startedAt,
       endedAt: s.endedAt,
+      outcome: s.outcome,
       outputLength: s.output.length,
     }));
     this.broadcast({ type: "session:list", payload: sessions });
@@ -430,6 +432,7 @@ export class DashboardWebServer {
       const session = this.sessions.get(payload.sessionId);
       if (session) {
         session.endedAt = Date.now();
+        session.outcome = payload.outcome;
         this.broadcastSessionList();
         // Clean up subscribers
         this.sessionSubscribers.delete(payload.sessionId);

--- a/src/enforcement/code-review.ts
+++ b/src/enforcement/code-review.ts
@@ -39,6 +39,8 @@ export async function runCodeReview(
     model: sessionConfig.model,
   });
 
+  let outcome: "approved" | "changes_requested" | "failed" | "completed" = "completed";
+
   try {
     if (sessionConfig.model) {
       await client.setModel(sessionId, sessionConfig.model);
@@ -90,9 +92,10 @@ export async function runCodeReview(
 
     log.info({ approved, issueCount: issues.length }, "code review completed");
 
+    outcome = approved ? "approved" : "changes_requested";
     return { approved, feedback: response, issues };
   } finally {
-    eventBus?.emitTyped("session:end", { sessionId });
+    eventBus?.emitTyped("session:end", { sessionId, outcome });
     await client.endSession(sessionId);
   }
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -12,7 +12,7 @@ export interface SprintEngineEvents {
   "issue:fail": { issueNumber: number; reason: string; duration_ms: number };
   "worker:output": { sessionId: string; text: string };
   "session:start": { sessionId: string; role: string; issueNumber?: number; model?: string };
-  "session:end": { sessionId: string };
+  "session:end": { sessionId: string; outcome?: "completed" | "approved" | "changes_requested" | "failed" };
   "sprint:start": { sprintNumber: number; resumed?: boolean };
   "sprint:planned": { issues: { number: number; title: string }[] };
   "sprint:complete": { sprintNumber: number };


### PR DESCRIPTION
## Problem

As a PO looking at the dashboard, you can't tell what's happening:
- Reviewer shows ✅ even when it rejected code (CHANGES_REQUESTED)
- Activity log doesn't show the review→developer→re-review loop
- Can't tell which agent is currently active at a glance

## Changes

### Session outcome tracking (backend → frontend)
- Extended `session:end` event with `outcome` field: `completed`, `approved`, `changes_requested`, `failed`
- `code-review.ts`: emits outcome based on review decision
- `execution.ts`: emits outcome for planner, TDD, developer, acceptance reviewer sessions
- `ws-server.ts`: passes outcome through to frontend via session list

### Outcome-aware session icons
- ⚡ (pulsing) = active/running
- ✅ = completed/approved
- 🔄 = changes requested
- ❌ = failed

### Review loop activity entries
- `review rejected — fixing` when code review returns changes
- `developer fixing review issues` during fix attempt
- `re-reviewing code` on re-review
- `acceptance failed — fixing` on AC rejection
- Session end entries append outcome suffix (e.g. '— changes requested')

### Active agent highlighting
- Active sessions have subtle green background tint
- ⚡ icon pulses with CSS animation
- Immediate visual identification of what's running

## Verification
- 585 unit tests pass ✅
- Type check clean ✅
- Build succeeds ✅