### PR TITLE
fix: code review round 3 — planning limit, signal handlers, timeouts, validation

### DIFF
--- a/src/ceremonies/planning.ts
+++ b/src/ceremonies/planning.ts
@@ -24,7 +24,14 @@ export async function runSprintPlanning(
   const log = logger.child({ ceremony: "planning" });
 
   // Read prompt template
-  const templatePath = path.join(config.projectPath, ".aiscrum", "roles", "planner", "prompts", "planning.md");
+  const templatePath = path.join(
+    config.projectPath,
+    ".aiscrum",
+    "roles",
+    "planner",
+    "prompts",
+    "planning.md",
+  );
   const template = await fs.readFile(templatePath, "utf-8");
 
   const prompt = substitutePrompt(template, {
@@ -53,9 +60,16 @@ export async function runSprintPlanning(
       await client.setModel(sessionId, sessionConfig.model);
     }
     const result = await client.sendPrompt(sessionId, fullPrompt, config.sessionTimeoutMs);
-    const plan = SprintPlanSchema.parse(
-      extractJson(result.response),
-    ) as SprintPlan;
+    const plan = SprintPlanSchema.parse(extractJson(result.response)) as SprintPlan;
+
+    // Enforce max_issues — LLM may return more than requested
+    if (plan.sprint_issues.length > config.maxIssuesPerSprint) {
+      log.warn(
+        { returned: plan.sprint_issues.length, max: config.maxIssuesPerSprint },
+        "planner returned more issues than max — truncating",
+      );
+      plan.sprint_issues = plan.sprint_issues.slice(0, config.maxIssuesPerSprint);
+    }
 
     log.info(
       {
@@ -70,7 +84,10 @@ export async function runSprintPlanning(
     const milestoneTitle = `${config.sprintPrefix} ${config.sprintNumber}`;
     const existing = await getMilestone(milestoneTitle);
     if (!existing) {
-      await createMilestone(milestoneTitle, `${config.sprintPrefix} ${config.sprintNumber} milestone`);
+      await createMilestone(
+        milestoneTitle,
+        `${config.sprintPrefix} ${config.sprintNumber} milestone`,
+      );
     }
 
     // Set labels and milestone on each selected issue

--- a/src/ceremonies/retro.ts
+++ b/src/ceremonies/retro.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import yaml from "yaml";
 import type { AcpClient } from "../acp/client.js";
 import type {
   SprintConfig,
@@ -45,7 +46,14 @@ export async function runSprintRetro(
     }));
 
   // Read prompt template
-  const templatePath = path.join(config.projectPath, ".aiscrum", "roles", "retro", "prompts", "retro.md");
+  const templatePath = path.join(
+    config.projectPath,
+    ".aiscrum",
+    "roles",
+    "retro",
+    "prompts",
+    "retro.md",
+  );
   const template = await fs.readFile(templatePath, "utf-8");
 
   const prompt = substitutePrompt(template, {
@@ -80,23 +88,30 @@ export async function runSprintRetro(
       wentWell: (rawRetro.wentWell ?? rawRetro.went_well ?? []) as string[],
       wentBadly: (rawRetro.wentBadly ?? rawRetro.went_poorly ?? []) as string[],
       improvements: [],
-      previousImprovementsChecked: (rawRetro.previousImprovementsChecked ?? rawRetro.previous_improvements_applied !== undefined) as boolean,
+      previousImprovementsChecked: (rawRetro.previousImprovementsChecked ??
+        rawRetro.previous_improvements_applied !== undefined) as boolean,
     };
 
     // Normalize improvements: prompt format uses problem/action/category,
     // code expects title/description/target/autoApplicable
     const rawImprovements = (rawRetro.improvements ?? []) as Record<string, unknown>[];
     for (const raw of rawImprovements) {
-      const title = (raw.title as string) || (raw.action as string) || (raw.problem as string) || "";
-      const description = (raw.description as string) ||
+      const title =
+        (raw.title as string) || (raw.action as string) || (raw.problem as string) || "";
+      const description =
+        (raw.description as string) ||
         [raw.problem, raw.root_cause, raw.action, raw.expected_outcome]
           .filter(Boolean)
           .join(" — ") ||
         "";
       const categoryMap: Record<string, RetroImprovement["target"]> = {
-        config: "config", agent: "agent", skill: "skill", process: "process",
+        config: "config",
+        agent: "agent",
+        skill: "skill",
+        process: "process",
       };
-      const target = (raw.target as RetroImprovement["target"]) ||
+      const target =
+        (raw.target as RetroImprovement["target"]) ||
         categoryMap[(raw.category as string)?.toLowerCase()] ||
         "process";
       const autoApplicable = raw.autoApplicable !== undefined ? Boolean(raw.autoApplicable) : true;
@@ -149,7 +164,10 @@ export async function runSprintRetro(
             labels: ["human-decision-needed", "type:improvement"],
           });
         } catch (issueErr) {
-          log.warn({ err: String(issueErr), title }, "Failed to create backlog issue for process improvement");
+          log.warn(
+            { err: String(issueErr), title },
+            "Failed to create backlog issue for process improvement",
+          );
         }
         continue;
       }
@@ -219,6 +237,27 @@ async function applyImprovement(
       `Do NOT create new files — only edit existing ones.`,
     ].join("\n");
     await client.sendPrompt(sessionId, prompt, config.sessionTimeoutMs);
+
+    // Validate config after ACP edits to prevent corruption
+    if (improvement.target === "config") {
+      const configFile = path.join(config.projectPath, ".aiscrum", "config.yaml");
+      try {
+        const raw = await fs.readFile(configFile, "utf-8");
+        yaml.parse(raw); // Throws on invalid YAML
+      } catch (parseErr: unknown) {
+        log.error(
+          { err: String(parseErr), title: improvement.title },
+          "Retro improvement corrupted config — reverting",
+        );
+        // Revert via git checkout
+        const { execFile } = await import("node:child_process");
+        const { promisify } = await import("node:util");
+        const exec = promisify(execFile);
+        await exec("git", ["checkout", "--", configFile], { cwd: config.projectPath });
+        throw new Error(`Config validation failed after retro improvement: ${String(parseErr)}`);
+      }
+    }
+
     log.info({ title: improvement.title }, "Applied improvement via ACP");
   } catch (err: unknown) {
     log.warn({ err: String(err), title: improvement.title }, "Failed to auto-apply improvement");

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -69,7 +69,9 @@ function registerPlan(program: Command): void {
           console.log(`  Estimated points: ${plan.estimated_points}`);
           console.log(`  Rationale: ${plan.rationale}`);
           for (const issue of plan.sprint_issues) {
-            console.log(`    #${issue.number} — ${issue.title} (${issue.points}pt, ICE=${issue.ice_score})`);
+            console.log(
+              `    #${issue.number} — ${issue.title} (${issue.points}pt, ICE=${issue.ice_score})`,
+            );
           }
         } finally {
           await client.disconnect();
@@ -110,7 +112,9 @@ function registerExecuteIssue(program: Command): void {
         const client = await createConnectedClient(config);
         try {
           const result = await executeIssue(client, sprintConfig, sprintIssue);
-          console.log(`\n${result.status === "completed" ? "✅" : "❌"} Issue #${result.issueNumber}: ${result.status}`);
+          console.log(
+            `\n${result.status === "completed" ? "✅" : "❌"} Issue #${result.issueNumber}: ${result.status}`,
+          );
           console.log(`  Quality gate: ${result.qualityGatePassed ? "passed" : "failed"}`);
           console.log(`  Branch: ${result.branch}`);
           console.log(`  Duration: ${(result.duration_ms / 1000).toFixed(1)}s`);
@@ -158,7 +162,9 @@ function registerCheckQuality(program: Command): void {
         };
 
         const result = await runQualityGate(gateConfig, process.cwd(), opts.branch, baseBranch);
-        console.log(`\n${result.passed ? "✅" : "❌"} Quality gate: ${result.passed ? "PASSED" : "FAILED"}`);
+        console.log(
+          `\n${result.passed ? "✅" : "❌"} Quality gate: ${result.passed ? "PASSED" : "FAILED"}`,
+        );
         for (const check of result.checks) {
           console.log(`  ${check.passed ? "✓" : "✗"} ${check.name}: ${check.detail}`);
         }
@@ -218,20 +224,26 @@ function registerFullCycle(program: Command): void {
           // Step 1: Plan
           console.log("\n🔄 Phase 1/4: Planning...");
           const plan = await runSprintPlanning(client, sprintConfig);
-          console.log(`  Planned ${plan.sprint_issues.length} issues (${plan.estimated_points} points)`);
+          console.log(
+            `  Planned ${plan.sprint_issues.length} issues (${plan.estimated_points} points)`,
+          );
 
           // Step 2: Execute all issues (with parallel dispatch, merge, pre-merge verification)
           console.log("\n🔄 Phase 2/4: Execution...");
           const sprintResult = await runParallelExecution(client, sprintConfig, plan);
           const results = sprintResult.results;
           for (const r of results) {
-            console.log(`  ${r.status === "completed" ? "✅" : "❌"} #${r.issueNumber} — ${r.status}`);
+            console.log(
+              `  ${r.status === "completed" ? "✅" : "❌"} #${r.issueNumber} — ${r.status}`,
+            );
           }
 
           // Step 3: Review
           console.log("\n🔄 Phase 3/4: Review...");
           const review = await runSprintReview(client, sprintConfig, sprintResult);
-          console.log(`  ${review.demoItems.length} demo items, ${review.openItems.length} open items`);
+          console.log(
+            `  ${review.demoItems.length} demo items, ${review.openItems.length} open items`,
+          );
 
           // Step 4: Retro
           console.log("\n🔄 Phase 4/4: Retrospective...");
@@ -261,10 +273,19 @@ function registerWeb(program: Command): void {
     .command("web")
     .description("Launch web dashboard — browser-based sprint monitor on localhost")
     .option("--sprint <number>", "Override sprint number (skip auto-detection)", parseSprintNumber)
-    .option("--port <number>", "Dashboard server port (default: 9100)", (v) => parseInt(v, 10), 9100)
+    .option(
+      "--port <number>",
+      "Dashboard server port (default: 9100)",
+      (v) => parseInt(v, 10),
+      9100,
+    )
     .option("--run", "Start sprint execution immediately")
     .option("--once", "Run only one sprint instead of looping (implies --run)")
-    .option("--max-sprints <number>", "Number of sprints to run (0=infinite, default: from config)", (v) => parseInt(v, 10))
+    .option(
+      "--max-sprints <number>",
+      "Number of sprints to run (0=infinite, default: from config)",
+      (v) => parseInt(v, 10),
+    )
     .option("--log-file <path>", "Log file path (default: sprint-runner.log)", "sprint-runner.log")
     .option("--no-open", "Don't auto-open browser")
     .action(async (opts) => {
@@ -295,7 +316,11 @@ function registerWeb(program: Command): void {
         runner.loadSavedState();
 
         // Load initial issues
-        let currentIssues: { number: number; title: string; status: "planned" | "in-progress" | "done" | "failed" }[] = [];
+        let currentIssues: {
+          number: number;
+          title: string;
+          status: "planned" | "in-progress" | "done" | "failed";
+        }[] = [];
         try {
           const milestoneIssues = await listIssues({
             milestone: `${config.sprint.prefix} ${initialSprint}`,
@@ -313,8 +338,8 @@ function registerWeb(program: Command): void {
           }
 
           currentIssues = milestoneIssues.map((i) => {
-            const labels = ((i.labels ?? []) as Array<string | { name: string }>).map(
-              (l) => (typeof l === "string" ? l : l.name),
+            const labels = ((i.labels ?? []) as Array<string | { name: string }>).map((l) =>
+              typeof l === "string" ? l : l.name,
             );
             let status: "planned" | "in-progress" | "done" | "failed" = "planned";
             if (completedIssues.has(i.number) || i.state === "closed") status = "done";
@@ -334,7 +359,9 @@ function registerWeb(program: Command): void {
               title: i.title,
               status: "planned" as const,
             }));
-          } catch (err) { logger.warn({ err }, "event handler error: sprint:planned"); }
+          } catch (err) {
+            logger.warn({ err }, "event handler error: sprint:planned");
+          }
         });
         eventBus.onTyped("issue:start", ({ issue }) => {
           try {
@@ -342,21 +369,31 @@ function registerWeb(program: Command): void {
             if (existing) {
               existing.status = "in-progress";
             } else {
-              currentIssues.push({ number: issue.number, title: issue.title, status: "in-progress" });
+              currentIssues.push({
+                number: issue.number,
+                title: issue.title,
+                status: "in-progress",
+              });
             }
-          } catch (err) { logger.warn({ err }, "event handler error: issue:start"); }
+          } catch (err) {
+            logger.warn({ err }, "event handler error: issue:start");
+          }
         });
         eventBus.onTyped("issue:done", ({ issueNumber }) => {
           try {
             const issue = currentIssues.find((i) => i.number === issueNumber);
             if (issue) issue.status = "done";
-          } catch (err) { logger.warn({ err }, "event handler error: issue:done"); }
+          } catch (err) {
+            logger.warn({ err }, "event handler error: issue:done");
+          }
         });
         eventBus.onTyped("issue:fail", ({ issueNumber }) => {
           try {
             const issue = currentIssues.find((i) => i.number === issueNumber);
             if (issue) issue.status = "failed";
-          } catch (err) { logger.warn({ err }, "event handler error: issue:fail"); }
+          } catch (err) {
+            logger.warn({ err }, "event handler error: issue:fail");
+          }
         });
 
         // Start/loop functions
@@ -376,7 +413,9 @@ function registerWeb(program: Command): void {
             (sprintNumber) => buildSprintConfig(config, sprintNumber),
             eventBus,
             () => sprintLimit,
-            (r) => { activeRunner = r; },
+            (r) => {
+              activeRunner = r;
+            },
           ).catch((err: unknown) => {
             const msg = err instanceof Error ? err.message : String(err);
             eventBus.emitTyped("sprint:error", { error: msg });
@@ -406,7 +445,7 @@ function registerWeb(program: Command): void {
             currentIssues = milestoneIssues.map((i) => ({
               number: i.number,
               title: i.title,
-              status: i.state === "closed" ? "done" as const : "planned" as const,
+              status: i.state === "closed" ? ("done" as const) : ("planned" as const),
             }));
           } catch {
             currentIssues = [];
@@ -456,35 +495,52 @@ function registerWeb(program: Command): void {
           try {
             dashboardServer.setActiveSprintNumber(sprintNumber);
             currentIssues = [];
-          } catch (err) { logger.warn({ err }, "event handler error: sprint:start"); }
+          } catch (err) {
+            logger.warn({ err }, "event handler error: sprint:start");
+          }
         });
 
         // Auto-open browser
         if (opts.open !== false) {
           const { exec } = await import("node:child_process");
-          const openCmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
+          const openCmd =
+            process.platform === "darwin"
+              ? "open"
+              : process.platform === "win32"
+                ? "start"
+                : "xdg-open";
           exec(`${openCmd} ${url}`);
         }
 
         // Start heartbeat supervisor
         const { HeartbeatSupervisor } = await import("../heartbeat.js");
-        const heartbeat = new HeartbeatSupervisor({
-          enabled: config.heartbeat?.enabled ?? true,
-          intervalMs: config.heartbeat?.interval_ms ?? 30000,
-          staleThresholdMs: config.heartbeat?.stale_threshold_ms ?? 300000,
-          stateDir: path.join(process.cwd(), "docs", "sprints"),
-          sprintSlug: prefixToSlug(config.sprint.prefix),
-        }, eventBus);
+        const heartbeat = new HeartbeatSupervisor(
+          {
+            enabled: config.heartbeat?.enabled ?? true,
+            intervalMs: config.heartbeat?.interval_ms ?? 30000,
+            staleThresholdMs: config.heartbeat?.stale_threshold_ms ?? 300000,
+            stateDir: path.join(process.cwd(), "docs", "sprints"),
+            sprintSlug: prefixToSlug(config.sprint.prefix),
+          },
+          eventBus,
+        );
         heartbeat.start();
 
         // Graceful shutdown
+        let cleaningUp = false;
         const cleanup = async () => {
+          if (cleaningUp) return;
+          cleaningUp = true;
           heartbeat.stop();
           await dashboardServer.stop();
           process.exit(0);
         };
-        process.on("SIGINT", () => { cleanup(); });
-        process.on("SIGTERM", () => { cleanup(); });
+        process.on("SIGINT", () => {
+          void cleanup();
+        });
+        process.on("SIGTERM", () => {
+          void cleanup();
+        });
 
         // Catch unhandled errors
         process.on("unhandledRejection", (reason: unknown) => {
@@ -514,7 +570,10 @@ function registerReview(program: Command): void {
     .action(async (opts) => {
       try {
         const config = loadConfigFromOpts(program.opts().config);
-        logger.info({ sprint: opts.sprint, project: config.project.name }, "Starting sprint review");
+        logger.info(
+          { sprint: opts.sprint, project: config.project.name },
+          "Starting sprint review",
+        );
 
         // Attempt to load sprint log for context
         let logContent: string;
@@ -526,7 +585,9 @@ function registerReview(program: Command): void {
           process.exit(1);
         }
 
-        console.log(`📋 ${config.sprint.prefix} ${opts.sprint} log loaded (${logContent.length} chars)`);
+        console.log(
+          `📋 ${config.sprint.prefix} ${opts.sprint} log loaded (${logContent.length} chars)`,
+        );
         console.log("⚠️  Sprint review requires a SprintResult from execution.");
         console.log("   Use 'full-cycle' for an end-to-end run, or provide sprint state.");
         console.log("   Sprint log preview:\n");
@@ -548,7 +609,10 @@ function registerRetro(program: Command): void {
     .action(async (opts) => {
       try {
         const config = loadConfigFromOpts(program.opts().config);
-        logger.info({ sprint: opts.sprint, project: config.project.name }, "Starting sprint retrospective");
+        logger.info(
+          { sprint: opts.sprint, project: config.project.name },
+          "Starting sprint retrospective",
+        );
 
         // Attempt to load sprint log for context
         let logContent: string;
@@ -560,8 +624,12 @@ function registerRetro(program: Command): void {
           process.exit(1);
         }
 
-        console.log(`📋 ${config.sprint.prefix} ${opts.sprint} log loaded (${logContent.length} chars)`);
-        console.log("⚠️  Sprint retro requires SprintResult and ReviewResult from prior ceremonies.");
+        console.log(
+          `📋 ${config.sprint.prefix} ${opts.sprint} log loaded (${logContent.length} chars)`,
+        );
+        console.log(
+          "⚠️  Sprint retro requires SprintResult and ReviewResult from prior ceremonies.",
+        );
         console.log("   Use 'full-cycle' for an end-to-end run, or provide sprint state.");
         console.log("   Sprint log preview:\n");
         console.log(logContent.slice(0, 500));
@@ -618,7 +686,10 @@ function registerMetrics(program: Command): void {
     .action(async (opts) => {
       try {
         const config = loadConfigFromOpts(program.opts().config);
-        logger.info({ sprint: opts.sprint, project: config.project.name }, "Loading sprint metrics");
+        logger.info(
+          { sprint: opts.sprint, project: config.project.name },
+          "Loading sprint metrics",
+        );
 
         let logContent: string;
         try {
@@ -657,7 +728,9 @@ function registerDriftReport(program: Command): void {
 
         if (changedFiles.length === 0) {
           console.log("⚠️  No changed files provided. Use --changed-files to specify files.");
-          console.log("   Example: sprint-runner drift-report --sprint 1 --changed-files src/a.ts src/b.ts --expected-files src/a.ts");
+          console.log(
+            "   Example: sprint-runner drift-report --sprint 1 --changed-files src/a.ts src/b.ts --expected-files src/a.ts",
+          );
           process.exit(0);
         }
 
@@ -714,7 +787,9 @@ function registerInit(program: Command): void {
           }
         }
 
-        console.log(`\n✅ Initialized! ${result.created.length} files created, ${result.skipped.length} skipped.`);
+        console.log(
+          `\n✅ Initialized! ${result.created.length} files created, ${result.skipped.length} skipped.`,
+        );
 
         if (result.configPath) {
           console.log(`\n📝 Edit ${result.configPath} to configure your project.`);

--- a/src/dashboard/frontend/src/components/SettingsPage.tsx
+++ b/src/dashboard/frontend/src/components/SettingsPage.tsx
@@ -70,7 +70,19 @@ function Toggle({ value, onChange }: { value: boolean; onChange: (v: boolean) =>
   );
 }
 
-function NumInput({ value, onChange, min, max, narrow }: { value: number; onChange: (v: number) => void; min?: number; max?: number; narrow?: boolean }) {
+function NumInput({
+  value,
+  onChange,
+  min,
+  max,
+  narrow,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+  min?: number;
+  max?: number;
+  narrow?: boolean;
+}) {
   return (
     <input
       type="number"
@@ -78,7 +90,12 @@ function NumInput({ value, onChange, min, max, narrow }: { value: number; onChan
       value={value}
       min={min}
       max={max}
-      onChange={(e) => onChange(parseInt(e.target.value, 10) || 0)}
+      onChange={(e) => {
+        const raw = parseInt(e.target.value, 10);
+        if (Number.isNaN(raw)) return;
+        const clamped = Math.max(min ?? -Infinity, Math.min(max ?? Infinity, raw));
+        onChange(clamped);
+      }}
     />
   );
 }
@@ -127,7 +144,15 @@ function Section({
 }
 
 /** Row with label, editable value, and description */
-function Row({ label, desc, children }: { label: string; desc: string; children: React.ReactNode }) {
+function Row({
+  label,
+  desc,
+  children,
+}: {
+  label: string;
+  desc: string;
+  children: React.ReactNode;
+}) {
   return (
     <tr>
       <td>{label}</td>
@@ -144,7 +169,13 @@ interface AgentRole {
   model?: string;
   mode?: string;
   skills: Array<{ name: string; description: string; content: string; dirName: string }>;
-  mcp_servers: Array<{ name: string; type: string; command?: string; url?: string; args?: string[] }>;
+  mcp_servers: Array<{
+    name: string;
+    type: string;
+    command?: string;
+    url?: string;
+    args?: string[];
+  }>;
 }
 
 interface QualityGates {
@@ -276,19 +307,27 @@ function PlaceholderHelp({ roleName }: { roleName: string }) {
   );
 }
 
-const MODEL_OPTIONS: Array<{ value: string; label: string } | { group: string; options: { value: string; label: string }[] }> = [
+const MODEL_OPTIONS: Array<
+  { value: string; label: string } | { group: string; options: { value: string; label: string }[] }
+> = [
   { value: "", label: "Default (inherit from global)" },
-  { group: "High Tier", options: [
-    { value: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
-    { value: "claude-opus-4", label: "Claude Opus 4" },
-    { value: "gpt-4.1", label: "GPT-4.1" },
-    { value: "o4-mini", label: "o4-mini" },
-  ]},
-  { group: "Low Tier", options: [
-    { value: "claude-haiku-3-5", label: "Claude Haiku 3.5" },
-    { value: "gpt-4.1-mini", label: "GPT-4.1 Mini" },
-    { value: "gpt-4.1-nano", label: "GPT-4.1 Nano" },
-  ]},
+  {
+    group: "High Tier",
+    options: [
+      { value: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
+      { value: "claude-opus-4", label: "Claude Opus 4" },
+      { value: "gpt-4.1", label: "GPT-4.1" },
+      { value: "o4-mini", label: "o4-mini" },
+    ],
+  },
+  {
+    group: "Low Tier",
+    options: [
+      { value: "claude-haiku-3-5", label: "Claude Haiku 3.5" },
+      { value: "gpt-4.1-mini", label: "GPT-4.1 Mini" },
+      { value: "gpt-4.1-nano", label: "GPT-4.1 Nano" },
+    ],
+  },
 ];
 
 function RoleEditor({ role, onSave }: { role: AgentRole; onSave: (r: AgentRole) => void }) {
@@ -297,7 +336,7 @@ function RoleEditor({ role, onSave }: { role: AgentRole; onSave: (r: AgentRole) 
   const [model, setModel] = useState(role.model ?? "");
   const [mode, setMode] = useState(role.mode ?? "autonomous");
   const [skills, setSkills] = useState<Record<string, string>>(
-    Object.fromEntries(role.skills.map((s) => [s.dirName, s.content]))
+    Object.fromEntries(role.skills.map((s) => [s.dirName, s.content])),
   );
   const [mcpServers, setMcpServers] = useState(role.mcp_servers);
   const [dirty, setDirty] = useState(false);
@@ -329,7 +368,7 @@ function RoleEditor({ role, onSave }: { role: AgentRole; onSave: (r: AgentRole) 
   };
 
   const updateMcp = (idx: number, patch: Partial<AgentRole["mcp_servers"][0]>) => {
-    setMcpServers((prev) => prev.map((m, i) => i === idx ? { ...m, ...patch } : m));
+    setMcpServers((prev) => prev.map((m, i) => (i === idx ? { ...m, ...patch } : m)));
     setDirty(true);
   };
 
@@ -357,9 +396,21 @@ function RoleEditor({ role, onSave }: { role: AgentRole; onSave: (r: AgentRole) 
         <div className="role-editor-badges">
           {model && <span className="role-badge">🧠 {model}</span>}
           {mode === "manual" && <span className="role-badge">🖐 manual</span>}
-          {role.skills.length > 0 && <span className="role-badge">🛠 {role.skills.length} skills</span>}
+          {role.skills.length > 0 && (
+            <span className="role-badge">🛠 {role.skills.length} skills</span>
+          )}
           {mcpServers.length > 0 && <span className="role-badge">🔌 {mcpServers.length} MCP</span>}
-          {dirty && <button className="btn btn-primary btn-small role-editor-save" onClick={(e) => { e.stopPropagation(); save(); }}>💾 Save</button>}
+          {dirty && (
+            <button
+              className="btn btn-primary btn-small role-editor-save"
+              onClick={(e) => {
+                e.stopPropagation();
+                save();
+              }}
+            >
+              💾 Save
+            </button>
+          )}
         </div>
       </div>
       {open && (
@@ -367,21 +418,41 @@ function RoleEditor({ role, onSave }: { role: AgentRole; onSave: (r: AgentRole) 
           <div className="role-config-row">
             <div className="role-config-field">
               <label>Model</label>
-              <select className="settings-input" value={model} onChange={(e) => { setModel(e.target.value); setDirty(true); }}>
+              <select
+                className="settings-input"
+                value={model}
+                onChange={(e) => {
+                  setModel(e.target.value);
+                  setDirty(true);
+                }}
+              >
                 {MODEL_OPTIONS.map((opt) =>
                   "group" in opt ? (
                     <optgroup key={opt.group} label={opt.group}>
-                      {opt.options.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+                      {opt.options.map((o) => (
+                        <option key={o.value} value={o.value}>
+                          {o.label}
+                        </option>
+                      ))}
                     </optgroup>
                   ) : (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  )
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ),
                 )}
               </select>
             </div>
             <div className="role-config-field">
               <label>Mode</label>
-              <select className="settings-input" value={mode} onChange={(e) => { setMode(e.target.value); setDirty(true); }}>
+              <select
+                className="settings-input"
+                value={mode}
+                onChange={(e) => {
+                  setMode(e.target.value);
+                  setDirty(true);
+                }}
+              >
                 <option value="autonomous">🤖 Autonomous</option>
                 <option value="manual">🖐 Manual</option>
               </select>
@@ -391,16 +462,23 @@ function RoleEditor({ role, onSave }: { role: AgentRole; onSave: (r: AgentRole) 
           {/* Skills — overview with collapsible edit */}
           <div className="role-section-label">🛠 Skills ({role.skills.length})</div>
           {role.skills.length === 0 && (
-            <div className="role-empty-hint">No skills configured. Add files to <code>.aiscrum/roles/{role.name}/skills/</code></div>
+            <div className="role-empty-hint">
+              No skills configured. Add files to <code>.aiscrum/roles/{role.name}/skills/</code>
+            </div>
           )}
           {role.skills.map((s) => (
             <div key={s.dirName} className="role-skill-card">
-              <div className="role-skill-card-header" onClick={() => setSkillEditing(skillEditing === s.dirName ? null : s.dirName)}>
+              <div
+                className="role-skill-card-header"
+                onClick={() => setSkillEditing(skillEditing === s.dirName ? null : s.dirName)}
+              >
                 <div className="role-skill-info">
                   <span className="role-skill-name">🛠 {s.name}</span>
                   <span className="role-skill-desc">{s.description}</span>
                 </div>
-                <button className="btn btn-small">{skillEditing === s.dirName ? "▾ Close" : "✎ Edit"}</button>
+                <button className="btn btn-small">
+                  {skillEditing === s.dirName ? "▾ Close" : "✎ Edit"}
+                </button>
               </div>
               {skillEditing === s.dirName && (
                 <textarea
@@ -413,33 +491,62 @@ function RoleEditor({ role, onSave }: { role: AgentRole; onSave: (r: AgentRole) 
           ))}
 
           {/* MCP Servers — editable */}
-          <div className="role-section-label">🔌 MCP Servers ({mcpServers.length})
-            <button className="btn btn-small" style={{ marginLeft: 8 }} onClick={addMcp}>+ Add</button>
+          <div className="role-section-label">
+            🔌 MCP Servers ({mcpServers.length})
+            <button className="btn btn-small" style={{ marginLeft: 8 }} onClick={addMcp}>
+              + Add
+            </button>
           </div>
           {mcpServers.length === 0 && (
             <div className="role-empty-hint">No MCP servers configured for this agent.</div>
           )}
           {mcpServers.map((m, i) => (
             <div key={i} className="role-mcp-edit-row">
-              <input className="settings-input" placeholder="Name" value={m.name} onChange={(e) => updateMcp(i, { name: e.target.value })} />
-              <select className="settings-input" value={m.type} onChange={(e) => updateMcp(i, { type: e.target.value })}>
+              <input
+                className="settings-input"
+                placeholder="Name"
+                value={m.name}
+                onChange={(e) => updateMcp(i, { name: e.target.value })}
+              />
+              <select
+                className="settings-input"
+                value={m.type}
+                onChange={(e) => updateMcp(i, { type: e.target.value })}
+              >
                 <option value="stdio">stdio</option>
                 <option value="sse">sse</option>
                 <option value="streamable-http">streamable-http</option>
               </select>
               {m.type === "stdio" ? (
-                <input className="settings-input" style={{ flex: 2 }} placeholder="Command (e.g. npx server)" value={m.command ?? ""} onChange={(e) => updateMcp(i, { command: e.target.value })} />
+                <input
+                  className="settings-input"
+                  style={{ flex: 2 }}
+                  placeholder="Command (e.g. npx server)"
+                  value={m.command ?? ""}
+                  onChange={(e) => updateMcp(i, { command: e.target.value })}
+                />
               ) : (
-                <input className="settings-input" style={{ flex: 2 }} placeholder="URL" value={m.url ?? ""} onChange={(e) => updateMcp(i, { url: e.target.value })} />
+                <input
+                  className="settings-input"
+                  style={{ flex: 2 }}
+                  placeholder="URL"
+                  value={m.url ?? ""}
+                  onChange={(e) => updateMcp(i, { url: e.target.value })}
+                />
               )}
-              <button className="btn btn-small btn-danger" onClick={() => removeMcp(i)}>✕</button>
+              <button className="btn btn-small btn-danger" onClick={() => removeMcp(i)}>
+                ✕
+              </button>
             </div>
           ))}
 
           <PlaceholderHelp roleName={role.name} />
           <div>
             <label>Instructions (copilot-instructions.md)</label>
-            <textarea value={instructions} onChange={(e) => update("instructions", e.target.value)} />
+            <textarea
+              value={instructions}
+              onChange={(e) => update("instructions", e.target.value)}
+            />
           </div>
           {Object.entries(prompts).map(([fname, content]) => (
             <div key={fname}>
@@ -473,14 +580,19 @@ export function SettingsPage() {
       fetch("/api/config").then((r) => r.json()),
       fetch("/api/roles").then((r) => r.json()),
       fetch("/api/quality-gates").then((r) => r.json()),
-    ]).then(([cfg, rls, qg]) => {
-      setConfig(cfg as Config);
-      setSavedConfig(JSON.stringify(cfg));
-      const roleList = (rls as AgentRole[]) ?? [];
-      setRoles(roleList);
-      setSavedRoles(JSON.stringify(roleList));
-      if (qg) { setQualityGates(qg as QualityGates); setSavedQg(JSON.stringify(qg)); }
-    }).catch((e) => setError(String(e)));
+    ])
+      .then(([cfg, rls, qg]) => {
+        setConfig(cfg as Config);
+        setSavedConfig(JSON.stringify(cfg));
+        const roleList = (rls as AgentRole[]) ?? [];
+        setRoles(roleList);
+        setSavedRoles(JSON.stringify(roleList));
+        if (qg) {
+          setQualityGates(qg as QualityGates);
+          setSavedQg(JSON.stringify(qg));
+        }
+      })
+      .catch((e) => setError(String(e)));
   }, []);
 
   const isDirty = config ? JSON.stringify(config) !== savedConfig : false;
@@ -539,59 +651,88 @@ export function SettingsPage() {
   const reset = useCallback(() => {
     if (savedConfig) setConfig(JSON.parse(savedConfig));
     if (savedQg) setQualityGates(JSON.parse(savedQg));
-    if (savedRoles) { setRoles(JSON.parse(savedRoles)); setResetKey((k) => k + 1); }
+    if (savedRoles) {
+      setRoles(JSON.parse(savedRoles));
+      setResetKey((k) => k + 1);
+    }
   }, [savedConfig, savedQg, savedRoles]);
 
-  const saveRole = useCallback(async (role: AgentRole) => {
-    try {
-      const skillsMap: Record<string, string> = {};
-      for (const s of role.skills) skillsMap[s.dirName] = s.content;
-      const res = await fetch("/api/roles", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: role.name,
-          instructions: role.instructions,
-          prompts: role.prompts,
-          model: role.model,
-          mode: role.mode,
-          skills: skillsMap,
-          mcp_servers: role.mcp_servers,
-        }),
-      });
-      if (res.ok) {
-        const updatedRoles = roles.map((r) => r.name === role.name ? role : r);
-        setRoles(updatedRoles);
-        setSavedRoles(JSON.stringify(updatedRoles));
-        showToast(`✅ ${role.name} saved`, "success");
-      } else {
-        showToast(`❌ Failed to save ${role.name}`, "error");
+  const saveRole = useCallback(
+    async (role: AgentRole) => {
+      try {
+        const skillsMap: Record<string, string> = {};
+        for (const s of role.skills) skillsMap[s.dirName] = s.content;
+        const res = await fetch("/api/roles", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: role.name,
+            instructions: role.instructions,
+            prompts: role.prompts,
+            model: role.model,
+            mode: role.mode,
+            skills: skillsMap,
+            mcp_servers: role.mcp_servers,
+          }),
+        });
+        if (res.ok) {
+          const updatedRoles = roles.map((r) => (r.name === role.name ? role : r));
+          setRoles(updatedRoles);
+          setSavedRoles(JSON.stringify(updatedRoles));
+          showToast(`✅ ${role.name} saved`, "success");
+        } else {
+          showToast(`❌ Failed to save ${role.name}`, "error");
+        }
+      } catch (e) {
+        showToast(`❌ ${String(e)}`, "error");
       }
-    } catch (e) {
-      showToast(`❌ ${String(e)}`, "error");
-    }
-  }, [showToast]);
+    },
+    [showToast],
+  );
 
   // Updater helpers
   const up = useCallback(<K extends keyof Config>(section: K, patch: Partial<Config[K]>) => {
-    setConfig((prev) => prev ? { ...prev, [section]: { ...prev[section], ...patch } } : prev);
+    setConfig((prev) => (prev ? { ...prev, [section]: { ...prev[section], ...patch } } : prev));
   }, []);
 
-  const upQg = useCallback((patch: Partial<Config["quality_gates"]>) => up("quality_gates", patch), [up]);
+  const upQg = useCallback(
+    (patch: Partial<Config["quality_gates"]>) => up("quality_gates", patch),
+    [up],
+  );
   const upSprint = useCallback((patch: Partial<Config["sprint"]>) => up("sprint", patch), [up]);
   const upCopilot = useCallback((patch: Partial<Config["copilot"]>) => up("copilot", patch), [up]);
   const upGit = useCallback((patch: Partial<Config["git"]>) => up("git", patch), [up]);
   const upNotif = useCallback((patch: Partial<Config["escalation"]["notifications"]>) => {
-    setConfig((prev) => prev ? { ...prev, escalation: { ...prev.escalation, notifications: { ...prev.escalation.notifications, ...patch } } } : prev);
+    setConfig((prev) =>
+      prev
+        ? {
+            ...prev,
+            escalation: {
+              ...prev.escalation,
+              notifications: { ...prev.escalation.notifications, ...patch },
+            },
+          }
+        : prev,
+    );
   }, []);
-  const upQgCheck = useCallback((check: keyof QualityGates["checks"], patch: Partial<{ enabled: boolean; command: string | string[] }>) => {
-    setQualityGates((prev) => prev ? { ...prev, checks: { ...prev.checks, [check]: { ...prev.checks[check], ...patch } } } : prev);
-  }, []);
+  const upQgCheck = useCallback(
+    (
+      check: keyof QualityGates["checks"],
+      patch: Partial<{ enabled: boolean; command: string | string[] }>,
+    ) => {
+      setQualityGates((prev) =>
+        prev
+          ? { ...prev, checks: { ...prev.checks, [check]: { ...prev.checks[check], ...patch } } }
+          : prev,
+      );
+    },
+    [],
+  );
   const upQgLimits = useCallback((patch: Partial<QualityGates["limits"]>) => {
-    setQualityGates((prev) => prev ? { ...prev, limits: { ...prev.limits, ...patch } } : prev);
+    setQualityGates((prev) => (prev ? { ...prev, limits: { ...prev.limits, ...patch } } : prev));
   }, []);
   const upQgReview = useCallback((patch: Partial<QualityGates["review"]>) => {
-    setQualityGates((prev) => prev ? { ...prev, review: { ...prev.review, ...patch } } : prev);
+    setQualityGates((prev) => (prev ? { ...prev, review: { ...prev.review, ...patch } } : prev));
   }, []);
 
   if (error) return <div className="settings-loading">❌ Failed to load config: {error}</div>;
@@ -602,7 +743,11 @@ export function SettingsPage() {
       <h1>⚙️ Settings</h1>
 
       <div className="settings-actions">
-        <button className="btn btn-primary btn-small" onClick={save} disabled={!isDirty && !qgDirty}>
+        <button
+          className="btn btn-primary btn-small"
+          onClick={save}
+          disabled={!isDirty && !qgDirty}
+        >
           💾 Save
         </button>
         <button className="btn btn-small" onClick={reset} disabled={!isDirty && !qgDirty}>
@@ -618,7 +763,10 @@ export function SettingsPage() {
               <TextInput value={config.project.name} onChange={(v) => up("project", { name: v })} />
             </Row>
             <Row label="Base Branch" desc="Main branch to merge PRs into (e.g. main, develop)">
-              <TextInput value={config.project.base_branch} onChange={(v) => up("project", { base_branch: v })} />
+              <TextInput
+                value={config.project.base_branch}
+                onChange={(v) => up("project", { base_branch: v })}
+              />
             </Row>
           </tbody>
         </table>
@@ -628,24 +776,51 @@ export function SettingsPage() {
         <table className="settings-table">
           <tbody>
             <Row label="Executable" desc="Path to the Copilot CLI binary">
-              <TextInput value={config.copilot.executable} onChange={(v) => upCopilot({ executable: v })} />
+              <TextInput
+                value={config.copilot.executable}
+                onChange={(v) => upCopilot({ executable: v })}
+              />
             </Row>
-            <Row label="Max Parallel Sessions" desc="How many ACP sessions can run simultaneously (1-20)">
-              <NumInput value={config.copilot.max_parallel_sessions} onChange={(v) => upCopilot({ max_parallel_sessions: v })} min={1} max={20} narrow />
+            <Row
+              label="Max Parallel Sessions"
+              desc="How many ACP sessions can run simultaneously (1-20)"
+            >
+              <NumInput
+                value={config.copilot.max_parallel_sessions}
+                onChange={(v) => upCopilot({ max_parallel_sessions: v })}
+                min={1}
+                max={20}
+                narrow
+              />
             </Row>
             <Row label="Session Timeout" desc="Max time (seconds) before an idle session is killed">
-              <NumInput value={Math.round(config.copilot.session_timeout_ms / 1000)} onChange={(v) => upCopilot({ session_timeout_ms: v * 1000 })} min={0} narrow />
+              <NumInput
+                value={Math.round(config.copilot.session_timeout_ms / 1000)}
+                onChange={(v) => upCopilot({ session_timeout_ms: v * 1000 })}
+                min={0}
+                narrow
+              />
             </Row>
-            <Row label="Auto-approve Tools" desc="Automatically approve tool calls without human confirmation">
-              <Toggle value={config.copilot.auto_approve_tools} onChange={(v) => upCopilot({ auto_approve_tools: v })} />
+            <Row
+              label="Auto-approve Tools"
+              desc="Automatically approve tool calls without human confirmation"
+            >
+              <Toggle
+                value={config.copilot.auto_approve_tools}
+                onChange={(v) => upCopilot({ auto_approve_tools: v })}
+              />
             </Row>
           </tbody>
         </table>
         {config.copilot.instructions.length > 0 && (
           <div style={{ marginTop: 8 }}>
-            <span style={{ fontSize: 12, color: "var(--text-dim)" }}>Instructions ({config.copilot.instructions.length})</span>
+            <span style={{ fontSize: 12, color: "var(--text-dim)" }}>
+              Instructions ({config.copilot.instructions.length})
+            </span>
             <ul className="settings-list">
-              {config.copilot.instructions.map((inst, i) => <li key={i}>{inst}</li>)}
+              {config.copilot.instructions.map((inst, i) => (
+                <li key={i}>{inst}</li>
+              ))}
             </ul>
           </div>
         )}
@@ -654,38 +829,92 @@ export function SettingsPage() {
       <Section icon="🏃" title="Sprint">
         <table className="settings-table">
           <tbody>
-            <Row label="Prefix" desc="Milestone title prefix for sprint naming (e.g. 'Sprint' → 'Sprint 1')">
+            <Row
+              label="Prefix"
+              desc="Milestone title prefix for sprint naming (e.g. 'Sprint' → 'Sprint 1')"
+            >
               <TextInput value={config.sprint.prefix} onChange={(v) => upSprint({ prefix: v })} />
             </Row>
             <Row label="Min Issues" desc="Minimum issues to plan per sprint (0 = no minimum)">
-              <NumInput value={config.sprint.min_issues} onChange={(v) => upSprint({ min_issues: v })} min={0} narrow />
+              <NumInput
+                value={config.sprint.min_issues}
+                onChange={(v) => upSprint({ min_issues: v })}
+                min={0}
+                narrow
+              />
             </Row>
             <Row label="Max Issues" desc="Maximum issues to plan per sprint">
-              <NumInput value={config.sprint.max_issues} onChange={(v) => upSprint({ max_issues: v })} min={1} narrow />
+              <NumInput
+                value={config.sprint.max_issues}
+                onChange={(v) => upSprint({ max_issues: v })}
+                min={1}
+                narrow
+              />
             </Row>
             <Row label="Max Issues Created" desc="Max issues the agent can auto-create per sprint">
-              <NumInput value={config.sprint.max_issues_created_per_sprint} onChange={(v) => upSprint({ max_issues_created_per_sprint: v })} min={1} narrow />
+              <NumInput
+                value={config.sprint.max_issues_created_per_sprint}
+                onChange={(v) => upSprint({ max_issues_created_per_sprint: v })}
+                min={1}
+                narrow
+              />
             </Row>
             <Row label="Max Sprints" desc="Number of sprints to run in a loop (0 = unlimited)">
-              <NumInput value={config.sprint.max_sprints} onChange={(v) => upSprint({ max_sprints: v })} min={0} narrow />
+              <NumInput
+                value={config.sprint.max_sprints}
+                onChange={(v) => upSprint({ max_sprints: v })}
+                min={0}
+                narrow
+              />
             </Row>
             <Row label="Max Drift Incidents" desc="How many unplanned issues before escalation">
-              <NumInput value={config.sprint.max_drift_incidents} onChange={(v) => upSprint({ max_drift_incidents: v })} min={0} narrow />
+              <NumInput
+                value={config.sprint.max_drift_incidents}
+                onChange={(v) => upSprint({ max_drift_incidents: v })}
+                min={0}
+                narrow
+              />
             </Row>
             <Row label="Max Retries" desc="Retry attempts for a failed issue before giving up">
-              <NumInput value={config.sprint.max_retries} onChange={(v) => upSprint({ max_retries: v })} min={0} narrow />
+              <NumInput
+                value={config.sprint.max_retries}
+                onChange={(v) => upSprint({ max_retries: v })}
+                min={0}
+                narrow
+              />
             </Row>
-            <Row label="Challenger" desc="Run adversarial review agent to challenge sprint decisions">
-              <Toggle value={config.sprint.enable_challenger} onChange={(v) => upSprint({ enable_challenger: v })} />
+            <Row
+              label="Challenger"
+              desc="Run adversarial review agent to challenge sprint decisions"
+            >
+              <Toggle
+                value={config.sprint.enable_challenger}
+                onChange={(v) => upSprint({ enable_challenger: v })}
+              />
             </Row>
             <Row label="TDD" desc="Require test-driven development workflow for all issues">
-              <Toggle value={config.sprint.enable_tdd} onChange={(v) => upSprint({ enable_tdd: v })} />
+              <Toggle
+                value={config.sprint.enable_tdd}
+                onChange={(v) => upSprint({ enable_tdd: v })}
+              />
             </Row>
-            <Row label="Sequential Execution" desc="Run developer agents one at a time to avoid merge conflicts">
-              <Toggle value={config.sprint.sequential_execution} onChange={(v) => upSprint({ sequential_execution: v })} />
+            <Row
+              label="Sequential Execution"
+              desc="Run developer agents one at a time to avoid merge conflicts"
+            >
+              <Toggle
+                value={config.sprint.sequential_execution}
+                onChange={(v) => upSprint({ sequential_execution: v })}
+              />
             </Row>
-            <Row label="Auto-revert Drift" desc="Automatically revert changes that cause sprint scope drift">
-              <Toggle value={config.sprint.auto_revert_drift} onChange={(v) => upSprint({ auto_revert_drift: v })} />
+            <Row
+              label="Auto-revert Drift"
+              desc="Automatically revert changes that cause sprint scope drift"
+            >
+              <Toggle
+                value={config.sprint.auto_revert_drift}
+                onChange={(v) => upSprint({ auto_revert_drift: v })}
+              />
             </Row>
           </tbody>
         </table>
@@ -697,8 +926,13 @@ export function SettingsPage() {
             {(["tests", "lint", "types", "build"] as const).map((check) => (
               <div key={check} className="qg-card">
                 <div className="qg-card-header">
-                  <Toggle value={qualityGates.checks[check].enabled} onChange={(v) => upQgCheck(check, { enabled: v })} />
-                  <span className="qg-card-title">{check.charAt(0).toUpperCase() + check.slice(1)}</span>
+                  <Toggle
+                    value={qualityGates.checks[check].enabled}
+                    onChange={(v) => upQgCheck(check, { enabled: v })}
+                  />
+                  <span className="qg-card-title">
+                    {check.charAt(0).toUpperCase() + check.slice(1)}
+                  </span>
                 </div>
                 <label>Command</label>
                 <textarea
@@ -713,49 +947,93 @@ export function SettingsPage() {
               <div className="qg-card-header">
                 <span className="qg-card-title">Max Diff Lines</span>
               </div>
-              <NumInput value={qualityGates.limits.max_diff_lines} onChange={(v) => upQgLimits({ max_diff_lines: v })} min={1} narrow />
-              <div style={{ fontSize: 12, color: "var(--text-dim)", marginTop: 4 }}>Lines changed per PR before extra review</div>
+              <NumInput
+                value={qualityGates.limits.max_diff_lines}
+                onChange={(v) => upQgLimits({ max_diff_lines: v })}
+                min={1}
+                narrow
+              />
+              <div style={{ fontSize: 12, color: "var(--text-dim)", marginTop: 4 }}>
+                Lines changed per PR before extra review
+              </div>
             </div>
             <div className="qg-card">
               <div className="qg-card-header">
-                <Toggle value={qualityGates.review.require_challenger} onChange={(v) => upQgReview({ require_challenger: v })} />
+                <Toggle
+                  value={qualityGates.review.require_challenger}
+                  onChange={(v) => upQgReview({ require_challenger: v })}
+                />
                 <span className="qg-card-title">Challenger Review</span>
               </div>
-              <div style={{ fontSize: 12, color: "var(--text-dim)" }}>Adversarial review agent challenges every PR</div>
+              <div style={{ fontSize: 12, color: "var(--text-dim)" }}>
+                Adversarial review agent challenges every PR
+              </div>
             </div>
           </div>
         ) : (
           <table className="settings-table">
             <tbody>
               <Row label="Tests" desc="Require tests to pass before merging">
-                <Toggle value={config.quality_gates.require_tests} onChange={(v) => upQg({ require_tests: v })} />
+                <Toggle
+                  value={config.quality_gates.require_tests}
+                  onChange={(v) => upQg({ require_tests: v })}
+                />
               </Row>
               <Row label="Test Command" desc="Command to run tests">
-                <TextInput value={cmdStr(config.quality_gates.test_command)} onChange={(v) => upQg({ test_command: v })} />
+                <TextInput
+                  value={cmdStr(config.quality_gates.test_command)}
+                  onChange={(v) => upQg({ test_command: v })}
+                />
               </Row>
               <Row label="Lint" desc="Require linter to pass before merging">
-                <Toggle value={config.quality_gates.require_lint} onChange={(v) => upQg({ require_lint: v })} />
+                <Toggle
+                  value={config.quality_gates.require_lint}
+                  onChange={(v) => upQg({ require_lint: v })}
+                />
               </Row>
               <Row label="Lint Command" desc="Command to run linter">
-                <TextInput value={cmdStr(config.quality_gates.lint_command)} onChange={(v) => upQg({ lint_command: v })} />
+                <TextInput
+                  value={cmdStr(config.quality_gates.lint_command)}
+                  onChange={(v) => upQg({ lint_command: v })}
+                />
               </Row>
               <Row label="Type Check" desc="Require type checking to pass before merging">
-                <Toggle value={config.quality_gates.require_types} onChange={(v) => upQg({ require_types: v })} />
+                <Toggle
+                  value={config.quality_gates.require_types}
+                  onChange={(v) => upQg({ require_types: v })}
+                />
               </Row>
               <Row label="Type Command" desc="Command to run type checker">
-                <TextInput value={cmdStr(config.quality_gates.typecheck_command)} onChange={(v) => upQg({ typecheck_command: v })} />
+                <TextInput
+                  value={cmdStr(config.quality_gates.typecheck_command)}
+                  onChange={(v) => upQg({ typecheck_command: v })}
+                />
               </Row>
               <Row label="Build" desc="Require build to succeed before merging">
-                <Toggle value={config.quality_gates.require_build} onChange={(v) => upQg({ require_build: v })} />
+                <Toggle
+                  value={config.quality_gates.require_build}
+                  onChange={(v) => upQg({ require_build: v })}
+                />
               </Row>
               <Row label="Build Command" desc="Command to build the project">
-                <TextInput value={cmdStr(config.quality_gates.build_command)} onChange={(v) => upQg({ build_command: v })} />
+                <TextInput
+                  value={cmdStr(config.quality_gates.build_command)}
+                  onChange={(v) => upQg({ build_command: v })}
+                />
               </Row>
               <Row label="Max Diff Lines" desc="Maximum lines changed per PR">
-                <NumInput value={config.quality_gates.max_diff_lines} onChange={(v) => upQg({ max_diff_lines: v })} min={1} narrow />
+                <NumInput
+                  value={config.quality_gates.max_diff_lines}
+                  onChange={(v) => upQg({ max_diff_lines: v })}
+                  min={1}
+                  narrow
+                />
               </Row>
               <Row label="Challenger" desc="Require adversarial code review on every PR">
-                <Toggle value={config.quality_gates.require_challenger} onChange={(v) => upQg({ require_challenger: v })} />
+                <Toggle
+                  value={config.quality_gates.require_challenger}
+                  onChange={(v) => upQg({ require_challenger: v })}
+                />
               </Row>
             </tbody>
           </table>
@@ -769,13 +1047,27 @@ export function SettingsPage() {
               <div className="settings-mcp-name">{srv.name}</div>
               <div className="settings-mcp-detail">
                 Type: <code>{srv.type}</code>
-                {srv.command && <> · Command: <code>{srv.command} {srv.args?.join(" ")}</code></>}
-                {srv.url && <> · URL: <code>{srv.url}</code></>}
+                {srv.command && (
+                  <>
+                    {" "}
+                    · Command:{" "}
+                    <code>
+                      {srv.command} {srv.args?.join(" ")}
+                    </code>
+                  </>
+                )}
+                {srv.url && (
+                  <>
+                    {" "}
+                    · URL: <code>{srv.url}</code>
+                  </>
+                )}
               </div>
             </div>
           ))}
           <div style={{ fontSize: 12, color: "var(--text-dim)", marginTop: 8 }}>
-            MCP servers connect external tools to Copilot sessions. Edit in <code>.aiscrum/config.yaml</code>.
+            MCP servers connect external tools to Copilot sessions. Edit in{" "}
+            <code>.aiscrum/config.yaml</code>.
           </div>
         </Section>
       )}
@@ -787,19 +1079,36 @@ export function SettingsPage() {
               <div className="settings-mcp-name">{phase}</div>
               <table className="settings-table">
                 <tbody>
-                  {cfg.model && <tr><td>Model</td><td><code>{cfg.model}</code></td><td>AI model for this phase</td></tr>}
+                  {cfg.model && (
+                    <tr>
+                      <td>Model</td>
+                      <td>
+                        <code>{cfg.model}</code>
+                      </td>
+                      <td>AI model for this phase</td>
+                    </tr>
+                  )}
                   {cfg.mcp_servers && cfg.mcp_servers.length > 0 && (
-                    <tr><td>MCP Servers</td><td>{cfg.mcp_servers.map((s) => s.name).join(", ")}</td><td>Additional servers for this phase</td></tr>
+                    <tr>
+                      <td>MCP Servers</td>
+                      <td>{cfg.mcp_servers.map((s) => s.name).join(", ")}</td>
+                      <td>Additional servers for this phase</td>
+                    </tr>
                   )}
                   {cfg.instructions && cfg.instructions.length > 0 && (
-                    <tr><td>Instructions</td><td>{cfg.instructions.length} custom</td><td>Extra instructions appended for this phase</td></tr>
+                    <tr>
+                      <td>Instructions</td>
+                      <td>{cfg.instructions.length} custom</td>
+                      <td>Extra instructions appended for this phase</td>
+                    </tr>
                   )}
                 </tbody>
               </table>
             </div>
           ))}
           <div style={{ fontSize: 12, color: "var(--text-dim)", marginTop: 8 }}>
-            Override model, MCP servers, or instructions per sprint phase. Edit in <code>.aiscrum/config.yaml</code>.
+            Override model, MCP servers, or instructions per sprint phase. Edit in{" "}
+            <code>.aiscrum/config.yaml</code>.
           </div>
         </Section>
       )}
@@ -808,13 +1117,22 @@ export function SettingsPage() {
         <table className="settings-table">
           <tbody>
             <Row label="ntfy" desc="Send push notifications via ntfy.sh when events occur">
-              <Toggle value={config.escalation.notifications.ntfy} onChange={(v) => upNotif({ ntfy: v })} />
+              <Toggle
+                value={config.escalation.notifications.ntfy}
+                onChange={(v) => upNotif({ ntfy: v })}
+              />
             </Row>
             <Row label="Topic" desc="ntfy topic name for push notifications">
-              <TextInput value={config.escalation.notifications.ntfy_topic} onChange={(v) => upNotif({ ntfy_topic: v })} />
+              <TextInput
+                value={config.escalation.notifications.ntfy_topic}
+                onChange={(v) => upNotif({ ntfy_topic: v })}
+              />
             </Row>
             <Row label="Server" desc="ntfy server URL (default: https://ntfy.sh)">
-              <TextInput value={config.escalation.notifications.ntfy_server_url} onChange={(v) => upNotif({ ntfy_server_url: v })} />
+              <TextInput
+                value={config.escalation.notifications.ntfy_server_url}
+                onChange={(v) => upNotif({ ntfy_server_url: v })}
+              />
             </Row>
           </tbody>
         </table>
@@ -823,20 +1141,38 @@ export function SettingsPage() {
       <Section icon="🔀" title="Git">
         <table className="settings-table">
           <tbody>
-            <Row label="Worktree Base" desc="Directory where git worktrees are created for parallel work">
-              <TextInput value={config.git.worktree_base} onChange={(v) => upGit({ worktree_base: v })} />
+            <Row
+              label="Worktree Base"
+              desc="Directory where git worktrees are created for parallel work"
+            >
+              <TextInput
+                value={config.git.worktree_base}
+                onChange={(v) => upGit({ worktree_base: v })}
+              />
             </Row>
-            <Row label="Branch Pattern" desc="Pattern for feature branches. Placeholders: {prefix}, {sprint}, {issue}">
-              <TextInput value={config.git.branch_pattern} onChange={(v) => upGit({ branch_pattern: v })} />
+            <Row
+              label="Branch Pattern"
+              desc="Pattern for feature branches. Placeholders: {prefix}, {sprint}, {issue}"
+            >
+              <TextInput
+                value={config.git.branch_pattern}
+                onChange={(v) => upGit({ branch_pattern: v })}
+              />
             </Row>
             <Row label="Auto Merge" desc="Automatically merge PRs when all quality gates pass">
               <Toggle value={config.git.auto_merge} onChange={(v) => upGit({ auto_merge: v })} />
             </Row>
             <Row label="Squash Merge" desc="Use squash merge instead of regular merge commits">
-              <Toggle value={config.git.squash_merge} onChange={(v) => upGit({ squash_merge: v })} />
+              <Toggle
+                value={config.git.squash_merge}
+                onChange={(v) => upGit({ squash_merge: v })}
+              />
             </Row>
             <Row label="Delete Branch" desc="Delete feature branch after successful merge">
-              <Toggle value={config.git.delete_branch_after_merge} onChange={(v) => upGit({ delete_branch_after_merge: v })} />
+              <Toggle
+                value={config.git.delete_branch_after_merge}
+                onChange={(v) => upGit({ delete_branch_after_merge: v })}
+              />
             </Row>
           </tbody>
         </table>
@@ -845,7 +1181,8 @@ export function SettingsPage() {
       {roles.length > 0 && (
         <Section icon="🤖" title={`Agent Roles (${roles.length})`}>
           <div style={{ fontSize: 13, color: "var(--text-dim)", marginBottom: 12 }}>
-            Each agent role has system instructions and prompt templates. Edit the content below and save per role.
+            Each agent role has system instructions and prompt templates. Edit the content below and
+            save per role.
           </div>
           {roles.map((role) => (
             <RoleEditor key={`${role.name}-${resetKey}`} role={role} onSave={saveRole} />

--- a/src/enforcement/challenger.ts
+++ b/src/enforcement/challenger.ts
@@ -63,7 +63,7 @@ export async function runChallengerReview(
     await client.setModel(sessionId, sessionConfig.model);
   }
 
-  const result = await client.sendPrompt(sessionId, prompt);
+  const result = await client.sendPrompt(sessionId, prompt, config.sessionTimeoutMs);
   await client.endSession(sessionId);
 
   const response = result.response.trim();

--- a/src/enforcement/escalation.ts
+++ b/src/enforcement/escalation.ts
@@ -12,11 +12,13 @@ const MAX_HTTP_STRING_LENGTH = 500;
 
 /** Sanitize a string for safe use in HTTP headers/body via curl. */
 export function sanitizeForHttp(str: string): string {
-  return str
-    .replace(/[\r\n]+/g, " ")
-    // eslint-disable-next-line no-control-regex
-    .replace(/[\x00-\x1f\x7f]/g, "")
-    .slice(0, MAX_HTTP_STRING_LENGTH);
+  return (
+    str
+      .replace(/[\r\n]+/g, " ")
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\x00-\x1f\x7f]/g, "")
+      .slice(0, MAX_HTTP_STRING_LENGTH)
+  );
 }
 
 export interface EscalationConfig {
@@ -79,7 +81,7 @@ export async function escalateToStakeholder(
       state,
       config.maxIssuesCreatedPerSprint ?? DEFAULT_MAX_ISSUES,
     );
-    
+
     if (issue) {
       log.info({ number: issue.number }, "escalation issue created");
     } else {
@@ -137,6 +139,10 @@ export async function escalateToStakeholder(
         "-s",
         "-o",
         "/dev/null",
+        "--max-time",
+        "10",
+        "--connect-timeout",
+        "5",
         "-d",
         `[${event.level}] ${sanitizeForHttp(event.reason)}: ${sanitizeForHttp(event.detail)}`,
         "-H",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,11 +28,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const pkg = JSON.parse(readFileSync(resolve(__dirname, "..", "package.json"), "utf-8"));
 
-// Graceful shutdown on SIGINT (Ctrl+C)
-process.on("SIGINT", () => {
-  console.log("\n🛑 Received SIGINT, shutting down...");
-  process.exit(130);
-});
+// Global SIGINT handler removed — individual commands register their own cleanup handlers
 
 const program = new Command();
 


### PR DESCRIPTION
## Changes

### Blocking fixes
1. **Sprint planning max_issues enforcement** — Truncates LLM response to `config.maxIssuesPerSprint` if it returns too many issues
2. **SIGINT handler conflict** — Removed global handler from index.ts that was calling `process.exit(130)` before commands.ts cleanup could run
3. **Signal handler race** — Added re-entry guard + `void` for async cleanup to prevent double-cleanup on rapid Ctrl+C

### Non-blocking fixes
4. **ntfy curl timeout** — Added `--max-time 10 --connect-timeout 5` to prevent indefinite hang
5. **Challenger session timeout** — Now passes `config.sessionTimeoutMs` to `sendPrompt`
6. **Retro config validation** — Validates YAML after ACP applies config improvements; reverts via `git checkout` on corruption
7. **NumInput clamping** — Values clamped to min/max bounds, NaN input ignored

## Verification
- 585 tests pass
- Type check clean
- Build succeeds (backend + frontend)