### PR TITLE
fix: review round 2 — schema bugs, memory leaks, stale comments

### DIFF
--- a/src/ceremonies/execution.ts
+++ b/src/ceremonies/execution.ts
@@ -665,10 +665,6 @@ export async function executeIssue(
   log.info("issue marked in-progress");
   progress("creating worktree");
 
-  // Step 2: Create worktree
-  await createWorktree({ path: worktreePath, branch, base: config.baseBranch });
-  log.info({ worktreePath, branch }, "worktree created");
-
   let qualityResult: QualityResult = { passed: false, checks: [] };
   let codeReview: CodeReviewResult | undefined;
   let retryCount = 0;
@@ -680,6 +676,10 @@ export async function executeIssue(
   let devSessionId: string | undefined;
 
   try {
+    // Step 2: Create worktree
+    await createWorktree({ path: worktreePath, branch, base: config.baseBranch });
+    log.info({ worktreePath, branch }, "worktree created");
+
     // Step 3: Plan phase (own ACP session as planner)
     const implementationPlan = await planPhase(ctx);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,7 +54,7 @@ const ProjectSchema = z.object({
 
 const CopilotSchema = z.object({
   executable: z.string().min(1).default("copilot"),
-  max_parallel_sessions: z.number().int().min(1).max(20).default(4),
+  max_parallel_sessions: z.number().int().min(1).max(100).default(4),
   session_timeout_ms: z.number().int().min(0).default(600000),
   auto_approve_tools: z.boolean().default(true),
   allow_tool_patterns: z.array(z.string()).default([]),

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -152,6 +152,7 @@ function createWebSocket(set: SetFn, get: GetFn): void {
   ws.onclose = () => {
     set({
       connected: false,
+      activities: [],
       chatSessions: [],
       activeChatId: null,
       generalChatId: null,
@@ -770,6 +771,10 @@ function addActivity(
     a.status === "active" && a.type === type ? { ...a, status: "done" as const } : a,
   );
   activities.push({ type, label, detail, status, time: new Date() });
+  // Cap at 500 entries to prevent unbounded memory growth
+  if (activities.length > 500) {
+    activities.splice(0, activities.length - 500);
+  }
   set({ activities });
 }
 

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -434,8 +434,14 @@ export class DashboardWebServer {
         session.endedAt = Date.now();
         session.outcome = payload.outcome;
         this.broadcastSessionList();
-        // Clean up subscribers
         this.sessionSubscribers.delete(payload.sessionId);
+        // Prune ended session after 5 minutes to prevent memory leak
+        setTimeout(() => {
+          const s = this.sessions.get(payload.sessionId);
+          if (s?.endedAt) {
+            this.sessions.delete(payload.sessionId);
+          }
+        }, 5 * 60 * 1000);
       }
     });
 

--- a/src/enforcement/quality-gate.ts
+++ b/src/enforcement/quality-gate.ts
@@ -136,7 +136,7 @@ export async function runQualityGate(
     });
   }
 
-  // 6. Compute diff stat (reused by scope-drift and diff-size checks)
+  // 6. Compute diff stat for diff-size check
   try {
     const stat = await diffStat(branch, baseBranch);
 
@@ -152,7 +152,7 @@ export async function runQualityGate(
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    log.warn({ error: msg }, "diffStat() failed — skipping scope-drift and diff-size checks");
+    log.warn({ error: msg }, "diffStat() failed — skipping diff-size check");
     checks.push({
       name: "diff-stat",
       passed: false,

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -16,7 +16,7 @@ export const SprintPlanSchema = z.object({
     )
     .min(1),
   execution_groups: z.array(z.array(z.coerce.number())).optional(),
-  estimated_points: z.number().default(0),
+  estimated_points: z.number().nullable().default(0).transform((v) => v ?? 0),
   rationale: z.string().default(""),
 });
 


### PR DESCRIPTION
## Code Review Round 2 Fixes

### 🔴 Blocking
| # | Issue | Fix |
|---|-------|-----|
| 1 | `max_parallel_sessions` schema max=20 rejects prod config (42) | Raised to 100 |
| 2 | `estimated_points` crashes on null from LLM | Added `.nullable().transform()` |

### 🟡 Non-blocking
| # | Issue | Fix |
|---|-------|-----|
| 3 | Sessions Map never cleaned up → memory leak | Prune ended sessions after 5 min |
| 4 | WebSocket reconnect duplicates activities | Clear activities on disconnect |
| 5 | Activities array grows unbounded | Capped at 500 entries |
| 6 | Stale scope-drift comments | Updated to reference diff-size only |
| 7 | Worktree leak if exception before try block | Moved creation inside try |

### Verification
- 0 lint errors ✅
- 585 unit tests pass ✅
- Type check clean ✅
- Build succeeds ✅