### PR TITLE
feat: typed agent schemas — replace string matching with Zod validation

### DIFF
--- a/src/ceremonies/execution.ts
+++ b/src/ceremonies/execution.ts
@@ -16,18 +16,16 @@ import type {
 import { createWorktree, removeWorktree } from "../git/worktree.js";
 import { runQualityGate } from "../enforcement/quality-gate.js";
 import { runCodeReview } from "../enforcement/code-review.js";
-import {
-  formatHuddleComment,
-  formatSprintLogEntry,
-} from "../documentation/huddle.js";
+import { formatHuddleComment, formatSprintLogEntry } from "../documentation/huddle.js";
 import type { ZeroChangeDiagnostic, HuddleEntryWithDiag } from "../documentation/huddle.js";
 import { appendToSprintLog } from "../documentation/sprint-log.js";
 import { addComment } from "../github/issues.js";
 import { setLabel } from "../github/labels.js";
 import { getChangedFiles } from "../git/diff-analysis.js";
 import { getPRStats } from "../git/merge.js";
-import { substitutePrompt, extractJson, sanitizePromptInput } from "./helpers.js";
+import { substitutePrompt, extractJson, sanitizePromptInput, parseWithRetry } from "./helpers.js";
 import { logger, appendErrorLog } from "../logger.js";
+import { AcceptanceCriteriaSchema } from "../types/schemas.js";
 import type { SprintEventBus } from "../events.js";
 import { buildBranch, buildQualityGateConfig } from "./quality-retry.js";
 import { sessionController } from "../dashboard/session-control.js";
@@ -79,7 +77,14 @@ async function planPhase(ctx: ExecutionContext): Promise<string> {
     log.info("planner session started in Plan mode");
     progress("planning implementation");
 
-    const planTemplatePath = path.join(config.projectPath, ".aiscrum", "roles", "planner", "prompts", "item-planner.md");
+    const planTemplatePath = path.join(
+      config.projectPath,
+      ".aiscrum",
+      "roles",
+      "planner",
+      "prompts",
+      "item-planner.md",
+    );
     const planTemplate = await fs.readFile(planTemplatePath, "utf-8");
     let planPrompt = substitutePrompt(planTemplate, promptVars);
 
@@ -91,7 +96,10 @@ async function planPhase(ctx: ExecutionContext): Promise<string> {
     implementationPlan = planResult.response;
 
     try {
-      const planJson = extractJson<{ summary: string; steps: Array<{ file?: string; action?: string }> }>(implementationPlan);
+      const planJson = extractJson<{
+        summary: string;
+        steps: Array<{ file?: string; action?: string }>;
+      }>(implementationPlan);
       log.info(
         { summary: planJson.summary, stepCount: planJson.steps?.length ?? 0 },
         "implementation plan created",
@@ -109,11 +117,17 @@ async function planPhase(ctx: ExecutionContext): Promise<string> {
             existing.add(f);
           }
           issue.expectedFiles = [...existing];
-          log.info({ expectedFiles: issue.expectedFiles }, "expectedFiles updated from implementation plan");
+          log.info(
+            { expectedFiles: issue.expectedFiles },
+            "expectedFiles updated from implementation plan",
+          );
         }
       }
     } catch {
-      log.warn({ issue: issue.number, responseLength: implementationPlan.length }, "implementation plan JSON extraction failed — proceeding with unstructured plan");
+      log.warn(
+        { issue: issue.number, responseLength: implementationPlan.length },
+        "implementation plan JSON extraction failed — proceeding with unstructured plan",
+      );
     }
 
     await addComment(
@@ -161,7 +175,14 @@ async function tddPhase(ctx: ExecutionContext, implementationPlan: string): Prom
     log.info("test-engineer session started");
     progress("writing tests (TDD)");
 
-    const tddTemplatePath = path.join(config.projectPath, ".aiscrum", "roles", "test-engineer", "prompts", "tdd.md");
+    const tddTemplatePath = path.join(
+      config.projectPath,
+      ".aiscrum",
+      "roles",
+      "test-engineer",
+      "prompts",
+      "tdd.md",
+    );
     const tddTemplate = await fs.readFile(tddTemplatePath, "utf-8");
     let tddPrompt = substitutePrompt(tddTemplate, promptVars);
 
@@ -193,7 +214,10 @@ interface ImplementResult {
 }
 
 /** Create ACP session in Agent mode, implement the plan. Session stays open for QG retries. */
-async function implementPhase(ctx: ExecutionContext, implementationPlan: string): Promise<ImplementResult> {
+async function implementPhase(
+  ctx: ExecutionContext,
+  implementationPlan: string,
+): Promise<ImplementResult> {
   const { client, config, issue, eventBus, log, worktreePath, progress } = ctx;
   const workerConfig = await resolveSessionConfig(config, "worker");
   const promptVars = buildPromptVars(ctx);
@@ -218,7 +242,14 @@ async function implementPhase(ctx: ExecutionContext, implementationPlan: string)
     log.info("developer session started in Agent mode");
     progress("implementing");
 
-    const workerTemplatePath = path.join(config.projectPath, ".aiscrum", "roles", "general", "prompts", "worker.md");
+    const workerTemplatePath = path.join(
+      config.projectPath,
+      ".aiscrum",
+      "roles",
+      "general",
+      "prompts",
+      "worker.md",
+    );
     const workerTemplate = await fs.readFile(workerTemplatePath, "utf-8");
     let workerPrompt = substitutePrompt(workerTemplate, promptVars);
 
@@ -238,7 +269,10 @@ async function implementPhase(ctx: ExecutionContext, implementationPlan: string)
       for (const msg of messages) {
         if (msg.type === "user-message" && msg.content) {
           log.info({ sessionId }, "sending queued user message to session");
-          eventBus?.emitTyped("worker:output", { sessionId, text: `\n\n---\n**User message:** ${msg.content}\n---\n\n` });
+          eventBus?.emitTyped("worker:output", {
+            sessionId,
+            text: `\n\n---\n**User message:** ${msg.content}\n---\n\n`,
+          });
           await client.sendPrompt(sessionId, msg.content, config.sessionTimeoutMs);
         }
       }
@@ -267,20 +301,14 @@ async function implementPhase(ctx: ExecutionContext, implementationPlan: string)
 
 const execFile = promisify(execFileCb);
 
-interface AcceptanceCriteriaResult {
-  approved: boolean;
-  feedback?: string;
-  criteria?: Array<{
-    criterion: string;
-    passed: boolean;
-    evidence?: string;
-    concern?: string;
-  }>;
-  summary?: string;
-}
+// AcceptanceCriteriaResult type is derived from AcceptanceCriteriaSchema in schemas.ts
+type AcceptanceCriteriaResult = import("zod").infer<typeof AcceptanceCriteriaSchema>;
 
 /** Run acceptance criteria review via a fresh ACP reviewer session. */
-async function acceptanceCriteriaReview(ctx: ExecutionContext, qualityResult: QualityResult): Promise<AcceptanceCriteriaResult> {
+async function acceptanceCriteriaReview(
+  ctx: ExecutionContext,
+  qualityResult: QualityResult,
+): Promise<AcceptanceCriteriaResult> {
   const { client, config, issue, eventBus, log, worktreePath, branch } = ctx;
 
   const reviewerConfig = await resolveSessionConfig(config, "reviewer");
@@ -288,14 +316,23 @@ async function acceptanceCriteriaReview(ctx: ExecutionContext, qualityResult: Qu
   // Get diff
   let diff: string;
   try {
-    const { stdout } = await execFile("git", ["diff", `${config.baseBranch}...${branch}`], { cwd: worktreePath });
+    const { stdout } = await execFile("git", ["diff", `${config.baseBranch}...${branch}`], {
+      cwd: worktreePath,
+    });
     diff = stdout;
   } catch {
     diff = "(diff unavailable)";
   }
 
   // Load prompt template
-  const templatePath = path.join(config.projectPath, ".aiscrum", "roles", "quality-reviewer", "prompts", "acceptance-review.md");
+  const templatePath = path.join(
+    config.projectPath,
+    ".aiscrum",
+    "roles",
+    "quality-reviewer",
+    "prompts",
+    "acceptance-review.md",
+  );
   const template = await fs.readFile(templatePath, "utf-8");
 
   const promptVars: Record<string, string> = {
@@ -328,13 +365,23 @@ async function acceptanceCriteriaReview(ctx: ExecutionContext, qualityResult: Qu
     }
 
     const result = await client.sendPrompt(sessionId, prompt, config.sessionTimeoutMs);
-    const acResult = extractJson<AcceptanceCriteriaResult>(result.response);
+    const acResult = await parseWithRetry(
+      AcceptanceCriteriaSchema,
+      result.response,
+      async (hint) => {
+        const retry = await client.sendPrompt(sessionId, hint, config.sessionTimeoutMs);
+        return retry.response;
+      },
+    );
 
     // Post results as issue comment
     const status = acResult.approved ? "✅ Passed" : "❌ Failed";
-    const criteriaLines = (acResult.criteria ?? []).map(
-      (c) => `- ${c.passed ? "✅" : "❌"} ${c.criterion}${c.passed ? (c.evidence ? `: ${c.evidence}` : "") : (c.concern ? `: ${c.concern}` : "")}`,
-    ).join("\n");
+    const criteriaLines = acResult.criteria
+      .map(
+        (c) =>
+          `- ${c.passed ? "✅" : "❌"} ${c.criterion}${c.passed ? (c.evidence ? `: ${c.evidence}` : "") : c.concern ? `: ${c.concern}` : ""}`,
+      )
+      .join("\n");
     const comment = `### 📋 Acceptance Criteria Review — ${status}\n\n${criteriaLines}${acResult.summary ? `\n\n${acResult.summary}` : ""}`;
     await addComment(issue.number, comment).catch((err) =>
       log.warn({ err: String(err) }, "failed to post AC review comment"),
@@ -360,7 +407,10 @@ interface ReviewOutcome {
 }
 
 /** Run quality gate and code review. Sends QG retry feedback to the developer session. */
-async function qualityAndReviewPhase(ctx: ExecutionContext, devSessionId: string): Promise<ReviewOutcome> {
+async function qualityAndReviewPhase(
+  ctx: ExecutionContext,
+  devSessionId: string,
+): Promise<ReviewOutcome> {
   const { client, config, issue, log, worktreePath, branch, progress } = ctx;
 
   progress("quality gate");
@@ -369,20 +419,24 @@ async function qualityAndReviewPhase(ctx: ExecutionContext, devSessionId: string
   let qualityResult = await runQualityGate(gateConfig, worktreePath, branch, config.baseBranch);
 
   // Post quality gate results as issue comment
-  const qgChecks = qualityResult.checks.map(
-    (c) => `${c.passed ? "✅" : "❌"} **${c.name}**: ${c.detail}`
-  ).join("\n");
+  const qgChecks = qualityResult.checks
+    .map((c) => `${c.passed ? "✅" : "❌"} **${c.name}**: ${c.detail}`)
+    .join("\n");
   const qgStatus = qualityResult.passed ? "✅ Passed" : "❌ Failed";
-  await addComment(
-    issue.number,
-    `### 🔍 Quality Gate — ${qgStatus}\n\n${qgChecks}`,
-  ).catch((err) => log.warn({ err: String(err) }, "failed to post quality gate comment"));
+  await addComment(issue.number, `### 🔍 Quality Gate — ${qgStatus}\n\n${qgChecks}`).catch((err) =>
+    log.warn({ err: String(err) }, "failed to post quality gate comment"),
+  );
 
   let retryCount = 0;
   if (!qualityResult.passed) {
     // Retry using the SAME developer session — it has full context
     qualityResult = await handleQualityRetryInSession(
-      client, config, issue, worktreePath, qualityResult, devSessionId,
+      client,
+      config,
+      issue,
+      worktreePath,
+      qualityResult,
+      devSessionId,
     );
     retryCount = qualityResult.passed ? 0 : config.maxRetries;
   }
@@ -400,8 +454,15 @@ async function qualityAndReviewPhase(ctx: ExecutionContext, devSessionId: string
         codeReview = fixResult.codeReview;
       }
     } catch (err: unknown) {
-      log.warn({ err, issue: issue.number }, "code review failed — proceeding without review (tracked in metrics)");
-      codeReview = { approved: false, feedback: "Code review skipped due to error", issues: ["review-skipped"] };
+      log.warn(
+        { err, issue: issue.number },
+        "code review failed — proceeding without review (tracked in metrics)",
+      );
+      codeReview = {
+        approved: false,
+        feedback: "Code review skipped due to error",
+        issues: ["review-skipped"],
+      };
     }
   }
 
@@ -412,8 +473,9 @@ async function qualityAndReviewPhase(ctx: ExecutionContext, devSessionId: string
       const acReview = await acceptanceCriteriaReview(ctx, qualityResult);
       if (!acReview.approved) {
         progress("acceptance failed — fixing");
-        const feedback = acReview.feedback ?? "Acceptance criteria not met";
-        await client.sendPrompt(devSessionId,
+        const feedback = acReview.reasoning || acReview.summary || "Acceptance criteria not met";
+        await client.sendPrompt(
+          devSessionId,
           `## Acceptance Criteria Review Failed\n\n${feedback}\n\nPlease fix the issues and ensure all acceptance criteria are met.`,
           config.sessionTimeoutMs,
         );
@@ -424,7 +486,10 @@ async function qualityAndReviewPhase(ctx: ExecutionContext, devSessionId: string
         }
       }
     } catch (err) {
-      log.warn({ err, issue: issue.number }, "acceptance criteria review failed — proceeding without (tracked in metrics)");
+      log.warn(
+        { err, issue: issue.number },
+        "acceptance criteria review failed — proceeding without (tracked in metrics)",
+      );
     }
   }
 
@@ -539,7 +604,10 @@ async function cleanupPhase(ctx: ExecutionContext, input: CleanupInput): Promise
     log.info("worktree removed");
   } catch (err: unknown) {
     cleanupWarning = `⚠️ Orphaned worktree requires manual cleanup: \`${worktreePath}\``;
-    log.error({ err, worktreePath }, "failed to remove worktree — orphaned worktree may need manual cleanup");
+    log.error(
+      { err, worktreePath },
+      "failed to remove worktree — orphaned worktree may need manual cleanup",
+    );
   }
 
   // Enrich with PR stats
@@ -549,7 +617,10 @@ async function cleanupPhase(ctx: ExecutionContext, input: CleanupInput): Promise
     if (stats) {
       prStats = stats;
       if (input.filesChanged.length === 0 && stats.changedFiles > 0) {
-        log.info({ prNumber: stats.prNumber, changedFiles: stats.changedFiles }, "PR has files — overriding local diff");
+        log.info(
+          { prNumber: stats.prNumber, changedFiles: stats.changedFiles },
+          "PR has files — overriding local diff",
+        );
         input.filesChanged = [`(${stats.changedFiles} files via PR #${stats.prNumber})`];
       }
     }
@@ -561,11 +632,13 @@ async function cleanupPhase(ctx: ExecutionContext, input: CleanupInput): Promise
   let zeroChangeDiagnostic: ZeroChangeDiagnostic | undefined;
   if (input.filesChanged.length === 0 && input.qualityResult.passed === false) {
     // Classify the outcome
-    const hasError = input.errorMessage || input.timedOut || 
-      input.acpOutputLines.some((line) => 
-        /Error:|FAIL|Exception|TypeError|ReferenceError/.test(line)
+    const hasError =
+      input.errorMessage ||
+      input.timedOut ||
+      input.acpOutputLines.some((line) =>
+        /Error:|FAIL|Exception|TypeError|ReferenceError/.test(line),
       );
-    
+
     zeroChangeDiagnostic = {
       lastOutputLines: input.acpOutputLines,
       timedOut: input.timedOut,
@@ -605,14 +678,23 @@ async function cleanupPhase(ctx: ExecutionContext, input: CleanupInput): Promise
   try {
     await setLabel(issue.number, finalLabel);
     if (finalLabel === "status:blocked") {
-      const blockReason = input.errorMessage
-        ?? input.qualityResult?.checks.filter((c) => !c.passed).map((c) => `${c.name}: ${c.detail}`).join("; ")
-        ?? "Unknown reason";
-      await addComment(issue.number, `**Block reason:** ${blockReason}`).catch((err) => log.warn({ err: String(err), issue: issue.number }, "failed to post block reason comment"));
+      const blockReason =
+        input.errorMessage ??
+        input.qualityResult?.checks
+          .filter((c) => !c.passed)
+          .map((c) => `${c.name}: ${c.detail}`)
+          .join("; ") ??
+        "Unknown reason";
+      await addComment(issue.number, `**Block reason:** ${blockReason}`).catch((err) =>
+        log.warn({ err: String(err), issue: issue.number }, "failed to post block reason comment"),
+      );
     }
     log.info({ status: input.status, finalLabel }, "final status set");
   } catch (err: unknown) {
-    log.warn({ err, issueNumber: issue.number, finalLabel }, "failed to set final label — non-critical");
+    log.warn(
+      { err, issueNumber: issue.number, finalLabel },
+      "failed to set final label — non-critical",
+    );
   }
 }
 
@@ -653,12 +735,22 @@ export async function executeIssue(
 ): Promise<IssueResult> {
   const log = logger.child({ ceremony: "execution", issue: issue.number });
   const startTime = Date.now();
-  const progress = (step: string) => eventBus?.emitTyped("issue:progress", { issueNumber: issue.number, step });
+  const progress = (step: string) =>
+    eventBus?.emitTyped("issue:progress", { issueNumber: issue.number, step });
 
   const branch = buildBranch(config, issue.number);
   const worktreePath = path.resolve(config.worktreeBase, `issue-${issue.number}`);
 
-  const ctx: ExecutionContext = { client, config, issue, eventBus, log, branch, worktreePath, progress };
+  const ctx: ExecutionContext = {
+    client,
+    config,
+    issue,
+    eventBus,
+    log,
+    branch,
+    worktreePath,
+    progress,
+  };
 
   // Step 1: Set in-progress label
   await setLabel(issue.number, "status:in-progress");
@@ -718,7 +810,12 @@ export async function executeIssue(
         passed: false,
         checks: [
           ...qualityResult.checks,
-          { name: "files-changed", passed: false, detail: "Worker produced 0 file changes", category: "other" as const },
+          {
+            name: "files-changed",
+            passed: false,
+            detail: "Worker produced 0 file changes",
+            category: "other" as const,
+          },
         ],
       };
     } else {
@@ -726,19 +823,37 @@ export async function executeIssue(
     }
   } catch (err: unknown) {
     errorMessage = err instanceof Error ? err.message : String(err);
-    appendErrorLog("error", `Issue #${issue.number} execution failed: ${errorMessage}`, { issue: issue.number });
+    appendErrorLog("error", `Issue #${issue.number} execution failed: ${errorMessage}`, {
+      issue: issue.number,
+    });
     log.error({ err: errorMessage, issue: issue.number }, "issue execution failed");
     status = "failed";
   } finally {
     // Close developer session after all retries are done
     if (devSessionId) {
-      eventBus?.emitTyped("session:end", { sessionId: devSessionId, outcome: status === "completed" ? "completed" : "failed" });
+      eventBus?.emitTyped("session:end", {
+        sessionId: devSessionId,
+        outcome: status === "completed" ? "completed" : "failed",
+      });
       await client.endSession(devSessionId).catch((err) => {
-        log.warn({ err, sessionId: devSessionId, issue: issue.number }, "failed to end developer session — possible session leak");
+        log.warn(
+          { err, sessionId: devSessionId, issue: issue.number },
+          "failed to end developer session — possible session leak",
+        );
       });
     }
     // Step 8: Cleanup (worktree, huddle, labels)
-    await cleanupPhase(ctx, { status, qualityResult, codeReview, retryCount, filesChanged, errorMessage, startTime, acpOutputLines, timedOut });
+    await cleanupPhase(ctx, {
+      status,
+      qualityResult,
+      codeReview,
+      retryCount,
+      filesChanged,
+      errorMessage,
+      startTime,
+      acpOutputLines,
+      timedOut,
+    });
   }
 
   const duration_ms = Date.now() - startTime;

--- a/src/ceremonies/helpers.ts
+++ b/src/ceremonies/helpers.ts
@@ -2,11 +2,11 @@
  * Shared helpers for sprint ceremony modules.
  */
 
+import type { z } from "zod";
+import { logger } from "../logger.js";
+
 /** Replace `{{KEY}}` placeholders in a template string. */
-export function substitutePrompt(
-  template: string,
-  vars: Record<string, string>,
-): string {
+export function substitutePrompt(template: string, vars: Record<string, string>): string {
   let result = template;
   for (const [key, value] of Object.entries(vars)) {
     result = result.replaceAll(`{{${key}}}`, value);
@@ -34,7 +34,9 @@ export function extractJson<T = unknown>(text: string): T {
       return JSON.parse(fencedMatch[1]) as T;
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      throw new Error(`Failed to parse JSON from response: ${msg}. Input (first 200 chars): ${text.slice(0, 200)}`);
+      throw new Error(
+        `Failed to parse JSON from response: ${msg}. Input (first 200 chars): ${text.slice(0, 200)}`,
+      );
     }
   }
 
@@ -75,10 +77,44 @@ export function extractJson<T = unknown>(text: string): T {
         return JSON.parse(text.slice(start, i + 1)) as T;
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
-        throw new Error(`Failed to parse JSON from response: ${msg}. Input (first 200 chars): ${text.slice(0, 200)}`);
+        throw new Error(
+          `Failed to parse JSON from response: ${msg}. Input (first 200 chars): ${text.slice(0, 200)}`,
+        );
       }
     }
   }
 
   throw new Error("No complete JSON found in response");
+}
+
+/**
+ * Parse an agent response against a Zod schema, retrying once on validation failure.
+ * On first failure, calls `retryFn` with a format hint derived from the schema error.
+ * Logs the first failure as a warning. Throws on second failure.
+ */
+export async function parseWithRetry<S extends z.ZodTypeAny>(
+  schema: S,
+  rawResponse: string,
+  retryFn: (formatHint: string) => Promise<string>,
+): Promise<z.output<S>> {
+  const log = logger.child({ module: "parseWithRetry" });
+
+  try {
+    return schema.parse(extractJson(rawResponse));
+  } catch (firstError: unknown) {
+    const errMsg = firstError instanceof Error ? firstError.message : String(firstError);
+    log.warn({ error: errMsg }, "schema validation failed — retrying with format hint");
+
+    const formatHint = [
+      "Your previous response could not be parsed.",
+      `Error: ${errMsg}`,
+      "",
+      "Please respond with your analysis as readable text, then include a JSON block at the end.",
+      "The JSON must be wrapped in a ```json fenced code block.",
+      "Do NOT change your analysis — only fix the JSON format.",
+    ].join("\n");
+
+    const retryResponse = await retryFn(formatHint);
+    return schema.parse(extractJson(retryResponse));
+  }
 }

--- a/src/ceremonies/refinement.ts
+++ b/src/ceremonies/refinement.ts
@@ -7,14 +7,7 @@ import { listIssues } from "../github/issues.js";
 import { logger } from "../logger.js";
 import { substitutePrompt, extractJson } from "./helpers.js";
 import { resolveSessionConfig } from "../acp/session-config.js";
-
-interface RefinementResponse {
-  refined_issues: Array<{
-    number: number;
-    title: string;
-    ice_score: number;
-  }>;
-}
+import { RefinementResponseSchema } from "../types/schemas.js";
 
 /**
  * Run the refinement ceremony: load idea issues, ask ACP to refine them,
@@ -36,7 +29,14 @@ export async function runRefinement(
   log.info({ count: ideas.length }, "Loaded idea issues for refinement");
 
   // Read prompt template
-  const templatePath = path.join(config.projectPath, ".aiscrum", "roles", "refiner", "prompts", "refinement.md");
+  const templatePath = path.join(
+    config.projectPath,
+    ".aiscrum",
+    "roles",
+    "refiner",
+    "prompts",
+    "refinement.md",
+  );
   const template = await fs.readFile(templatePath, "utf-8");
 
   const prompt = substitutePrompt(template, {
@@ -63,11 +63,9 @@ export async function runRefinement(
       await client.setModel(sessionId, sessionConfig.model);
     }
     const result = await client.sendPrompt(sessionId, fullPrompt, config.sessionTimeoutMs);
-    const parsed = extractJson<RefinementResponse>(result.response);
+    const parsed = RefinementResponseSchema.parse(extractJson(result.response));
 
-    // Ensure refined_issues array exists (model may omit it)
-    const refinedIssues = parsed.refined_issues ?? [];
-    const refined: RefinedIssue[] = refinedIssues.map((issue) => ({
+    const refined: RefinedIssue[] = parsed.refined_issues.map((issue) => ({
       number: issue.number,
       title: issue.title,
       ice_score: issue.ice_score,

--- a/src/ceremonies/retro.ts
+++ b/src/ceremonies/retro.ts
@@ -15,6 +15,7 @@ import { logger } from "../logger.js";
 import { substitutePrompt, extractJson, sanitizePromptInput } from "./helpers.js";
 import { resolveSessionConfig } from "../acp/session-config.js";
 import { createIssue } from "../github/issues.js";
+import { RetroResultSchema, normalizeRetroFields } from "../types/schemas.js";
 
 /**
  * Run the sprint retro ceremony: analyse sprint data, ask ACP for
@@ -83,41 +84,9 @@ export async function runSprintRetro(
     const response = await client.sendPrompt(sessionId, fullPrompt, config.sessionTimeoutMs);
     const rawRetro = extractJson<Record<string, unknown>>(response.response);
 
-    // Normalize field names: ACP may return snake_case or the prompt's format
-    const retro: RetroResult = {
-      wentWell: (rawRetro.wentWell ?? rawRetro.went_well ?? []) as string[],
-      wentBadly: (rawRetro.wentBadly ?? rawRetro.went_poorly ?? []) as string[],
-      improvements: [],
-      previousImprovementsChecked: (rawRetro.previousImprovementsChecked ??
-        rawRetro.previous_improvements_applied !== undefined) as boolean,
-    };
-
-    // Normalize improvements: prompt format uses problem/action/category,
-    // code expects title/description/target/autoApplicable
-    const rawImprovements = (rawRetro.improvements ?? []) as Record<string, unknown>[];
-    for (const raw of rawImprovements) {
-      const title =
-        (raw.title as string) || (raw.action as string) || (raw.problem as string) || "";
-      const description =
-        (raw.description as string) ||
-        [raw.problem, raw.root_cause, raw.action, raw.expected_outcome]
-          .filter(Boolean)
-          .join(" — ") ||
-        "";
-      const categoryMap: Record<string, RetroImprovement["target"]> = {
-        config: "config",
-        agent: "agent",
-        skill: "skill",
-        process: "process",
-      };
-      const target =
-        (raw.target as RetroImprovement["target"]) ||
-        categoryMap[(raw.category as string)?.toLowerCase()] ||
-        "process";
-      const autoApplicable = raw.autoApplicable !== undefined ? Boolean(raw.autoApplicable) : true;
-
-      retro.improvements.push({ title, description, autoApplicable, target });
-    }
+    // Normalize LLM field name variations, then validate via Zod schema
+    const normalized = normalizeRetroFields(rawRetro);
+    const retro: RetroResult = RetroResultSchema.parse(normalized);
 
     log.info(
       {

--- a/src/ceremonies/review.ts
+++ b/src/ceremonies/review.ts
@@ -8,6 +8,7 @@ import { logger } from "../logger.js";
 import { substitutePrompt, extractJson, sanitizePromptInput } from "./helpers.js";
 import { resolveSessionConfig } from "../acp/session-config.js";
 import { getPRStatus } from "../git/merge.js";
+import { ReviewResultSchema } from "../types/schemas.js";
 
 /**
  * Verify that all completed sprint issues have properly merged PRs.
@@ -17,15 +18,23 @@ async function verifyPRMerges(
   results: IssueResult[],
 ): Promise<Array<{ issueNumber: number; prNumber?: number; status?: string; reason: string }>> {
   const log = logger.child({ ceremony: "review" });
-  const flagged: Array<{ issueNumber: number; prNumber?: number; status?: string; reason: string }> = [];
+  const flagged: Array<{
+    issueNumber: number;
+    prNumber?: number;
+    status?: string;
+    reason: string;
+  }> = [];
 
   for (const result of results) {
     if (result.status !== "completed") continue;
 
     const prStatus = await getPRStatus(result.branch);
-    
+
     if (!prStatus) {
-      log.warn({ issue: result.issueNumber, branch: result.branch }, "No PR found for completed issue");
+      log.warn(
+        { issue: result.issueNumber, branch: result.branch },
+        "No PR found for completed issue",
+      );
       flagged.push({
         issueNumber: result.issueNumber,
         reason: "Completed issue has no PR found — needs investigation",
@@ -91,17 +100,25 @@ export async function runSprintReview(
     filesChanged: r.filesChanged,
     retryCount: r.retryCount,
     qualityGatePassed: r.qualityGatePassed,
-    qualityChecks: r.qualityDetails?.checks?.map((c) => ({
-      name: c.name,
-      passed: c.passed,
-      category: c.category,
-    })) ?? [],
+    qualityChecks:
+      r.qualityDetails?.checks?.map((c) => ({
+        name: c.name,
+        passed: c.passed,
+        category: c.category,
+      })) ?? [],
     codeReviewApproved: r.codeReview?.approved,
     codeReviewIssues: r.codeReview?.issues?.length ?? 0,
   }));
 
   // Read prompt template
-  const templatePath = path.join(config.projectPath, ".aiscrum", "roles", "reviewer", "prompts", "review.md");
+  const templatePath = path.join(
+    config.projectPath,
+    ".aiscrum",
+    "roles",
+    "reviewer",
+    "prompts",
+    "review.md",
+  );
   const template = await fs.readFile(templatePath, "utf-8");
 
   const prompt = substitutePrompt(template, {
@@ -133,13 +150,14 @@ export async function runSprintReview(
       await client.setModel(sessionId, sessionConfig.model);
     }
     const response = await client.sendPrompt(sessionId, fullPrompt, config.sessionTimeoutMs);
-    const review = extractJson<ReviewResult>(response.response);
+    const review = ReviewResultSchema.parse(extractJson(response.response));
 
-    // Ensure arrays exist (model may omit them)
-    review.demoItems = review.demoItems ?? [];
-    review.openItems = review.openItems ?? [];
     log.info(
-      { demoItems: review.demoItems.length, openItems: review.openItems.length, flaggedPRs: flaggedPRs.length },
+      {
+        demoItems: review.demoItems.length,
+        openItems: review.openItems.length,
+        flaggedPRs: flaggedPRs.length,
+      },
       "Sprint review completed",
     );
 

--- a/src/enforcement/challenger.ts
+++ b/src/enforcement/challenger.ts
@@ -3,7 +3,9 @@ import { getIssue } from "../github/issues.js";
 import { logger } from "../logger.js";
 import type { AcpClient } from "../acp/client.js";
 import type { SprintConfig } from "../types.js";
+import { ChallengerActionSchema } from "../types/schemas.js";
 import { resolveSessionConfig } from "../acp/session-config.js";
+import { parseWithRetry } from "../ceremonies/helpers.js";
 
 export interface ChallengerResult {
   approved: boolean;
@@ -57,6 +59,15 @@ export async function runChallengerReview(
     "REJECTED: <one-line reason>",
     "",
     "Then provide detailed feedback below.",
+    "",
+    "At the end, include a JSON block in a ```json fenced code block:",
+    "```",
+    "{",
+    '  "decision": "approved" | "rejected",',
+    '  "reasoning": "why you made this decision",',
+    '  "feedback": "detailed feedback text"',
+    "}",
+    "```",
   ].join("\n");
 
   if (sessionConfig.model) {
@@ -64,16 +75,23 @@ export async function runChallengerReview(
   }
 
   const result = await client.sendPrompt(sessionId, prompt, config.sessionTimeoutMs);
+
+  const action = await parseWithRetry(ChallengerActionSchema, result.response, async (hint) => {
+    const retry = await client.sendPrompt(sessionId, hint, config.sessionTimeoutMs);
+    return retry.response;
+  });
+
   await client.endSession(sessionId);
 
-  const response = result.response.trim();
-  const firstLine = response.split("\n")[0] ?? "";
-  const approved = firstLine.toUpperCase().startsWith("APPROVED");
+  const approved = action.decision === "approved";
 
-  log.info({ approved, issueNumber }, "challenger review completed");
+  log.info(
+    { decision: action.decision, issueNumber, reasoning: action.reasoning },
+    "challenger review completed",
+  );
 
   return {
     approved,
-    feedback: response,
+    feedback: result.response,
   };
 }

--- a/src/enforcement/code-review.ts
+++ b/src/enforcement/code-review.ts
@@ -4,8 +4,10 @@
 
 import type { AcpClient } from "../acp/client.js";
 import type { SprintConfig, SprintIssue, CodeReviewResult } from "../types.js";
+import { CodeReviewActionSchema } from "../types/schemas.js";
 import { resolveSessionConfig } from "../acp/session-config.js";
 import { diffStat } from "../git/diff-analysis.js";
+import { parseWithRetry } from "../ceremonies/helpers.js";
 import { logger } from "../logger.js";
 
 /**
@@ -70,30 +72,37 @@ export async function runCodeReview(
       "Review the actual file changes using the tools available to you.",
       "Read the changed files and the diff to understand what was modified.",
       "",
-      "Respond with EXACTLY one of these on the FIRST line:",
-      "APPROVED: <one-line summary of what looks good>",
-      "CHANGES_REQUESTED: <one-line summary of what needs fixing>",
-      "",
-      "Then list any issues found, one per line, prefixed with '- '.",
-      "If approved, you may still list non-blocking suggestions prefixed with '- [suggestion] '.",
+      "Write your review as readable text first, then include a JSON block at the end.",
+      "The JSON must be in a ```json fenced code block with this exact structure:",
+      "```",
+      "{",
+      '  "decision": "approved" | "changes_requested" | "failed",',
+      '  "reasoning": "why you made this decision",',
+      '  "summary": "one-line summary",',
+      '  "issues": ["issue 1", "issue 2"]',
+      "}",
+      "```",
+      'Use "approved" if no blocking issues found.',
+      'Use "changes_requested" if there are issues to fix (issues array must not be empty).',
+      'Use "failed" only if the review itself could not be completed.',
     ].join("\n");
 
     const result = await client.sendPrompt(sessionId, prompt, config.sessionTimeoutMs);
-    const response = result.response.trim();
 
-    const firstLine = response.split("\n")[0] ?? "";
-    const approved = firstLine.toUpperCase().startsWith("APPROVED");
+    const action = await parseWithRetry(CodeReviewActionSchema, result.response, async (hint) => {
+      const retry = await client.sendPrompt(sessionId, hint, config.sessionTimeoutMs);
+      return retry.response;
+    });
 
-    // Extract issue lines
-    const issues = response
-      .split("\n")
-      .filter((line) => line.startsWith("- ") && !line.toLowerCase().includes("[suggestion]"))
-      .map((line) => line.slice(2).trim());
+    const approved = action.decision === "approved";
 
-    log.info({ approved, issueCount: issues.length }, "code review completed");
+    log.info(
+      { decision: action.decision, issueCount: action.issues.length, reasoning: action.reasoning },
+      "code review completed",
+    );
 
     outcome = approved ? "approved" : "changes_requested";
-    return { approved, feedback: response, issues };
+    return { approved, feedback: result.response, issues: action.issues };
   } finally {
     eventBus?.emitTyped("session:end", { sessionId, outcome });
     await client.endSession(sessionId);

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -7,16 +7,28 @@ export const SprintPlanSchema = z.object({
       z.object({
         number: z.coerce.number(),
         title: z.string().default(""),
-        ice_score: z.number().nullable().default(0).transform((v) => v ?? 0),
+        ice_score: z
+          .number()
+          .nullable()
+          .default(0)
+          .transform((v) => v ?? 0),
         depends_on: z.array(z.coerce.number()).default([]),
         acceptanceCriteria: z.string().default(""),
         expectedFiles: z.array(z.string()).default([]),
-        points: z.number().nullable().default(0).transform((v) => v ?? 0),
+        points: z
+          .number()
+          .nullable()
+          .default(0)
+          .transform((v) => v ?? 0),
       }),
     )
     .min(1),
   execution_groups: z.array(z.array(z.coerce.number())).optional(),
-  estimated_points: z.number().nullable().default(0).transform((v) => v ?? 0),
+  estimated_points: z
+    .number()
+    .nullable()
+    .default(0)
+    .transform((v) => v ?? 0),
   rationale: z.string().default(""),
 });
 
@@ -28,8 +40,14 @@ export const ReviewResultSchema = z.object({
 });
 
 export const RetroResultSchema = z.object({
-  wentWell: z.array(z.string()).default([]),
-  wentBadly: z.array(z.string()).default([]),
+  wentWell: z
+    .array(z.string())
+    .default([])
+    .or(z.undefined().transform(() => [] as string[])),
+  wentBadly: z
+    .array(z.string())
+    .default([])
+    .or(z.undefined().transform(() => [] as string[])),
   improvements: z
     .array(
       z.object({
@@ -41,4 +59,117 @@ export const RetroResultSchema = z.object({
     )
     .default([]),
   previousImprovementsChecked: z.boolean().default(false),
+});
+
+// Preprocessor that normalizes LLM field name variations before Zod validation
+export function normalizeRetroFields(raw: Record<string, unknown>): Record<string, unknown> {
+  return {
+    wentWell: (raw.wentWell ?? raw.went_well ?? []) as string[],
+    wentBadly: (raw.wentBadly ?? raw.went_poorly ?? raw.went_badly ?? []) as string[],
+    previousImprovementsChecked: Boolean(
+      raw.previousImprovementsChecked ??
+      raw.previous_improvements_checked ??
+      raw.previous_improvements_applied ??
+      false,
+    ),
+    improvements: normalizeRetroImprovements(raw.improvements),
+  };
+}
+
+function normalizeRetroImprovements(raw: unknown): unknown[] {
+  if (!Array.isArray(raw)) return [];
+  const categoryMap: Record<string, string> = {
+    config: "config",
+    agent: "agent",
+    skill: "skill",
+    process: "process",
+  };
+  return raw.map((item: Record<string, unknown>) => ({
+    title: (item.title as string) || (item.action as string) || (item.problem as string) || "",
+    description:
+      (item.description as string) ||
+      [item.problem, item.root_cause, item.action, item.expected_outcome]
+        .filter(Boolean)
+        .join(" — ") ||
+      "",
+    autoApplicable: item.autoApplicable !== undefined ? Boolean(item.autoApplicable) : true,
+    target:
+      (item.target as string) || categoryMap[(item.category as string)?.toLowerCase()] || "process",
+  }));
+}
+
+// --- Action Schemas (#421 + #425) ---
+
+export const CodeReviewActionSchema = z.discriminatedUnion("decision", [
+  z.object({
+    decision: z.literal("approved"),
+    reasoning: z.string().default(""),
+    summary: z.string().default(""),
+    issues: z.array(z.string()).default([]),
+  }),
+  z.object({
+    decision: z.literal("changes_requested"),
+    reasoning: z.string().default(""),
+    summary: z.string().default(""),
+    issues: z.array(z.string()).min(1),
+  }),
+  z.object({
+    decision: z.literal("failed"),
+    reasoning: z.string().default(""),
+    summary: z.string().default(""),
+    issues: z.array(z.string()).default([]),
+  }),
+]);
+
+export type CodeReviewAction = z.infer<typeof CodeReviewActionSchema>;
+
+export const ChallengerActionSchema = z.discriminatedUnion("decision", [
+  z.object({
+    decision: z.literal("approved"),
+    reasoning: z.string().default(""),
+    feedback: z.string().default(""),
+  }),
+  z.object({
+    decision: z.literal("rejected"),
+    reasoning: z.string().default(""),
+    feedback: z.string(),
+  }),
+]);
+
+export type ChallengerAction = z.infer<typeof ChallengerActionSchema>;
+
+// --- Refinement Schema (#422) ---
+
+export const RefinementResponseSchema = z.object({
+  refined_issues: z
+    .array(
+      z.object({
+        number: z.coerce.number(),
+        title: z.string().default(""),
+        ice_score: z
+          .number()
+          .nullable()
+          .default(0)
+          .transform((v) => v ?? 0),
+      }),
+    )
+    .default([]),
+});
+
+// --- Acceptance Criteria Schema (#423 + #425) ---
+
+export const AcceptanceCriteriaSchema = z.object({
+  approved: z.boolean(),
+  reasoning: z.string().default(""),
+  summary: z.string().default(""),
+  criteria: z
+    .array(
+      z.object({
+        criterion: z.string(),
+        passed: z.boolean(),
+        evidence: z.string().optional(),
+        concern: z.string().optional(),
+      }),
+    )
+    .default([]),
 });

--- a/tests/ceremonies/execution.test.ts
+++ b/tests/ceremonies/execution.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type {
-  SprintConfig,
-  SprintIssue,
-  QualityResult,
-} from "../../src/types.js";
+import type { SprintConfig, SprintIssue, QualityResult } from "../../src/types.js";
 
 vi.mock("../../src/acp/session-config.js", () => ({
   resolveSessionConfig: vi.fn().mockResolvedValue({
@@ -57,9 +53,16 @@ vi.mock("../../src/logger.js", () => {
 });
 
 vi.mock("node:child_process", () => {
-  const cb = vi.fn((_cmd: string, _args: string[], _opts: unknown, callback: (err: null, result: { stdout: string; stderr: string }) => void) => {
-    callback(null, { stdout: "diff --git a/src/foo.ts b/src/foo.ts\n+added line", stderr: "" });
-  });
+  const cb = vi.fn(
+    (
+      _cmd: string,
+      _args: string[],
+      _opts: unknown,
+      callback: (err: null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      callback(null, { stdout: "diff --git a/src/foo.ts b/src/foo.ts\n+added line", stderr: "" });
+    },
+  );
   return { execFile: cb };
 });
 
@@ -87,42 +90,35 @@ vi.mock("node:util", async (importOriginal) => {
 
 vi.mock("node:fs/promises", () => ({
   default: {
-    readFile: vi
-      .fn()
-      .mockImplementation((filePath: string) => {
-        if (filePath.includes("item-planner")) {
-          return Promise.resolve("Plan for issue #{{ISSUE_NUMBER}}: {{ISSUE_TITLE}}");
-        }
-        if (filePath.includes("tdd")) {
-          return Promise.resolve("TDD tests for issue #{{ISSUE_NUMBER}}: {{ISSUE_TITLE}}\nPlan: {{IMPLEMENTATION_PLAN}}");
-        }
-        if (filePath.includes("acceptance-review")) {
-          return Promise.resolve("Review AC for issue #{{ISSUE_NUMBER}}: {{ISSUE_TITLE}}\nCriteria: {{ACCEPTANCE_CRITERIA}}\nDiff: {{DIFF}}");
-        }
-        return Promise.resolve("Worker prompt for issue #{{ISSUE_NUMBER}}");
-      }),
+    readFile: vi.fn().mockImplementation((filePath: string) => {
+      if (filePath.includes("item-planner")) {
+        return Promise.resolve("Plan for issue #{{ISSUE_NUMBER}}: {{ISSUE_TITLE}}");
+      }
+      if (filePath.includes("tdd")) {
+        return Promise.resolve(
+          "TDD tests for issue #{{ISSUE_NUMBER}}: {{ISSUE_TITLE}}\nPlan: {{IMPLEMENTATION_PLAN}}",
+        );
+      }
+      if (filePath.includes("acceptance-review")) {
+        return Promise.resolve(
+          "Review AC for issue #{{ISSUE_NUMBER}}: {{ISSUE_TITLE}}\nCriteria: {{ACCEPTANCE_CRITERIA}}\nDiff: {{DIFF}}",
+        );
+      }
+      return Promise.resolve("Worker prompt for issue #{{ISSUE_NUMBER}}");
+    }),
   },
 }));
 
-const { createWorktree, removeWorktree } = await import(
-  "../../src/git/worktree.js"
-);
-const { runQualityGate } = await import(
-  "../../src/enforcement/quality-gate.js"
-);
-const { formatHuddleComment, formatSprintLogEntry } = await import(
-  "../../src/documentation/huddle.js"
-);
-const { appendToSprintLog } = await import(
-  "../../src/documentation/sprint-log.js"
-);
+const { createWorktree, removeWorktree } = await import("../../src/git/worktree.js");
+const { runQualityGate } = await import("../../src/enforcement/quality-gate.js");
+const { formatHuddleComment, formatSprintLogEntry } =
+  await import("../../src/documentation/huddle.js");
+const { appendToSprintLog } = await import("../../src/documentation/sprint-log.js");
 const { addComment } = await import("../../src/github/issues.js");
 const { setLabel } = await import("../../src/github/labels.js");
 await import("../../src/git/diff-analysis.js");
 
-const { executeIssue } = await import(
-  "../../src/ceremonies/execution.js"
-);
+const { executeIssue } = await import("../../src/ceremonies/execution.js");
 
 // --- Helpers ---
 
@@ -142,7 +138,7 @@ function makeConfig(overrides: Partial<SprintConfig> = {}): SprintConfig {
     enableChallenger: false,
     enableTdd: false,
     autoRevertDrift: false,
-  backlogLabels: [],
+    backlogLabels: [],
     autoMerge: true,
     squashMerge: true,
     deleteBranchAfterMerge: true,
@@ -169,11 +165,32 @@ function makeIssue(overrides: Partial<SprintIssue> = {}): SprintIssue {
 }
 
 function makeMockClient() {
+  let callCount = 0;
   return {
-    createSession: vi.fn().mockResolvedValue({ sessionId: "session-abc", availableModes: [], currentMode: "", availableModels: [], currentModel: "" }),
-    sendPrompt: vi.fn().mockResolvedValue({
-      response: "Done implementing issue",
-      stopReason: "end_turn",
+    createSession: vi
+      .fn()
+      .mockResolvedValue({
+        sessionId: "session-abc",
+        availableModes: [],
+        currentMode: "",
+        availableModels: [],
+        currentModel: "",
+      }),
+    sendPrompt: vi.fn().mockImplementation((_sid: string, prompt: string) => {
+      callCount++;
+      // AC review prompts come from the acceptance-review template
+      if (typeof prompt === "string" && prompt.includes("Review AC for issue")) {
+        return Promise.resolve({
+          response: JSON.stringify({
+            approved: true,
+            reasoning: "all good",
+            summary: "Criteria met",
+            criteria: [],
+          }),
+          stopReason: "end_turn",
+        });
+      }
+      return Promise.resolve({ response: "Done implementing issue", stopReason: "end_turn" });
     }),
     endSession: vi.fn().mockResolvedValue(undefined),
     setMode: vi.fn().mockResolvedValue(undefined),
@@ -450,9 +467,7 @@ describe("executeIssue", () => {
         zeroChangeDiagnostic: expect.objectContaining({
           workerOutcome: "worker-error",
           timedOut: false,
-          lastOutputLines: expect.arrayContaining([
-            expect.stringContaining("Error:"),
-          ]),
+          lastOutputLines: expect.arrayContaining([expect.stringContaining("Error:")]),
         }),
       }),
     );
@@ -547,8 +562,10 @@ describe("executeIssue", () => {
         return Promise.resolve({
           response: JSON.stringify({
             approved: false,
-            feedback: "Missing search endpoint implementation",
-            criteria: [{ criterion: "returns results", passed: false, concern: "no endpoint found" }],
+            reasoning: "Missing search endpoint implementation",
+            criteria: [
+              { criterion: "returns results", passed: false, concern: "no endpoint found" },
+            ],
           }),
           stopReason: "end_turn",
         });
@@ -561,7 +578,8 @@ describe("executeIssue", () => {
 
     // Developer session should receive AC failure feedback
     const feedbackCalls = mockClient.sendPrompt.mock.calls.filter(
-      (call: unknown[]) => typeof call[1] === "string" && call[1].includes("Acceptance Criteria Review Failed"),
+      (call: unknown[]) =>
+        typeof call[1] === "string" && call[1].includes("Acceptance Criteria Review Failed"),
     );
     expect(feedbackCalls.length).toBe(1);
     expect(feedbackCalls[0][1]).toContain("Missing search endpoint implementation");
@@ -588,4 +606,3 @@ describe("executeIssue", () => {
     expect(result.qualityGatePassed).toBe(true);
   });
 });
-

--- a/tests/ceremonies/helpers.test.ts
+++ b/tests/ceremonies/helpers.test.ts
@@ -1,17 +1,14 @@
-import { describe, it, expect } from "vitest";
-import { extractJson } from "../../src/ceremonies/helpers.js";
+import { describe, it, expect, vi } from "vitest";
+import { z } from "zod";
+import { extractJson, parseWithRetry } from "../../src/ceremonies/helpers.js";
 
 describe("extractJson", () => {
   it("throws descriptive error for malformed JSON", () => {
-    expect(() => extractJson("```json\n{invalid}\n```")).toThrow(
-      "Failed to parse JSON",
-    );
+    expect(() => extractJson("```json\n{invalid}\n```")).toThrow("Failed to parse JSON");
   });
 
   it("throws for garbage text with braces", () => {
-    expect(() => extractJson("{not json at all}")).toThrow(
-      "Failed to parse JSON",
-    );
+    expect(() => extractJson("{not json at all}")).toThrow("Failed to parse JSON");
   });
 
   it("throws for empty string", () => {
@@ -28,5 +25,42 @@ describe("extractJson", () => {
 
   it("handles valid JSON without fence", () => {
     expect(extractJson('some text {"a":1} more text')).toEqual({ a: 1 });
+  });
+});
+
+vi.mock("../../src/logger.js", () => ({
+  logger: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) },
+}));
+
+describe("parseWithRetry", () => {
+  const schema = z.object({ decision: z.string(), issues: z.array(z.string()).default([]) });
+
+  it("succeeds on first attempt with valid JSON", async () => {
+    const retryFn = vi.fn();
+    const result = await parseWithRetry(schema, '```json\n{"decision":"approved"}\n```', retryFn);
+    expect(result).toEqual({ decision: "approved", issues: [] });
+    expect(retryFn).not.toHaveBeenCalled();
+  });
+
+  it("retries on invalid JSON and succeeds on second attempt", async () => {
+    const retryFn = vi
+      .fn()
+      .mockResolvedValue('```json\n{"decision":"rejected","issues":["bug"]}\n```');
+    const result = await parseWithRetry(schema, "no json here", retryFn);
+    expect(result).toEqual({ decision: "rejected", issues: ["bug"] });
+    expect(retryFn).toHaveBeenCalledOnce();
+    expect(retryFn.mock.calls[0][0]).toContain("could not be parsed");
+  });
+
+  it("throws on second failure after retry", async () => {
+    const retryFn = vi.fn().mockResolvedValue("still no json");
+    await expect(parseWithRetry(schema, "bad", retryFn)).rejects.toThrow();
+    expect(retryFn).toHaveBeenCalledOnce();
+  });
+
+  it("retries on schema validation failure (valid JSON but wrong shape)", async () => {
+    const retryFn = vi.fn().mockResolvedValue('```json\n{"decision":"ok"}\n```');
+    const result = await parseWithRetry(schema, '{"wrong_field": 123}', retryFn);
+    expect(result.decision).toBe("ok");
   });
 });

--- a/tests/enforcement/challenger.test.ts
+++ b/tests/enforcement/challenger.test.ts
@@ -42,12 +42,20 @@ vi.mock("../../src/logger.js", () => ({
 
 import { runChallengerReview } from "../../src/enforcement/challenger.js";
 
-function makeMockClient(response = "APPROVED: Looks good") {
+function makeMockClient(
+  response = '```json\n{"decision":"approved","reasoning":"Looks good","feedback":"All clear"}\n```',
+) {
   return {
-    createSession: vi.fn().mockResolvedValue({ sessionId: "session-1", availableModes: [], currentMode: "", availableModels: [], currentModel: "" }),
-    sendPrompt: vi
+    createSession: vi
       .fn()
-      .mockResolvedValue({ response, stopReason: "end_turn" }),
+      .mockResolvedValue({
+        sessionId: "session-1",
+        availableModes: [],
+        currentMode: "",
+        availableModels: [],
+        currentModel: "",
+      }),
+    sendPrompt: vi.fn().mockResolvedValue({ response, stopReason: "end_turn" }),
     endSession: vi.fn().mockResolvedValue(undefined),
     setMode: vi.fn().mockResolvedValue(undefined),
     setModel: vi.fn().mockResolvedValue(undefined),
@@ -84,35 +92,51 @@ describe("runChallengerReview", () => {
     vi.clearAllMocks();
   });
 
-  it("approves when response starts with APPROVED", async () => {
-    const client = makeMockClient("APPROVED: Looks good");
+  it("approves when response contains approved decision", async () => {
+    const client = makeMockClient(
+      'Review looks solid.\n\n```json\n{"decision":"approved","reasoning":"Looks good","feedback":"All clear"}\n```',
+    );
     const result = await runChallengerReview(client, config, "feat/auth", 42);
 
     expect(result.approved).toBe(true);
-    expect(result.feedback).toContain("APPROVED: Looks good");
+    expect(result.feedback).toContain("Review looks solid");
   });
 
-  it("rejects when response starts with REJECTED", async () => {
-    const client = makeMockClient("REJECTED: Missing tests\nMore details");
+  it("rejects when response contains rejected decision", async () => {
+    const client = makeMockClient(
+      'Missing tests for auth module.\n\n```json\n{"decision":"rejected","reasoning":"Missing tests","feedback":"Need auth tests"}\n```',
+    );
     const result = await runChallengerReview(client, config, "feat/auth", 42);
 
     expect(result.approved).toBe(false);
-    expect(result.feedback).toContain("REJECTED: Missing tests");
+    expect(result.feedback).toContain("Missing tests for auth module");
   });
 
-  it("rejects when response does not start with APPROVED", async () => {
-    const client = makeMockClient("Some other response");
-    const result = await runChallengerReview(client, config, "feat/auth", 42);
+  it("retries when response has no valid JSON", async () => {
+    const client = makeMockClient();
+    (client.sendPrompt as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        response: "Some other response without JSON",
+        stopReason: "end_turn",
+      })
+      .mockResolvedValueOnce({
+        response:
+          '```json\n{"decision":"rejected","reasoning":"no tests","feedback":"Add tests"}\n```',
+        stopReason: "end_turn",
+      });
 
+    const result = await runChallengerReview(client, config, "feat/auth", 42);
     expect(result.approved).toBe(false);
+    expect(client.sendPrompt).toHaveBeenCalledTimes(2);
   });
 
   it("passes issue details and diff stats to prompt", async () => {
-    const client = makeMockClient("APPROVED: All good");
+    const client = makeMockClient(
+      '```json\n{"decision":"approved","reasoning":"All good","feedback":"ok"}\n```',
+    );
     await runChallengerReview(client, config, "feat/auth", 42);
 
-    const prompt = (client.sendPrompt as ReturnType<typeof vi.fn>).mock
-      .calls[0][1] as string;
+    const prompt = (client.sendPrompt as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
     expect(prompt).toContain("Fix auth bug");
     expect(prompt).toContain("50");
   });

--- a/tests/enforcement/code-review.test.ts
+++ b/tests/enforcement/code-review.test.ts
@@ -71,7 +71,8 @@ describe("runCodeReview", () => {
 
   it("returns approved when reviewer says APPROVED", async () => {
     client.sendPrompt.mockResolvedValue({
-      response: "APPROVED: Clean implementation, tests cover all cases.\n- [suggestion] Consider adding JSDoc.",
+      response:
+        'Clean implementation, tests cover all cases.\n\n```json\n{"decision":"approved","reasoning":"Code is solid","summary":"Clean implementation","issues":[]}\n```',
     });
 
     const result = await runCodeReview(
@@ -83,17 +84,13 @@ describe("runCodeReview", () => {
     );
 
     expect(result.approved).toBe(true);
-    expect(result.issues).toHaveLength(0); // suggestions are filtered out
-    expect(result.feedback).toContain("APPROVED");
+    expect(result.issues).toHaveLength(0);
   });
 
   it("returns rejected with issues when reviewer says CHANGES_REQUESTED", async () => {
     client.sendPrompt.mockResolvedValue({
-      response: [
-        "CHANGES_REQUESTED: Missing error handling in edge case",
-        "- uncaught exception in parseInput when input is null",
-        "- no validation for negative numbers",
-      ].join("\n"),
+      response:
+        'Missing error handling in edge case.\n\n```json\n{"decision":"changes_requested","reasoning":"edge cases not handled","summary":"Missing error handling","issues":["uncaught exception in parseInput when input is null","no validation for negative numbers"]}\n```',
     });
 
     const result = await runCodeReview(
@@ -111,7 +108,10 @@ describe("runCodeReview", () => {
   });
 
   it("creates and tears down a session", async () => {
-    client.sendPrompt.mockResolvedValue({ response: "APPROVED: looks good" });
+    client.sendPrompt.mockResolvedValue({
+      response:
+        '```json\n{"decision":"approved","reasoning":"ok","summary":"looks good","issues":[]}\n```',
+    });
 
     await runCodeReview(
       client as never,
@@ -129,7 +129,9 @@ describe("runCodeReview", () => {
   });
 
   it("sets the reviewer model", async () => {
-    client.sendPrompt.mockResolvedValue({ response: "APPROVED: ok" });
+    client.sendPrompt.mockResolvedValue({
+      response: '```json\n{"decision":"approved","reasoning":"ok","summary":"ok","issues":[]}\n```',
+    });
 
     await runCodeReview(
       client as never,
@@ -158,29 +160,10 @@ describe("runCodeReview", () => {
     expect(client.endSession).toHaveBeenCalledWith("review-session-1");
   });
 
-  it("handles empty response", async () => {
-    client.sendPrompt.mockResolvedValue({ response: "" });
-
-    const result = await runCodeReview(
-      client as never,
-      baseConfig,
-      issue,
-      "sprint/1/issue-42",
-      "/tmp/worktrees/issue-42",
-    );
-
-    // Empty response defaults to not-approved (doesn't start with APPROVED)
-    expect(result.approved).toBe(false);
-    expect(result.issues).toHaveLength(0);
-  });
-
-  it("filters out suggestion lines from issues list", async () => {
-    client.sendPrompt.mockResolvedValue({
-      response: [
-        "APPROVED: implementation is correct",
-        "- [suggestion] rename variable for clarity",
-        "- [Suggestion] add more tests",
-      ].join("\n"),
+  it("retries when response has no valid JSON", async () => {
+    // First call returns no JSON, retry returns valid JSON
+    client.sendPrompt.mockResolvedValueOnce({ response: "No JSON here" }).mockResolvedValueOnce({
+      response: '```json\n{"decision":"approved","reasoning":"ok","summary":"ok","issues":[]}\n```',
     });
 
     const result = await runCodeReview(
@@ -192,6 +175,22 @@ describe("runCodeReview", () => {
     );
 
     expect(result.approved).toBe(true);
-    expect(result.issues).toHaveLength(0);
+    expect(client.sendPrompt).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns feedback as full response text for session display", async () => {
+    const fullResponse =
+      'The code looks good overall.\n\n```json\n{"decision":"approved","reasoning":"solid code","summary":"approved","issues":[]}\n```';
+    client.sendPrompt.mockResolvedValue({ response: fullResponse });
+
+    const result = await runCodeReview(
+      client as never,
+      baseConfig,
+      issue,
+      "sprint/1/issue-42",
+      "/tmp/worktrees/issue-42",
+    );
+
+    expect(result.feedback).toBe(fullResponse);
   });
 });

--- a/tests/types/schemas.test.ts
+++ b/tests/types/schemas.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import {
+  CodeReviewActionSchema,
+  ChallengerActionSchema,
+  RefinementResponseSchema,
+  AcceptanceCriteriaSchema,
+  RetroResultSchema,
+  ReviewResultSchema,
+  normalizeRetroFields,
+} from "../../src/types/schemas.js";
+
+describe("CodeReviewActionSchema", () => {
+  it("parses approved decision", () => {
+    const result = CodeReviewActionSchema.parse({
+      decision: "approved",
+      reasoning: "Code is solid",
+      summary: "All good",
+      issues: [],
+    });
+    expect(result.decision).toBe("approved");
+    expect(result.reasoning).toBe("Code is solid");
+  });
+
+  it("parses changes_requested with issues", () => {
+    const result = CodeReviewActionSchema.parse({
+      decision: "changes_requested",
+      reasoning: "Missing tests",
+      summary: "Needs work",
+      issues: ["no tests for edge case"],
+    });
+    expect(result.decision).toBe("changes_requested");
+    expect(result.issues).toHaveLength(1);
+  });
+
+  it("rejects changes_requested without issues", () => {
+    expect(() =>
+      CodeReviewActionSchema.parse({
+        decision: "changes_requested",
+        reasoning: "bad",
+        issues: [],
+      }),
+    ).toThrow();
+  });
+
+  it("defaults optional fields", () => {
+    const result = CodeReviewActionSchema.parse({ decision: "approved" });
+    expect(result.reasoning).toBe("");
+    expect(result.summary).toBe("");
+    expect(result.issues).toEqual([]);
+  });
+
+  it("rejects invalid decision", () => {
+    expect(() => CodeReviewActionSchema.parse({ decision: "maybe" })).toThrow();
+  });
+});
+
+describe("ChallengerActionSchema", () => {
+  it("parses approved", () => {
+    const result = ChallengerActionSchema.parse({
+      decision: "approved",
+      reasoning: "Solid work",
+      feedback: "All clear",
+    });
+    expect(result.decision).toBe("approved");
+  });
+
+  it("parses rejected with required feedback", () => {
+    const result = ChallengerActionSchema.parse({
+      decision: "rejected",
+      reasoning: "Missing coverage",
+      feedback: "Add tests for auth module",
+    });
+    expect(result.decision).toBe("rejected");
+    expect(result.feedback).toBe("Add tests for auth module");
+  });
+
+  it("rejects unknown decision", () => {
+    expect(() => ChallengerActionSchema.parse({ decision: "unknown" })).toThrow();
+  });
+});
+
+describe("RefinementResponseSchema", () => {
+  it("parses refined issues with defaults", () => {
+    const result = RefinementResponseSchema.parse({
+      refined_issues: [{ number: 1, title: "Fix bug", ice_score: null }],
+    });
+    expect(result.refined_issues[0].ice_score).toBe(0);
+  });
+
+  it("defaults to empty array when missing", () => {
+    const result = RefinementResponseSchema.parse({});
+    expect(result.refined_issues).toEqual([]);
+  });
+});
+
+describe("AcceptanceCriteriaSchema", () => {
+  it("parses full result", () => {
+    const result = AcceptanceCriteriaSchema.parse({
+      approved: true,
+      reasoning: "All criteria met",
+      summary: "Passed",
+      criteria: [{ criterion: "returns results", passed: true, evidence: "test passes" }],
+    });
+    expect(result.approved).toBe(true);
+    expect(result.criteria).toHaveLength(1);
+  });
+
+  it("defaults optional fields", () => {
+    const result = AcceptanceCriteriaSchema.parse({ approved: false });
+    expect(result.reasoning).toBe("");
+    expect(result.summary).toBe("");
+    expect(result.criteria).toEqual([]);
+  });
+
+  it("rejects missing approved", () => {
+    expect(() => AcceptanceCriteriaSchema.parse({})).toThrow();
+  });
+});
+
+describe("normalizeRetroFields", () => {
+  it("normalizes snake_case to camelCase", () => {
+    const result = normalizeRetroFields({
+      went_well: ["a"],
+      went_poorly: ["b"],
+      previous_improvements_checked: true,
+      improvements: [],
+    });
+    expect(result.wentWell).toEqual(["a"]);
+    expect(result.wentBadly).toEqual(["b"]);
+    expect(result.previousImprovementsChecked).toBe(true);
+  });
+
+  it("normalizes improvement fields", () => {
+    const result = normalizeRetroFields({
+      improvements: [{ problem: "Slow CI", action: "Parallelize", category: "config" }],
+    });
+    const improvements = result.improvements as Array<Record<string, unknown>>;
+    expect(improvements[0].title).toBe("Parallelize");
+    expect(improvements[0].target).toBe("config");
+  });
+
+  it("passes through RetroResultSchema", () => {
+    const normalized = normalizeRetroFields({
+      went_well: ["fast delivery"],
+      went_poorly: ["flaky tests"],
+      improvements: [
+        {
+          title: "Fix flaky tests",
+          description: "Add retries",
+          autoApplicable: true,
+          target: "process",
+        },
+      ],
+    });
+    const result = RetroResultSchema.parse(normalized);
+    expect(result.wentWell).toEqual(["fast delivery"]);
+    expect(result.improvements[0].title).toBe("Fix flaky tests");
+  });
+});
+
+describe("ReviewResultSchema", () => {
+  it("applies defaults for missing fields", () => {
+    const result = ReviewResultSchema.parse({});
+    expect(result.summary).toBe("No summary provided");
+    expect(result.demoItems).toEqual([]);
+    expect(result.openItems).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces fragile string-matching agent output parsing with typed Zod schemas and structured JSON responses. All agent outputs now go through schema validation with automatic retry on parse failure.

## What changed

### New schemas (`src/types/schemas.ts`)
- **CodeReviewActionSchema** — `discriminatedUnion` (approved / changes_requested / failed) with reasoning + issues
- **ChallengerActionSchema** — `discriminatedUnion` (approved / rejected) with reasoning + feedback
- **AcceptanceCriteriaSchema** — structured pass/fail with criteria array
- **RefinementResponseSchema** — validated refined issues with ICE scores
- **normalizeRetroFields()** — LLM field name normalization before schema parse

### New helper (`src/ceremonies/helpers.ts`)
- **parseWithRetry()** — attempts schema `.parse()`, retries once with format hint on failure

### Wired into all ceremony files
| File | Before | After |
|------|--------|-------|
| code-review.ts | First line starts with APPROVED | `CodeReviewActionSchema.parse()` + retry |
| challenger.ts | First line starts with APPROVED | `ChallengerActionSchema.parse()` + retry |
| retro.ts | Manual field mapping (`went_well`/`wentWell`) | `normalizeRetroFields()` + `RetroResultSchema.parse()` |
| review.ts | `extractJson<ReviewResult>()` type cast | `ReviewResultSchema.parse()` |
| refinement.ts | `extractJson<RefinementResponse>()` type hint | `RefinementResponseSchema.parse()` |
| execution.ts | `extractJson<AcceptanceCriteriaResult>()` cast | `AcceptanceCriteriaSchema` + `parseWithRetry()` |

### Prompt strategy
Agents instructed to write readable text first, then append a ```json block at end. Sessions remain human-readable while providing structured data for extraction.

### All schemas include `reasoning` field (#425)
Structured separation between what the agent thinks and what it decides — useful for debugging and sprint logs.

## Verification
- **606 tests pass** (585 existing + 21 new)
- Type check clean
- Build succeeds (backend + frontend)
- No test regressions

## Closes
- #421 Action Schemas for Code Review + Challenger
- #422 Enforce existing Zod schemas for Retro, Review, and Refinement
- #423 Acceptance Review schema
- #424 Schema-Violation Retry with format hint
- #425 Structured reasoning fields in agent output schemas