### PR TITLE
fix: code review findings — outcome defaults, lint errors, gate optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ check: lint typecheck test ## Run lint + types + tests
 gate: ## Full gate: format + lint + types + tests + build (pre-push)
 	npx prettier --check 'src/**/*.ts' 'tests/**/*.ts'
 	npx eslint src/ tests/
-	npx tsc --noEmit
 	npx vitest run
 	npx tsc && cd src/dashboard/frontend && npm run build
 

--- a/src/ceremonies/execution.ts
+++ b/src/ceremonies/execution.ts
@@ -320,7 +320,7 @@ async function acceptanceCriteriaReview(ctx: ExecutionContext, qualityResult: Qu
     model: reviewerConfig.model,
   });
 
-  let acOutcome: "approved" | "changes_requested" | "completed" = "completed";
+  let acOutcome: "approved" | "changes_requested" | "failed" = "failed";
 
   try {
     if (reviewerConfig.model) {

--- a/src/dashboard/frontend/src/components/Markdown.tsx
+++ b/src/dashboard/frontend/src/components/Markdown.tsx
@@ -32,7 +32,7 @@ function markdownToHtml(text: string): string {
   let blockId = 0;
 
   // Extract raw HTML table blocks (agent output) — pass through as-is
-  let processed = text.replace(/<table[\s\S]*?<\/table>/gi, (match) => {
+  const processed = text.replace(/<table[\s\S]*?<\/table>/gi, (match) => {
     const key = `__BLOCK_${blockId++}__`;
     blocks[key] = `<div class="md-table-wrap">${match}</div>`;
     return key;

--- a/src/dashboard/frontend/src/components/SessionPanel.css
+++ b/src/dashboard/frontend/src/components/SessionPanel.css
@@ -53,7 +53,7 @@
 }
 
 .session-ended { opacity: 0.5; }
-.session-active { background: rgba(var(--green-rgb, 46, 160, 67), 0.08); }
+.session-active { background: rgba(63, 185, 80, 0.08); }
 .session-viewing { background: var(--bg-hover); border-left: 2px solid var(--blue); }
 .session-viewing-badge {
   font-size: 10px;

--- a/src/enforcement/code-review.ts
+++ b/src/enforcement/code-review.ts
@@ -39,7 +39,7 @@ export async function runCodeReview(
     model: sessionConfig.model,
   });
 
-  let outcome: "approved" | "changes_requested" | "failed" | "completed" = "completed";
+  let outcome: "approved" | "changes_requested" | "failed" = "failed";
 
   try {
     if (sessionConfig.model) {

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";

--- a/tests/dashboard/session-logger.test.ts
+++ b/tests/dashboard/session-logger.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { writeSessionLog } from "../../src/dashboard/session-logger.js";

--- a/tests/e2e/interactions.spec.ts
+++ b/tests/e2e/interactions.spec.ts
@@ -24,7 +24,6 @@ test.describe("Sprint Report Deep", () => {
   });
 
   test("has sprint number selector", async ({ page }) => {
-    const select = page.locator(".report-sprint-select, select");
     // May or may not have a select depending on data
     const heading = page.locator(".sprint-report h1");
     await expect(heading).toBeVisible();

--- a/tests/e2e/sprint-controls.spec.ts
+++ b/tests/e2e/sprint-controls.spec.ts
@@ -4,8 +4,6 @@
  */
 import { test, expect, type Page } from "@playwright/test";
 
-const BASE = "http://localhost:9200";
-
 // Helper: wait for dashboard to load
 async function waitForDashboard(page: Page) {
   await page.goto("/");
@@ -80,7 +78,6 @@ test.describe("Sprint Control Buttons", () => {
     const startBtn = page.locator("button", { hasText: "▶ Start" });
     if (await startBtn.count() > 0 && await startBtn.isEnabled()) {
       // Set up WebSocket message listener
-      const wsMessages: string[] = [];
       await page.evaluate(() => {
         const origSend = WebSocket.prototype.send;
         (window as unknown as Record<string, string[]>).__wsMsgs = [];


### PR DESCRIPTION
## Code Review Fixes

Addresses all findings from intensive code review of PRs #410-#417.

### 🔴 Blocking (bugs)
| # | Issue | Fix |
|---|-------|-----|
| 1 | Acceptance review reports `completed` on exception | Default `acOutcome` to `failed` instead of `completed` |
| 5 | Code review outcome defaults to `completed` on error | Default `outcome` to `failed` instead of `completed` |

### 🟡 Non-blocking
| # | Issue | Fix |
|---|-------|-----|
| 2 | 6 pre-existing lint errors block git hooks | Fixed all: unused vars, prefer-const |
| 3 | Makefile gate runs `tsc` twice | Removed redundant `tsc --noEmit` (build includes type check) |
| 4 | CSS `--green-rgb` fallback uses wrong color | Replaced with direct RGB matching theme `--green: #3fb950` |

### Verification
- 0 lint errors ✅ (was 6)
- 585 unit tests pass ✅
- Type check clean ✅
- Build succeeds ✅