### PR TITLE
fix: prevent duplicate ntfy notifications on multi-sprint runs

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -24,8 +24,12 @@ function isTransientAcpError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message.toLowerCase() : String(err).toLowerCase();
   // Process exit is NOT transient — the connection is gone
   if (msg.includes("process exited")) return false;
-  return msg.includes("timeout") || msg.includes("timed out") ||
-         msg.includes("econnreset") || msg.includes("econnrefused");
+  return (
+    msg.includes("timeout") ||
+    msg.includes("timed out") ||
+    msg.includes("econnreset") ||
+    msg.includes("econnrefused")
+  );
 }
 
 export interface AcpClientOptions {
@@ -269,88 +273,109 @@ export class AcpClient {
       const onCommands = this.onCommandsUpdate;
       const onConfig = this.onConfigUpdate;
 
-      this.connection = new ClientSideConnection(
-        (_agent) => {
-          const client: Client = {
-            async requestPermission(
-              params: RequestPermissionRequest,
-            ): Promise<RequestPermissionResponse> {
-              return permissionHandler(params);
-            },
-            async sessionUpdate(params: SessionNotification): Promise<void> {
-              const update = params.update;
-              const sid = params.sessionId;
+      this.connection = new ClientSideConnection((_agent) => {
+        const client: Client = {
+          async requestPermission(
+            params: RequestPermissionRequest,
+          ): Promise<RequestPermissionResponse> {
+            return permissionHandler(params);
+          },
+          async sessionUpdate(params: SessionNotification): Promise<void> {
+            const update = params.update;
+            const sid = params.sessionId;
 
-              if (update.sessionUpdate === "agent_message_chunk") {
-                const content = update.content;
-                if (content.type === "text") {
-                  const chunks = sessionChunks.get(sid) ?? [];
-                  chunks.push(content.text);
-                  sessionChunks.set(sid, chunks);
-                  onChunk?.(sid, content.text);
-                }
-              } else if (update.sessionUpdate === "agent_thought_chunk") {
-                const content = (update as Record<string, unknown>).content as { type?: string; text?: string } | undefined;
-                if (content?.type === "text" && content.text) {
-                  onThinking?.(sid, content.text);
-                }
-              } else if (update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update") {
-                const tc = update as Record<string, unknown>;
-                onTool?.(sid, {
-                  toolCallId: String(tc.toolCallId ?? ""),
-                  title: String(tc.title ?? ""),
-                  status: tc.status as string | undefined,
-                  kind: tc.kind as string | undefined,
-                  locations: tc.locations as Array<{ uri?: string; range?: unknown }> | undefined,
+            if (update.sessionUpdate === "agent_message_chunk") {
+              const content = update.content;
+              if (content.type === "text") {
+                const chunks = sessionChunks.get(sid) ?? [];
+                chunks.push(content.text);
+                sessionChunks.set(sid, chunks);
+                onChunk?.(sid, content.text);
+              }
+            } else if (update.sessionUpdate === "agent_thought_chunk") {
+              const content = (update as Record<string, unknown>).content as
+                | { type?: string; text?: string }
+                | undefined;
+              if (content?.type === "text" && content.text) {
+                onThinking?.(sid, content.text);
+              }
+            } else if (
+              update.sessionUpdate === "tool_call" ||
+              update.sessionUpdate === "tool_call_update"
+            ) {
+              const tc = update as Record<string, unknown>;
+              onTool?.(sid, {
+                toolCallId: String(tc.toolCallId ?? ""),
+                title: String(tc.title ?? ""),
+                status: tc.status as string | undefined,
+                kind: tc.kind as string | undefined,
+                locations: tc.locations as Array<{ uri?: string; range?: unknown }> | undefined,
+              });
+            } else if (update.sessionUpdate === "usage_update") {
+              const u = update as Record<string, unknown>;
+              onUsage?.(sid, {
+                used: Number(u.used ?? 0),
+                size: Number(u.size ?? 0),
+                cost: u.cost as AcpUsageEvent["cost"],
+              });
+            } else if (update.sessionUpdate === "current_mode_update") {
+              const m = update as Record<string, unknown>;
+              if (m.currentModeId) {
+                onMode?.(sid, String(m.currentModeId));
+              }
+            } else if (update.sessionUpdate === "plan") {
+              const p = update as Record<string, unknown>;
+              const entries = p.entries as
+                | Array<{ content: string; priority: string; status: string }>
+                | undefined;
+              if (entries) {
+                onPlan?.(sid, {
+                  entries: entries.map((e) => ({
+                    content: e.content,
+                    priority: (e.priority ?? "medium") as AcpPlanEntry["priority"],
+                    status: (e.status ?? "pending") as AcpPlanEntry["status"],
+                  })),
                 });
-              } else if (update.sessionUpdate === "usage_update") {
-                const u = update as Record<string, unknown>;
-                onUsage?.(sid, {
-                  used: Number(u.used ?? 0),
-                  size: Number(u.size ?? 0),
-                  cost: u.cost as AcpUsageEvent["cost"],
-                });
-              } else if (update.sessionUpdate === "current_mode_update") {
-                const m = update as Record<string, unknown>;
-                if (m.currentModeId) {
-                  onMode?.(sid, String(m.currentModeId));
-                }
-              } else if (update.sessionUpdate === "plan") {
-                const p = update as Record<string, unknown>;
-                const entries = p.entries as Array<{ content: string; priority: string; status: string }> | undefined;
-                if (entries) {
-                  onPlan?.(sid, {
-                    entries: entries.map((e) => ({
-                      content: e.content,
-                      priority: (e.priority ?? "medium") as AcpPlanEntry["priority"],
-                      status: (e.status ?? "pending") as AcpPlanEntry["status"],
-                    })),
-                  });
-                }
-              } else if (update.sessionUpdate === "available_commands_update") {
-                const c = update as Record<string, unknown>;
-                const cmds = c.availableCommands as Array<{ name: string; description: string; input?: { hint?: string } }> | undefined;
-                if (cmds) {
-                  onCommands?.(sid, cmds.map((cmd) => ({
+              }
+            } else if (update.sessionUpdate === "available_commands_update") {
+              const c = update as Record<string, unknown>;
+              const cmds = c.availableCommands as
+                | Array<{ name: string; description: string; input?: { hint?: string } }>
+                | undefined;
+              if (cmds) {
+                onCommands?.(
+                  sid,
+                  cmds.map((cmd) => ({
                     name: cmd.name,
                     description: cmd.description,
                     hint: cmd.input?.hint,
-                  })));
-                }
-              } else if (update.sessionUpdate === "config_option_update") {
-                const c = update as Record<string, unknown>;
-                const opts = c.configOptions as Array<Record<string, unknown>> | undefined;
-                if (opts) {
-                  onConfig?.(sid, opts.map((o) => {
+                  })),
+                );
+              }
+            } else if (update.sessionUpdate === "config_option_update") {
+              const c = update as Record<string, unknown>;
+              const opts = c.configOptions as Array<Record<string, unknown>> | undefined;
+              if (opts) {
+                onConfig?.(
+                  sid,
+                  opts.map((o) => {
                     const flatOpts = Array.isArray(o.options)
                       ? (o.options as Array<Record<string, unknown>>).flatMap((item) =>
                           item.group != null
-                            ? ((item.options as Array<Record<string, unknown>>) ?? []).map((sub) => ({
-                                value: String(sub.value ?? ""),
-                                name: String(sub.name ?? ""),
-                                description: sub.description as string | undefined,
-                              }))
-                            : [{ value: String(item.value ?? ""), name: String(item.name ?? ""), description: item.description as string | undefined }],
+                            ? ((item.options as Array<Record<string, unknown>>) ?? []).map(
+                                (sub) => ({
+                                  value: String(sub.value ?? ""),
+                                  name: String(sub.name ?? ""),
+                                  description: sub.description as string | undefined,
+                                }),
+                              )
+                            : [
+                                {
+                                  value: String(item.value ?? ""),
+                                  name: String(item.name ?? ""),
+                                  description: item.description as string | undefined,
+                                },
+                              ],
                         )
                       : [];
                     return {
@@ -361,20 +386,16 @@ export class AcpClient {
                       currentValue: String(o.currentValue ?? ""),
                       options: flatOpts,
                     };
-                  }));
-                }
+                  }),
+                );
               }
+            }
 
-              log.debug(
-                { sessionId: sid, type: update.sessionUpdate },
-                "session update",
-              );
-            },
-          };
-          return client;
-        },
-        stream,
-      );
+            log.debug({ sessionId: sid, type: update.sessionUpdate }, "session update");
+          },
+        };
+        return client;
+      }, stream);
 
       // Initialize the connection
       await this.connection.initialize({
@@ -467,11 +488,7 @@ export class AcpClient {
   /**
    * Send a prompt and collect the full streamed response.
    */
-  async sendPrompt(
-    sessionId: string,
-    prompt: string,
-    timeoutMs?: number,
-  ): Promise<PromptResult> {
+  async sendPrompt(sessionId: string, prompt: string, timeoutMs?: number): Promise<PromptResult> {
     this.checkCircuitBreaker();
 
     const conn = this.requireConnection();
@@ -483,10 +500,7 @@ export class AcpClient {
         // Reset chunk buffer for this turn
         this.sessionChunks.set(sessionId, []);
 
-        this.log.info(
-          { sessionId, promptLength: prompt.length },
-          "sending prompt",
-        );
+        this.log.info({ sessionId, promptLength: prompt.length }, "sending prompt");
 
         const promptPromise = conn.prompt({
           sessionId,
@@ -537,7 +551,13 @@ export class AcpClient {
         if (attempt < ACP_MAX_RETRIES && isTransientAcpError(err)) {
           const delay = 1000 * Math.pow(2, attempt);
           this.log.warn(
-            { sessionId, attempt: attempt + 1, maxRetries: ACP_MAX_RETRIES, delay, error: err instanceof Error ? err.message : String(err) },
+            {
+              sessionId,
+              attempt: attempt + 1,
+              maxRetries: ACP_MAX_RETRIES,
+              delay,
+              error: err instanceof Error ? err.message : String(err),
+            },
             "transient ACP error, retrying",
           );
           await new Promise((resolve) => setTimeout(resolve, delay));

--- a/src/acp/permissions.ts
+++ b/src/acp/permissions.ts
@@ -1,7 +1,4 @@
-import type {
-  RequestPermissionRequest,
-  RequestPermissionResponse,
-} from "@agentclientprotocol/sdk";
+import type { RequestPermissionRequest, RequestPermissionResponse } from "@agentclientprotocol/sdk";
 import type { Logger } from "../logger.js";
 import { logger as defaultLogger } from "../logger.js";
 
@@ -25,12 +22,9 @@ export function createPermissionHandler(
   config: PermissionConfig = DEFAULT_PERMISSION_CONFIG,
   log: Logger = defaultLogger,
 ): (params: RequestPermissionRequest) => Promise<RequestPermissionResponse> {
-  return async (
-    params: RequestPermissionRequest,
-  ): Promise<RequestPermissionResponse> => {
+  return async (params: RequestPermissionRequest): Promise<RequestPermissionResponse> => {
     const toolCall = params.toolCall;
-    const toolName =
-      toolCall && "name" in toolCall ? (toolCall.name as string) : "unknown";
+    const toolName = toolCall && "name" in toolCall ? (toolCall.name as string) : "unknown";
     const options = params.options;
 
     // Find the allow_once option (preferred) or first allow option
@@ -49,9 +43,7 @@ export function createPermissionHandler(
 
     // Check allow patterns
     if (config.allowPatterns.length > 0 && allowOption) {
-      const matched = config.allowPatterns.some((pattern) =>
-        toolName.includes(pattern),
-      );
+      const matched = config.allowPatterns.some((pattern) => toolName.includes(pattern));
       if (matched) {
         log.debug(
           { tool: toolName, optionId: allowOption.optionId },
@@ -63,10 +55,7 @@ export function createPermissionHandler(
 
     // Reject if no auto-approve and no pattern match
     if (rejectOption) {
-      log.warn(
-        { tool: toolName, optionId: rejectOption.optionId },
-        "permission rejected",
-      );
+      log.warn({ tool: toolName, optionId: rejectOption.optionId }, "permission rejected");
       return { outcome: { outcome: "selected", optionId: rejectOption.optionId } };
     }
 

--- a/src/acp/session-config.ts
+++ b/src/acp/session-config.ts
@@ -55,19 +55,14 @@ function toAcpMcpServer(entry: McpServerEntry): McpServer {
 }
 
 /** Load instruction files from disk and concatenate their contents. */
-export async function loadInstructions(
-  filePaths: string[],
-  projectPath: string,
-): Promise<string> {
+export async function loadInstructions(filePaths: string[], projectPath: string): Promise<string> {
   if (filePaths.length === 0) return "";
 
   const log = logger.child({ component: "session-config" });
   const parts: string[] = [];
 
   for (const filePath of filePaths) {
-    const resolved = path.isAbsolute(filePath)
-      ? filePath
-      : path.resolve(projectPath, filePath);
+    const resolved = path.isAbsolute(filePath) ? filePath : path.resolve(projectPath, filePath);
     try {
       const content = await fs.readFile(resolved, "utf-8");
       parts.push(content);
@@ -97,10 +92,7 @@ export async function resolveSessionConfig(
   const mcpServers = allEntries.map(toAcpMcpServer);
 
   // Merge instructions: global + phase-specific
-  const allInstructionPaths = [
-    ...config.globalInstructions,
-    ...(phaseConfig?.instructions ?? []),
-  ];
+  const allInstructionPaths = [...config.globalInstructions, ...(phaseConfig?.instructions ?? [])];
   const instructions = await loadInstructions(allInstructionPaths, config.projectPath);
 
   // Model from phase config

--- a/src/ceremonies/dep-graph.ts
+++ b/src/ceremonies/dep-graph.ts
@@ -14,9 +14,7 @@ export interface ValidationResult {
  * Detect circular dependencies among issues.
  * Returns the circular chains if found, null if no cycles.
  */
-export function detectCircularDependencies(
-  issues: SprintIssue[],
-): number[][] | null {
+export function detectCircularDependencies(issues: SprintIssue[]): number[][] | null {
   const issueSet = new Set(issues.map((i) => i.number));
   const adj = new Map<number, number[]>();
   for (const issue of issues) {
@@ -89,9 +87,7 @@ export function buildExecutionGroups(issues: SprintIssue[]): ExecutionGroup[] {
 
   const cycles = detectCircularDependencies(issues);
   if (cycles) {
-    const detail = cycles
-      .map((c) => c.join(" → ") + " → " + String(c[0]))
-      .join("; ");
+    const detail = cycles.map((c) => c.join(" → ") + " → " + String(c[0])).join("; ");
     throw new Error(`Circular dependencies detected: ${detail}`);
   }
 

--- a/src/ceremonies/merge-pipeline.ts
+++ b/src/ceremonies/merge-pipeline.ts
@@ -28,14 +28,9 @@ export async function mergeCompletedBranches(
   const conflicted: number[] = [];
   const conflictDetails = new Map<number, string[]>();
 
-  const eligible = results.filter(
-    (r) => r.status === "completed" && r.qualityGatePassed,
-  );
+  const eligible = results.filter((r) => r.status === "completed" && r.qualityGatePassed);
 
-  log.info(
-    { total: results.length, eligible: eligible.length },
-    "starting merge pipeline",
-  );
+  log.info({ total: results.length, eligible: eligible.length }, "starting merge pipeline");
 
   for (const result of eligible) {
     const { issueNumber, branch } = result;
@@ -64,27 +59,18 @@ export async function mergeCompletedBranches(
           await deleteBranch(branch);
           log.debug({ branch }, "deleted branch after merge");
         } catch (delErr: unknown) {
-          log.warn(
-            { branch, error: (delErr as Error).message },
-            "failed to delete branch",
-          );
+          log.warn({ branch, error: (delErr as Error).message }, "failed to delete branch");
         }
       }
 
       log.info({ issueNumber, branch }, "merged successfully");
     } catch (err: unknown) {
-      log.error(
-        { issueNumber, branch, error: (err as Error).message },
-        "unexpected merge error",
-      );
+      log.error({ issueNumber, branch, error: (err as Error).message }, "unexpected merge error");
       conflicted.push(issueNumber);
     }
   }
 
-  log.info(
-    { merged: merged.length, conflicted: conflicted.length },
-    "merge pipeline complete",
-  );
+  log.info({ merged: merged.length, conflicted: conflicted.length }, "merge pipeline complete");
 
   return { merged, conflicted, conflictDetails };
 }
@@ -142,10 +128,7 @@ export async function resolveConflictsViaAcp(
 
     return succeeded;
   } catch (err: unknown) {
-    log.error(
-      { branch, error: (err as Error).message },
-      "ACP conflict resolution failed",
-    );
+    log.error({ branch, error: (err as Error).message }, "ACP conflict resolution failed");
     return false;
   }
 }

--- a/src/ceremonies/parallel-dispatcher.ts
+++ b/src/ceremonies/parallel-dispatcher.ts
@@ -5,12 +5,7 @@ import fs from "node:fs/promises";
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import type { AcpClient } from "../acp/client.js";
-import type {
-  SprintConfig,
-  SprintPlan,
-  SprintResult,
-  IssueResult,
-} from "../types.js";
+import type { SprintConfig, SprintPlan, SprintResult, IssueResult } from "../types.js";
 import { buildExecutionGroups } from "./dep-graph.js";
 import { executeIssue } from "./execution.js";
 import { hasConflicts, mergeIssuePR } from "../git/merge.js";
@@ -58,7 +53,10 @@ async function runPreMergeVerification(
     // 3.5. Install dependencies if package.json exists (worktree has no node_modules)
     try {
       await fs.access(path.join(tmpDir, "package.json"));
-      const lockFile = await fs.access(path.join(tmpDir, "package-lock.json")).then(() => true).catch(() => false);
+      const lockFile = await fs
+        .access(path.join(tmpDir, "package-lock.json"))
+        .then(() => true)
+        .catch(() => false);
       const installCmd = lockFile ? "ci" : "install";
       await execFile("npm", [installCmd, "--ignore-scripts"], { cwd: tmpDir, timeout: 120_000 });
     } catch {
@@ -68,8 +66,12 @@ async function runPreMergeVerification(
 
     // 4. Run tests + type check
     const gateConfig = buildQualityGateConfig(config);
-    const testCmd = Array.isArray(gateConfig.testCommand) ? gateConfig.testCommand : gateConfig.testCommand.split(" ");
-    const typeCmd = Array.isArray(gateConfig.typecheckCommand) ? gateConfig.typecheckCommand : gateConfig.typecheckCommand.split(" ");
+    const testCmd = Array.isArray(gateConfig.testCommand)
+      ? gateConfig.testCommand
+      : gateConfig.testCommand.split(" ");
+    const typeCmd = Array.isArray(gateConfig.typecheckCommand)
+      ? gateConfig.typecheckCommand
+      : gateConfig.typecheckCommand.split(" ");
 
     try {
       await execFile(testCmd[0], testCmd.slice(1), { cwd: tmpDir, timeout: 120_000 });
@@ -145,20 +147,47 @@ export async function runParallelExecution(
           // Rebase branch on latest main before pre-merge (main may have changed from earlier merges)
           // Use a temporary worktree to avoid "unstaged changes" errors in the main repo
           let rebaseSucceeded = true;
-          const rebaseTmpDir = path.join(os.tmpdir(), `rebase-${result.branch.replace(/\//g, "-")}-${Date.now()}`);
+          const rebaseTmpDir = path.join(
+            os.tmpdir(),
+            `rebase-${result.branch.replace(/\//g, "-")}-${Date.now()}`,
+          );
           try {
-            await execFile("git", ["fetch", "origin", config.baseBranch], { cwd: config.projectPath });
-            await createWorktree({ path: rebaseTmpDir, branch: `rebase-tmp-${Date.now()}`, base: result.branch });
+            await execFile("git", ["fetch", "origin", config.baseBranch], {
+              cwd: config.projectPath,
+            });
+            await createWorktree({
+              path: rebaseTmpDir,
+              branch: `rebase-tmp-${Date.now()}`,
+              base: result.branch,
+            });
             await execFile("git", ["rebase", `origin/${config.baseBranch}`], { cwd: rebaseTmpDir });
-            await execFile("git", ["push", "origin", `HEAD:${result.branch}`, "--force-with-lease"], { cwd: rebaseTmpDir });
+            await execFile(
+              "git",
+              ["push", "origin", `HEAD:${result.branch}`, "--force-with-lease"],
+              { cwd: rebaseTmpDir },
+            );
           } catch (rebaseErr) {
             rebaseSucceeded = false;
             // Rebase failed (conflicts) — abort and let pre-merge catch it
-            try { await execFile("git", ["rebase", "--abort"], { cwd: rebaseTmpDir }); } catch { /* ignore */ }
-            appendErrorLog("warn", `rebase on latest main failed — issue #${result.issueNumber}`, { issue: result.issueNumber, err: String(rebaseErr) });
-            log.warn({ issue: result.issueNumber, err: String(rebaseErr) }, "rebase on latest main failed — proceeding to pre-merge");
+            try {
+              await execFile("git", ["rebase", "--abort"], { cwd: rebaseTmpDir });
+            } catch {
+              /* ignore */
+            }
+            appendErrorLog("warn", `rebase on latest main failed — issue #${result.issueNumber}`, {
+              issue: result.issueNumber,
+              err: String(rebaseErr),
+            });
+            log.warn(
+              { issue: result.issueNumber, err: String(rebaseErr) },
+              "rebase on latest main failed — proceeding to pre-merge",
+            );
           } finally {
-            try { await removeWorktree(rebaseTmpDir); } catch { /* ignore */ }
+            try {
+              await removeWorktree(rebaseTmpDir);
+            } catch {
+              /* ignore */
+            }
           }
 
           // Pre-merge verification: test feature branch with main merged in
@@ -168,10 +197,28 @@ export async function runParallelExecution(
             if (!rebaseSucceeded && config.maxRetries > 0) {
               const issue = issueMap.get(result.issueNumber);
               if (issue) {
-                log.info({ issue: result.issueNumber }, "rebase conflict — re-executing issue from latest main");
-                await addComment(result.issueNumber, "⚠️ Merge conflict detected. Re-executing from latest main...").catch(() => {});
-                try { await execFile("git", ["push", "origin", "--delete", result.branch], { cwd: config.projectPath }); } catch { /* may not exist */ }
-                try { await execFile("git", ["branch", "-D", result.branch], { cwd: config.projectPath }); } catch { /* ignore */ }
+                log.info(
+                  { issue: result.issueNumber },
+                  "rebase conflict — re-executing issue from latest main",
+                );
+                await addComment(
+                  result.issueNumber,
+                  "⚠️ Merge conflict detected. Re-executing from latest main...",
+                ).catch(() => {});
+                try {
+                  await execFile("git", ["push", "origin", "--delete", result.branch], {
+                    cwd: config.projectPath,
+                  });
+                } catch {
+                  /* may not exist */
+                }
+                try {
+                  await execFile("git", ["branch", "-D", result.branch], {
+                    cwd: config.projectPath,
+                  });
+                } catch {
+                  /* ignore */
+                }
                 const retryResult = await executeIssue(client, config, issue, eventBus);
                 allResults[allResults.length - 1] = retryResult;
                 if (retryResult.status === "completed") {
@@ -183,43 +230,83 @@ export async function runParallelExecution(
                         deleteBranch: config.deleteBranchAfterMerge,
                       });
                       if (retryMerge.success) {
-                        log.info({ issue: retryResult.issueNumber, pr: retryMerge.prNumber }, "PR merged after conflict retry");
+                        log.info(
+                          { issue: retryResult.issueNumber, pr: retryMerge.prNumber },
+                          "PR merged after conflict retry",
+                        );
                         try {
                           const gateConfig = buildQualityGateConfig(config);
-                          const verifyResult = await verifyMainBranch(config.projectPath, gateConfig);
+                          const verifyResult = await verifyMainBranch(
+                            config.projectPath,
+                            gateConfig,
+                          );
                           if (!verifyResult.passed) {
-                            const failedChecks = verifyResult.checks.filter((c) => !c.passed).map((c) => c.name).join(", ");
-                            log.error({ issue: retryResult.issueNumber, failedChecks }, "post-merge verification FAILED on main");
-                            await escalateToStakeholder({
-                              level: "must",
-                              reason: `Post-merge verification failed after merging #${retryResult.issueNumber}`,
-                              detail: `Failed checks: ${failedChecks}. Main branch may be broken.`,
-                              context: { issueNumber: retryResult.issueNumber, branch: retryResult.branch },
-                              timestamp: new Date(),
-                            }, { ntfyEnabled: !!config.ntfy?.enabled, ntfyTopic: config.ntfy?.topic }, eventBus);
+                            const failedChecks = verifyResult.checks
+                              .filter((c) => !c.passed)
+                              .map((c) => c.name)
+                              .join(", ");
+                            log.error(
+                              { issue: retryResult.issueNumber, failedChecks },
+                              "post-merge verification FAILED on main",
+                            );
+                            await escalateToStakeholder(
+                              {
+                                level: "must",
+                                reason: `Post-merge verification failed after merging #${retryResult.issueNumber}`,
+                                detail: `Failed checks: ${failedChecks}. Main branch may be broken.`,
+                                context: {
+                                  issueNumber: retryResult.issueNumber,
+                                  branch: retryResult.branch,
+                                },
+                                timestamp: new Date(),
+                              },
+                              {
+                                ntfyEnabled: !!config.ntfy?.enabled,
+                                ntfyTopic: config.ntfy?.topic,
+                              },
+                              eventBus,
+                            );
                           }
                         } catch (verifyErr: unknown) {
-                          appendErrorLog("error", `post-merge verification failed (retry) — issue #${retryResult.issueNumber}`, { issue: retryResult.issueNumber, err: String(verifyErr) });
-                          log.error({ err: verifyErr, issue: retryResult.issueNumber }, "post-merge verification could not run");
+                          appendErrorLog(
+                            "error",
+                            `post-merge verification failed (retry) — issue #${retryResult.issueNumber}`,
+                            { issue: retryResult.issueNumber, err: String(verifyErr) },
+                          );
+                          log.error(
+                            { err: verifyErr, issue: retryResult.issueNumber },
+                            "post-merge verification could not run",
+                          );
                         }
                         continue;
                       }
-                    } catch { /* fall through to mark failed */ }
+                    } catch {
+                      /* fall through to mark failed */
+                    }
                   }
                 }
                 // Retry didn't resolve the conflict
                 retryResult.status = "failed";
                 retryResult.qualityGatePassed = false;
                 await setLabel(retryResult.issueNumber, "status:blocked");
-                await addComment(retryResult.issueNumber, "**Block reason:** Pre-merge verification failed after conflict retry").catch(() => {});
+                await addComment(
+                  retryResult.issueNumber,
+                  "**Block reason:** Pre-merge verification failed after conflict retry",
+                ).catch(() => {});
                 continue;
               }
             }
-            log.warn({ issue: result.issueNumber, reason: premerge.reason }, "pre-merge verification failed");
+            log.warn(
+              { issue: result.issueNumber, reason: premerge.reason },
+              "pre-merge verification failed",
+            );
             result.status = "failed";
             result.qualityGatePassed = false;
             await setLabel(result.issueNumber, "status:blocked");
-            await addComment(result.issueNumber, `**Block reason:** Pre-merge verification failed — ${premerge.reason ?? "unknown"}`).catch((err) => log.warn({ err: String(err) }, "failed to post block comment"));
+            await addComment(
+              result.issueNumber,
+              `**Block reason:** Pre-merge verification failed — ${premerge.reason ?? "unknown"}`,
+            ).catch((err) => log.warn({ err: String(err) }, "failed to post block comment"));
             continue;
           }
           try {
@@ -237,34 +324,65 @@ export async function runParallelExecution(
               result.status = "failed";
               result.qualityGatePassed = false;
               await setLabel(result.issueNumber, "status:blocked");
-              await addComment(result.issueNumber, `**Block reason:** PR merge failed — ${mergeResult.reason ?? "unknown"}`).catch((err) => log.warn({ err: String(err), issue: result.issueNumber }, "failed to post block reason comment"));
+              await addComment(
+                result.issueNumber,
+                `**Block reason:** PR merge failed — ${mergeResult.reason ?? "unknown"}`,
+              ).catch((err) =>
+                log.warn(
+                  { err: String(err), issue: result.issueNumber },
+                  "failed to post block reason comment",
+                ),
+              );
             } else {
-              log.info({ issue: result.issueNumber, branch: result.branch, pr: mergeResult.prNumber }, "PR merged");
+              log.info(
+                { issue: result.issueNumber, branch: result.branch, pr: mergeResult.prNumber },
+                "PR merged",
+              );
 
               // Post-merge verification: run tests + types on main to catch combinatorial breakage
               try {
                 const gateConfig = buildQualityGateConfig(config);
                 const verifyResult = await verifyMainBranch(config.projectPath, gateConfig);
                 if (!verifyResult.passed) {
-                  const failedChecks = verifyResult.checks.filter((c) => !c.passed).map((c) => c.name).join(", ");
-                  log.error({ issue: result.issueNumber, failedChecks }, "post-merge verification FAILED on main");
-                  await escalateToStakeholder({
-                    level: "must",
-                    reason: `Post-merge verification failed after merging #${result.issueNumber}`,
-                    detail: `Failed checks: ${failedChecks}. Main branch may be broken.`,
-                    context: { issueNumber: result.issueNumber, branch: result.branch },
-                    timestamp: new Date(),
-                  }, { ntfyEnabled: !!config.ntfy?.enabled, ntfyTopic: config.ntfy?.topic }, eventBus);
+                  const failedChecks = verifyResult.checks
+                    .filter((c) => !c.passed)
+                    .map((c) => c.name)
+                    .join(", ");
+                  log.error(
+                    { issue: result.issueNumber, failedChecks },
+                    "post-merge verification FAILED on main",
+                  );
+                  await escalateToStakeholder(
+                    {
+                      level: "must",
+                      reason: `Post-merge verification failed after merging #${result.issueNumber}`,
+                      detail: `Failed checks: ${failedChecks}. Main branch may be broken.`,
+                      context: { issueNumber: result.issueNumber, branch: result.branch },
+                      timestamp: new Date(),
+                    },
+                    { ntfyEnabled: !!config.ntfy?.enabled, ntfyTopic: config.ntfy?.topic },
+                    eventBus,
+                  );
                 }
               } catch (verifyErr: unknown) {
-                appendErrorLog("error", `post-merge verification FAILED — issue #${result.issueNumber}, halting merges`, { issue: result.issueNumber, err: String(verifyErr) });
-                log.error({ err: verifyErr, issue: result.issueNumber }, "post-merge verification could not run — halting further merges");
+                appendErrorLog(
+                  "error",
+                  `post-merge verification FAILED — issue #${result.issueNumber}, halting merges`,
+                  { issue: result.issueNumber, err: String(verifyErr) },
+                );
+                log.error(
+                  { err: verifyErr, issue: result.issueNumber },
+                  "post-merge verification could not run — halting further merges",
+                );
                 break;
               }
             }
           } catch (err: unknown) {
             mergeConflicts++;
-            appendErrorLog("error", `merge error — issue #${result.issueNumber}`, { issue: result.issueNumber, err: String(err) });
+            appendErrorLog("error", `merge error — issue #${result.issueNumber}`, {
+              issue: result.issueNumber,
+              err: String(err),
+            });
             log.error({ issue: result.issueNumber, err }, "merge error");
             result.status = "failed";
             result.qualityGatePassed = false;
@@ -301,13 +419,17 @@ export async function runParallelExecution(
 
       // Escalate with ntfy notification
       const failedIssueNumbers = failures.map((f) => `#${f.issueNumber}`).join(", ");
-      await escalateToStakeholder({
-        level: "must",
-        reason: `All issues in execution group ${group.group} failed`,
-        detail: `Failed issues: ${failedIssueNumbers}. Sprint execution paused until stakeholder intervenes. Unblock issues and resume to retry.`,
-        context: { group: group.group, failures: failures.length },
-        timestamp: new Date(),
-      }, { ntfyEnabled: !!config.ntfy?.enabled, ntfyTopic: config.ntfy?.topic }, eventBus);
+      await escalateToStakeholder(
+        {
+          level: "must",
+          reason: `All issues in execution group ${group.group} failed`,
+          detail: `Failed issues: ${failedIssueNumbers}. Sprint execution paused until stakeholder intervenes. Unblock issues and resume to retry.`,
+          context: { group: group.group, failures: failures.length },
+          timestamp: new Date(),
+        },
+        { ntfyEnabled: !!config.ntfy?.enabled, ntfyTopic: config.ntfy?.topic },
+        eventBus,
+      );
 
       // Emit event so runner can handle pause
       eventBus?.emitTyped("sprint:error", {
@@ -319,14 +441,11 @@ export async function runParallelExecution(
   }
 
   const totalGroupSize = groups.reduce((sum, g) => sum + g.issues.length, 0);
-  const parallelizationRatio =
-    groups.length > 0 ? totalGroupSize / groups.length : 1;
+  const parallelizationRatio = groups.length > 0 ? totalGroupSize / groups.length : 1;
 
   const durations = allResults.map((r) => r.duration_ms);
   const avgWorktreeLifetime =
-    durations.length > 0
-      ? durations.reduce((a, b) => a + b, 0) / durations.length
-      : 0;
+    durations.length > 0 ? durations.reduce((a, b) => a + b, 0) / durations.length : 0;
 
   return {
     results: allResults,

--- a/src/ceremonies/quality-retry.ts
+++ b/src/ceremonies/quality-retry.ts
@@ -1,10 +1,6 @@
 import type { AcpClient } from "../acp/client.js";
 import { resolveSessionConfig } from "../acp/session-config.js";
-import type {
-  SprintConfig,
-  SprintIssue,
-  QualityResult,
-} from "../types.js";
+import type { SprintConfig, SprintIssue, QualityResult } from "../types.js";
 import { runQualityGate } from "../enforcement/quality-gate.js";
 import type { QualityGateConfig } from "../enforcement/quality-gate.js";
 import { logger } from "../logger.js";
@@ -92,12 +88,7 @@ export async function handleQualityFailure(
   const branch = buildBranch(config, issue.number);
   const gateConfig = buildQualityGateConfig(config);
   gateConfig.expectedFiles = issue.expectedFiles;
-  const newResult = await runQualityGate(
-    gateConfig,
-    worktreePath,
-    branch,
-    config.baseBranch,
-  );
+  const newResult = await runQualityGate(gateConfig, worktreePath, branch, config.baseBranch);
 
   if (newResult.passed) {
     return newResult;

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -18,6 +18,7 @@ import { holisticDriftCheck } from "../enforcement/drift-control.js";
 import { getNextOpenMilestone } from "../github/milestones.js";
 import { SprintRunner } from "../runner.js";
 import { SprintEventBus } from "../events.js";
+import { attachSprintNotifications } from "../notifications/sprint-notifications.js";
 import { logger, redirectLogToFile, initErrorLogFile } from "../logger.js";
 import type { SprintIssue } from "../types.js";
 import {
@@ -310,6 +311,7 @@ function registerWeb(program: Command): void {
 
         const eventBus = new SprintEventBus();
         const sprintConfig = buildSprintConfig(config, initialSprint);
+        attachSprintNotifications(eventBus, sprintConfig.ntfy);
         const runner = new SprintRunner(sprintConfig, eventBus);
 
         // Load saved state

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -11,12 +11,17 @@ import type { SprintConfig } from "../types.js";
 /** Parse owner/name from a git remote URL (HTTPS or SSH). */
 function parseGitRemote(cwd: string): { owner: string; name: string } {
   try {
-    const url = execFileSync("git", ["remote", "get-url", "origin"], { cwd, encoding: "utf-8" }).trim();
+    const url = execFileSync("git", ["remote", "get-url", "origin"], {
+      cwd,
+      encoding: "utf-8",
+    }).trim();
     // HTTPS: https://github.com/owner/repo.git
     // SSH:   git@github.com:owner/repo.git
     const match = url.match(/[/:]([\w.-]+)\/([\w.-]+?)(?:\.git)?$/);
     if (match) return { owner: match[1]!, name: match[2]! };
-  } catch { /* ignore — return empty */ }
+  } catch {
+    /* ignore — return empty */
+  }
   return { owner: "", name: "" };
 }
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -83,12 +83,7 @@ export function initProject(options: InitOptions): InitResult {
   return result;
 }
 
-function copyDirRecursive(
-  src: string,
-  dest: string,
-  force: boolean,
-  result: InitResult,
-): void {
+function copyDirRecursive(src: string, dest: string, force: boolean, result: InitResult): void {
   fs.mkdirSync(dest, { recursive: true });
 
   for (const entry of fs.readdirSync(src, { withFileTypes: true })) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -88,7 +88,9 @@ const QualityGatesSchema = z.object({
   max_diff_lines: z.number().int().min(1).default(1000),
   test_command: z.union([z.string(), z.array(z.string())]).default(["npm", "run", "test"]),
   lint_command: z.union([z.string(), z.array(z.string())]).default(["npm", "run", "lint"]),
-  typecheck_command: z.union([z.string(), z.array(z.string())]).default(["npm", "run", "typecheck"]),
+  typecheck_command: z
+    .union([z.string(), z.array(z.string())])
+    .default(["npm", "run", "typecheck"]),
   build_command: z.union([z.string(), z.array(z.string())]).default(["npm", "run", "build"]),
   require_challenger: z.boolean().default(true),
 });
@@ -103,10 +105,9 @@ const EscalationSchema = z
       })
       .default({}),
   })
-  .refine(
-    (cfg) => !cfg.notifications.ntfy || cfg.notifications.ntfy_topic.length > 0,
-    { message: "ntfy_topic must be non-empty when ntfy notifications are enabled" },
-  );
+  .refine((cfg) => !cfg.notifications.ntfy || cfg.notifications.ntfy_topic.length > 0, {
+    message: "ntfy_topic must be non-empty when ntfy notifications are enabled",
+  });
 
 const GitSchema = z.object({
   worktree_base: z.string().min(1).default("../sprint-worktrees"),
@@ -114,10 +115,9 @@ const GitSchema = z.object({
     .string()
     .min(1)
     .default("{prefix}/{sprint}/issue-{issue}")
-    .refine(
-      (p) => p.includes("{issue}"),
-      { message: "branch_pattern must contain {issue} placeholder" },
-    ),
+    .refine((p) => p.includes("{issue}"), {
+      message: "branch_pattern must contain {issue} placeholder",
+    }),
   auto_merge: z.boolean().default(true),
   squash_merge: z.boolean().default(true),
   delete_branch_after_merge: z.boolean().default(true),
@@ -148,7 +148,10 @@ export type ConfigFile = z.infer<typeof ConfigFileSchema>;
 
 /** Convert a sprint prefix to a file-system-safe slug (e.g. "Test Sprint" → "test-sprint"). */
 export function prefixToSlug(prefix: string): string {
-  return prefix.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+  return prefix
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "");
 }
 
 // --- Environment variable substitution ---
@@ -187,5 +190,3 @@ export function loadConfig(configPath?: string): ConfigFile {
 
   return config;
 }
-
-

--- a/src/dashboard/chat-manager.ts
+++ b/src/dashboard/chat-manager.ts
@@ -34,18 +34,45 @@ export interface ChatManagerOptions {
   timeoutMs?: number;
   onStreamChunk?: (sessionId: string, text: string) => void;
   onThinkingChunk?: (sessionId: string, text: string) => void;
-  onToolCall?: (sessionId: string, toolCall: { toolCallId: string; title: string; status?: string; kind?: string }) => void;
+  onToolCall?: (
+    sessionId: string,
+    toolCall: { toolCallId: string; title: string; status?: string; kind?: string },
+  ) => void;
   onUsageUpdate?: (sessionId: string, usage: { used: number; size: number }) => void;
   onModeChange?: (sessionId: string, modeId: string) => void;
-  onPlanUpdate?: (sessionId: string, plan: { entries: Array<{ content: string; priority: string; status: string }> }) => void;
-  onCommandsUpdate?: (sessionId: string, commands: Array<{ name: string; description: string; hint?: string }>) => void;
-  onConfigUpdate?: (sessionId: string, configs: Array<{ id: string; name: string; category?: string; currentValue: string; options: Array<{ value: string; name: string }> }>) => void;
+  onPlanUpdate?: (
+    sessionId: string,
+    plan: { entries: Array<{ content: string; priority: string; status: string }> },
+  ) => void;
+  onCommandsUpdate?: (
+    sessionId: string,
+    commands: Array<{ name: string; description: string; hint?: string }>,
+  ) => void;
+  onConfigUpdate?: (
+    sessionId: string,
+    configs: Array<{
+      id: string;
+      name: string;
+      category?: string;
+      currentValue: string;
+      options: Array<{ value: string; name: string }>;
+    }>,
+  ) => void;
 }
 
 export class ChatManager {
   private client: AcpClient | null = null;
   private sessions = new Map<string, ChatSession>();
-  private pendingConfigs = new Map<string, Array<{ id: string; name: string; category?: string; currentValue: string; options: Array<{ value: string; name: string }> }>>();
+  private pendingConfigs = new Map<
+    string,
+    Array<{
+      id: string;
+      name: string;
+      category?: string;
+      currentValue: string;
+      options: Array<{ value: string; name: string }>;
+    }>
+  >();
   private readonly options: ChatManagerOptions;
   private connected = false;
 

--- a/src/dashboard/frontend/src/notifications.ts
+++ b/src/dashboard/frontend/src/notifications.ts
@@ -40,7 +40,10 @@ export function notify(title: string, body: string, tag?: string): void {
 }
 
 /** Map sprint events to notifications. Called from handleSprintEvent. */
-export function notifySprintEvent(eventName: string, payload: Record<string, unknown> | undefined): void {
+export function notifySprintEvent(
+  eventName: string,
+  payload: Record<string, unknown> | undefined,
+): void {
   if (!canNotify()) return;
 
   const p = payload ?? {};
@@ -55,7 +58,11 @@ export function notifySprintEvent(eventName: string, payload: Record<string, unk
       break;
 
     case "issue:fail":
-      notify("❌ Issue Failed", `#${p.issueNumber}: ${p.reason ?? "unknown error"}`, `issue-${p.issueNumber}`);
+      notify(
+        "❌ Issue Failed",
+        `#${p.issueNumber}: ${p.reason ?? "unknown error"}`,
+        `issue-${p.issueNumber}`,
+      );
       break;
 
     case "sprint:complete":

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -80,8 +80,8 @@ export interface DashboardStore {
   sprintLimit: number; // 0 = infinite
 
   // Backlog planning feedback
-  backlogPending: Set<number>;   // currently being added
-  backlogPlanned: Set<number>;   // confirmed added (hide from list)
+  backlogPending: Set<number>; // currently being added
+  backlogPlanned: Set<number>; // confirmed added (hide from list)
 
   // Heartbeat
   heartbeat: {
@@ -131,7 +131,10 @@ let sprintFetchVersion = 0;
 
 function createWebSocket(set: SetFn, get: GetFn): void {
   if (ws && (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN)) return;
-  if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
   const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
   const url = `${protocol}//${window.location.host}`;
   ws = new WebSocket(url);
@@ -166,7 +169,10 @@ function createWebSocket(set: SetFn, get: GetFn): void {
       chatConfig: {},
     });
     ws = null;
-    reconnectTimer = setTimeout(() => { reconnectTimer = null; createWebSocket(set, get); }, 2000);
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      createWebSocket(set, get);
+    }, 2000);
   };
 
   ws.onmessage = (event) => {
@@ -180,9 +186,7 @@ function createWebSocket(set: SetFn, get: GetFn): void {
 }
 
 type SetFn = (
-  partial:
-    | Partial<DashboardStore>
-    | ((state: DashboardStore) => Partial<DashboardStore>),
+  partial: Partial<DashboardStore> | ((state: DashboardStore) => Partial<DashboardStore>),
 ) => void;
 type GetFn = () => DashboardStore;
 
@@ -193,9 +197,7 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
       const activeSprintNumber = payload.sprintNumber;
       const store = get();
       const viewingSprintNumber =
-        store.viewingSprintNumber === 0
-          ? activeSprintNumber
-          : store.viewingSprintNumber;
+        store.viewingSprintNumber === 0 ? activeSprintNumber : store.viewingSprintNumber;
       set({
         state: payload,
         activeSprintNumber,
@@ -215,8 +217,7 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
         // Auto-follow: if user is viewing the current active sprint (or 0 = auto),
         // switch viewing to the new active sprint so the dashboard follows along.
         const shouldFollow =
-          store.viewingSprintNumber === 0 ||
-          store.viewingSprintNumber === store.activeSprintNumber;
+          store.viewingSprintNumber === 0 || store.viewingSprintNumber === store.activeSprintNumber;
         set({
           activeSprintNumber: p.activeSprintNumber,
           ...(shouldFollow ? { viewingSprintNumber: p.activeSprintNumber } : {}),
@@ -245,11 +246,13 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
     }
 
     case "session:status": {
-      const p = msg.payload as {
-        sessionId: string;
-        action: string;
-        message?: string;
-      } | undefined;
+      const p = msg.payload as
+        | {
+            sessionId: string;
+            action: string;
+            message?: string;
+          }
+        | undefined;
       if (p) {
         const store = get();
         const output = new Map(store.sessionOutput);
@@ -279,9 +282,7 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
         }
 
         const pending = get().pendingChatMessage;
-        const initialMessages: ChatMessage[] = pending
-          ? [{ role: "user", content: pending }]
-          : [];
+        const initialMessages: ChatMessage[] = pending ? [{ role: "user", content: pending }] : [];
         set((prev) => ({
           ...prev,
           chatSessions: [...prev.chatSessions, p],
@@ -317,10 +318,12 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
     }
 
     case "chat:done": {
-      const p = msg.payload as {
-        sessionId: string;
-        response: string;
-      } | undefined;
+      const p = msg.payload as
+        | {
+            sessionId: string;
+            response: string;
+          }
+        | undefined;
       if (p) {
         set((prev) => {
           const msgs = prev.chatMessages[p.sessionId] ?? [];
@@ -334,10 +337,7 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
             ...prev,
             chatMessages: {
               ...prev.chatMessages,
-              [p.sessionId]: [
-                ...msgs,
-                { role: "assistant", content: p.response.trimStart() },
-              ],
+              [p.sessionId]: [...msgs, { role: "assistant", content: p.response.trimStart() }],
             },
             chatStreaming: streaming,
             chatThinking: thinking,
@@ -363,14 +363,16 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
     }
 
     case "chat:tool-call": {
-      const p = msg.payload as {
-        sessionId: string;
-        toolCallId: string;
-        title?: string;
-        status?: string;
-        kind?: string;
-        locations?: Array<{ uri?: string; path?: string; line?: number }>;
-      } | undefined;
+      const p = msg.payload as
+        | {
+            sessionId: string;
+            toolCallId: string;
+            title?: string;
+            status?: string;
+            kind?: string;
+            locations?: Array<{ uri?: string; path?: string; line?: number }>;
+          }
+        | undefined;
       if (p) {
         set((prev) => {
           const existing = prev.chatToolCalls[p.sessionId] ?? [];
@@ -387,9 +389,8 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
             kind: p.kind ?? prev_entry?.kind,
             locations: locs ?? prev_entry?.locations,
           };
-          const updated = idx >= 0
-            ? existing.map((t, i) => (i === idx ? entry : t))
-            : [...existing, entry];
+          const updated =
+            idx >= 0 ? existing.map((t, i) => (i === idx ? entry : t)) : [...existing, entry];
           return {
             ...prev,
             chatToolCalls: { ...prev.chatToolCalls, [p.sessionId]: updated },
@@ -400,11 +401,13 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
     }
 
     case "chat:usage": {
-      const p = msg.payload as {
-        sessionId: string;
-        used: number;
-        size: number;
-      } | undefined;
+      const p = msg.payload as
+        | {
+            sessionId: string;
+            used: number;
+            size: number;
+          }
+        | undefined;
       if (p) {
         set((prev) => ({
           ...prev,
@@ -461,10 +464,12 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
     }
 
     case "chat:error": {
-      const p = msg.payload as {
-        sessionId?: string;
-        error: string;
-      } | undefined;
+      const p = msg.payload as
+        | {
+            sessionId?: string;
+            error: string;
+          }
+        | undefined;
       if (p) {
         const sid = p.sessionId ?? "__global__";
         set((prev) => {
@@ -475,10 +480,7 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
             ...prev,
             chatMessages: {
               ...prev.chatMessages,
-              [sid]: [
-                ...msgs,
-                { role: "system", content: `Error: ${p.error}` },
-              ],
+              [sid]: [...msgs, { role: "system", content: `Error: ${p.error}` }],
             },
             chatStreaming: streaming,
             // Show error in side panel even if no session was created
@@ -528,12 +530,7 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
   }
 }
 
-function handleSprintEvent(
-  name: string,
-  payload: unknown,
-  set: SetFn,
-  get: GetFn,
-): void {
+function handleSprintEvent(name: string, payload: unknown, set: SetFn, get: GetFn): void {
   const p = payload as Record<string, unknown> | undefined;
   const store = get();
 
@@ -609,9 +606,7 @@ function handleSprintEvent(
       const failNum = p?.issueNumber as number | undefined;
       if (failNum != null) {
         const issues = get().issues.map((i) =>
-          i.number === failNum
-            ? { ...i, status: "failed", failReason: p?.reason as string }
-            : i,
+          i.number === failNum ? { ...i, status: "failed", failReason: p?.reason as string } : i,
         );
         set({ issues });
       }
@@ -632,7 +627,10 @@ function handleSprintEvent(
     case "sprint:cancelled": {
       const returned = Array.isArray(p?.returnedIssues) ? (p.returnedIssues as number[]) : [];
       set((prev) => ({ ...prev, state: { ...prev.state, phase: "cancelled" } }));
-      addActivity(set, get(), "sprint",
+      addActivity(
+        set,
+        get(),
+        "sprint",
         `Sprint cancelled — ${returned.length} issue(s) returned to backlog`,
         returned.length > 0 ? `Issues: ${returned.join(", ")}` : null,
         "done",
@@ -661,10 +659,11 @@ function handleSprintEvent(
         refinement: "Refining backlog issues",
         planning: "Planning sprint scope",
       };
-      const desc = ROLE_DESCRIPTIONS[role] ?? `${role.charAt(0).toUpperCase() + role.slice(1)} Agent`;
+      const desc =
+        ROLE_DESCRIPTIONS[role] ?? `${role.charAt(0).toUpperCase() + role.slice(1)} Agent`;
       // Look up issue title from store
       const issueTitle = issueNum
-        ? get().issues.find((i) => i.number === issueNum)?.title ?? null
+        ? (get().issues.find((i) => i.number === issueNum)?.title ?? null)
         : null;
       const label = issueNum ? `${desc} — #${issueNum}` : desc;
       const detail = [issueTitle, model].filter(Boolean).join(" · ") || null;
@@ -675,12 +674,20 @@ function handleSprintEvent(
     case "session:end": {
       const outcome = (p?.outcome as string) ?? "completed";
       const acts = get().activities;
-      const idx = [...acts].reverse().findIndex((a) => a.type === "session" && a.status === "active");
+      const idx = [...acts]
+        .reverse()
+        .findIndex((a) => a.type === "session" && a.status === "active");
       if (idx >= 0) {
         const realIdx = acts.length - 1 - idx;
         const updated = [...acts];
-        const endStatus = outcome === "failed" || outcome === "changes_requested" ? "failed" : "done";
-        const suffix = outcome === "changes_requested" ? " — changes requested" : outcome === "failed" ? " — failed" : "";
+        const endStatus =
+          outcome === "failed" || outcome === "changes_requested" ? "failed" : "done";
+        const suffix =
+          outcome === "changes_requested"
+            ? " — changes requested"
+            : outcome === "failed"
+              ? " — failed"
+              : "";
         updated[realIdx] = {
           ...updated[realIdx]!,
           status: endStatus,
@@ -697,7 +704,10 @@ function handleSprintEvent(
       break;
 
     case "sprint:resumed":
-      set((prev) => ({ ...prev, state: { ...prev.state, phase: p?.phase as string ?? "execute" } }));
+      set((prev) => ({
+        ...prev,
+        state: { ...prev.state, phase: (p?.phase as string) ?? "execute" },
+      }));
       addActivity(set, get(), "sprint", `Sprint resumed → ${p?.phase}`, null, "active");
       break;
 
@@ -706,10 +716,7 @@ function handleSprintEvent(
       const logLevel = (p?.level as string) ?? "info";
       set((prev) => ({
         ...prev,
-        logs: [
-          ...prev.logs,
-          { level: logLevel, message: logMsg, time: new Date() },
-        ],
+        logs: [...prev.logs, { level: logLevel, message: logMsg, time: new Date() }],
       }));
       // Also surface info+ log messages in the activity feed
       if (logLevel !== "debug" && logMsg) {

--- a/src/dashboard/issue-cache.ts
+++ b/src/dashboard/issue-cache.ts
@@ -105,19 +105,25 @@ export class SprintIssueCache {
       if (this.options.loadState) {
         const state = this.options.loadState(sprintNumber);
         if (state?.result?.results && state.result.results.length > 0) {
-          this.cache.set(sprintNumber, state.result.results.map((r) => ({
-            number: r.issueNumber,
-            title: `Issue #${r.issueNumber}`,
-            status: (r.status === "completed" ? "done" : "failed") as CachedIssue["status"],
-          })));
+          this.cache.set(
+            sprintNumber,
+            state.result.results.map((r) => ({
+              number: r.issueNumber,
+              title: `Issue #${r.issueNumber}`,
+              status: (r.status === "completed" ? "done" : "failed") as CachedIssue["status"],
+            })),
+          );
           return;
         }
         if (state?.plan?.sprint_issues && state.plan.sprint_issues.length > 0) {
-          this.cache.set(sprintNumber, state.plan.sprint_issues.map((i) => ({
-            number: i.number,
-            title: i.title,
-            status: "planned" as const,
-          })));
+          this.cache.set(
+            sprintNumber,
+            state.plan.sprint_issues.map((i) => ({
+              number: i.number,
+              title: i.title,
+              status: "planned" as const,
+            })),
+          );
           return;
         }
       }
@@ -129,11 +135,14 @@ export class SprintIssueCache {
       });
 
       if (ghIssues.length > 0) {
-        this.cache.set(sprintNumber, ghIssues.map((i: GitHubIssue) => ({
-          number: i.number,
-          title: i.title,
-          status: (i.state === "closed" ? "done" : "planned") as CachedIssue["status"],
-        })));
+        this.cache.set(
+          sprintNumber,
+          ghIssues.map((i: GitHubIssue) => ({
+            number: i.number,
+            title: i.title,
+            status: (i.state === "closed" ? "done" : "planned") as CachedIssue["status"],
+          })),
+        );
       } else {
         // No issues found — cache empty array to avoid re-fetching
         this.cache.set(sprintNumber, []);

--- a/src/dashboard/session-control.ts
+++ b/src/dashboard/session-control.ts
@@ -63,7 +63,7 @@ export class SessionController {
 
   /** Get list of sessions with pending messages. */
   getActiveSessions(): string[] {
-    return [...this.queues.keys()].filter(id => this.hasPending(id));
+    return [...this.queues.keys()].filter((id) => this.hasPending(id));
   }
 }
 

--- a/src/dashboard/session-logger.ts
+++ b/src/dashboard/session-logger.ts
@@ -24,10 +24,7 @@ export interface SessionLogOptions {
  * Write a chat session transcript to the role's log directory.
  * Creates directories as needed. Silently returns on error (non-critical).
  */
-export function writeSessionLog(
-  session: ChatSession,
-  options: SessionLogOptions,
-): void {
+export function writeSessionLog(session: ChatSession, options: SessionLogOptions): void {
   try {
     if (session.messages.length === 0) {
       log.debug({ sessionId: session.id }, "Skipping empty session log");
@@ -52,10 +49,7 @@ export function writeSessionLog(
     const content = formatSessionLog(session);
     fs.writeFileSync(filepath, content, "utf-8");
 
-    log.info(
-      { sessionId: session.id, role: session.role, filepath },
-      "Session log written",
-    );
+    log.info({ sessionId: session.id, role: session.role, filepath }, "Session log written");
   } catch (err: unknown) {
     log.warn({ err, sessionId: session.id }, "Failed to write session log");
   }

--- a/src/documentation/huddle.ts
+++ b/src/documentation/huddle.ts
@@ -30,9 +30,10 @@ function formatQualityChecks(entry: HuddleEntry): string {
 
 function formatZeroChangeDiagnostic(diag: ZeroChangeDiagnostic): string {
   const outcomeIcon = diag.workerOutcome === "worker-error" ? "🐛" : "🔇";
-  const outcomeLabel = diag.workerOutcome === "worker-error" ? "Worker Error" : "Task Not Applicable";
+  const outcomeLabel =
+    diag.workerOutcome === "worker-error" ? "Worker Error" : "Task Not Applicable";
   const timeoutIndicator = diag.timedOut ? " ⏱ Timed out" : "";
-  
+
   const lines = [
     `**${outcomeIcon} ${outcomeLabel}**${timeoutIndicator}`,
     "",
@@ -44,7 +45,7 @@ function formatZeroChangeDiagnostic(diag: ZeroChangeDiagnostic): string {
     "```",
     "</details>",
   ];
-  
+
   return lines.join("\n");
 }
 
@@ -89,11 +90,7 @@ export function formatHuddleComment(entry: HuddleEntryWithDiag): string {
     lines.push("", formatZeroChangeDiagnostic(entry.zeroChangeDiagnostic));
   }
 
-  lines.push(
-    "",
-    `**Files Changed** (${entry.filesChanged.length}):`,
-    files,
-  );
+  lines.push("", `**Files Changed** (${entry.filesChanged.length}):`, files);
 
   if (entry.prStats) {
     lines.push(
@@ -128,7 +125,9 @@ export function formatSprintLogEntry(entry: HuddleEntryWithDiag): string {
   ];
 
   if (entry.prStats) {
-    lines.push(`- **PR**: #${entry.prStats.prNumber} (+${entry.prStats.additions} −${entry.prStats.deletions})`);
+    lines.push(
+      `- **PR**: #${entry.prStats.prNumber} (+${entry.prStats.additions} −${entry.prStats.deletions})`,
+    );
   }
 
   if (entry.errorMessage) {

--- a/src/documentation/velocity.ts
+++ b/src/documentation/velocity.ts
@@ -59,10 +59,7 @@ export function readVelocity(filePath: string = DEFAULT_FILE_PATH): VelocityEntr
     .filter((e): e is VelocityEntry => e !== null);
 }
 
-export function appendVelocity(
-  entry: VelocityEntry,
-  filePath: string = DEFAULT_FILE_PATH,
-): void {
+export function appendVelocity(entry: VelocityEntry, filePath: string = DEFAULT_FILE_PATH): void {
   try {
     const dir = path.dirname(filePath);
     fs.mkdirSync(dir, { recursive: true });

--- a/src/enforcement/drift-control.ts
+++ b/src/enforcement/drift-control.ts
@@ -69,9 +69,7 @@ export async function holisticDriftCheck(
   const totalFilesChanged = allChangedFiles.length;
   const plannedChanges = totalFilesChanged - unplannedChanges.length;
   const driftPercentage =
-    totalFilesChanged > 0
-      ? (unplannedChanges.length / totalFilesChanged) * 100
-      : 0;
+    totalFilesChanged > 0 ? (unplannedChanges.length / totalFilesChanged) * 100 : 0;
 
   const report: DriftReport = {
     totalFilesChanged,

--- a/src/enforcement/quality-gate.ts
+++ b/src/enforcement/quality-gate.ts
@@ -75,9 +75,7 @@ export async function runQualityGate(
         name: "tests-exist",
         passed: testFiles.length > 0,
         detail:
-          testFiles.length > 0
-            ? `Found ${testFiles.length} test file(s)`
-            : "No test files found",
+          testFiles.length > 0 ? `Found ${testFiles.length} test file(s)` : "No test files found",
         category: "test",
       });
     } catch (err) {

--- a/src/events.ts
+++ b/src/events.ts
@@ -12,7 +12,10 @@ export interface SprintEngineEvents {
   "issue:fail": { issueNumber: number; reason: string; duration_ms: number };
   "worker:output": { sessionId: string; text: string };
   "session:start": { sessionId: string; role: string; issueNumber?: number; model?: string };
-  "session:end": { sessionId: string; outcome?: "completed" | "approved" | "changes_requested" | "failed" };
+  "session:end": {
+    sessionId: string;
+    outcome?: "completed" | "approved" | "changes_requested" | "failed";
+  };
   "sprint:start": { sprintNumber: number; resumed?: boolean };
   "sprint:planned": { issues: { number: number; title: string }[] };
   "sprint:complete": { sprintNumber: number };
@@ -21,8 +24,14 @@ export interface SprintEngineEvents {
   "sprint:error": { error: string };
   "sprint:paused": Record<string, never>;
   "sprint:resumed": { phase: SprintPhase };
-  "log": { level: "info" | "warn" | "error"; message: string };
-  "heartbeat:tick": { sprintNumber: number | null; phase: SprintPhase | null; healthy: boolean; staleLock: boolean; lastTickAt: string };
+  log: { level: "info" | "warn" | "error"; message: string };
+  "heartbeat:tick": {
+    sprintNumber: number | null;
+    phase: SprintPhase | null;
+    healthy: boolean;
+    staleLock: boolean;
+    lastTickAt: string;
+  };
   "heartbeat:stale": { sprintNumber: number; phase: SprintPhase; staleSinceMs: number };
   "heartbeat:recovered": { sprintNumber: number; action: string };
 }

--- a/src/git/diff-analysis.ts
+++ b/src/git/diff-analysis.ts
@@ -8,19 +8,12 @@ const execFile = promisify(execFileCb);
 /**
  * Get lines changed, files changed between two branches.
  */
-export async function diffStat(
-  branch: string,
-  base: string,
-): Promise<DiffStat> {
+export async function diffStat(branch: string, base: string): Promise<DiffStat> {
   const log = logger.child({ module: "diff-analysis" });
 
   let stdout: string;
   try {
-    const result = await execFile("git", [
-      "diff",
-      "--numstat",
-      `${base}...${branch}`,
-    ]);
+    const result = await execFile("git", ["diff", "--numstat", `${base}...${branch}`]);
     stdout = result.stdout;
   } catch (err: unknown) {
     log.warn({ branch, base, err }, "git diff failed — returning empty diff");
@@ -57,10 +50,7 @@ export async function diffStat(
  * List changed file paths between a branch and an optional base.
  * If base is omitted, diffs against HEAD.
  */
-export async function getChangedFiles(
-  branch: string,
-  base?: string,
-): Promise<string[]> {
+export async function getChangedFiles(branch: string, base?: string): Promise<string[]> {
   const log = logger.child({ module: "diff-analysis" });
 
   // Ensure we have the latest refs before comparing
@@ -73,11 +63,7 @@ export async function getChangedFiles(
   const rangeSpec = base ? `${base}...${branch}` : branch;
   let stdout: string;
   try {
-    const result = await execFile("git", [
-      "diff",
-      "--name-only",
-      rangeSpec,
-    ]);
+    const result = await execFile("git", ["diff", "--name-only", rangeSpec]);
     stdout = result.stdout;
   } catch (err: unknown) {
     log.warn({ branch, base, err }, "git diff failed — returning empty file list");

--- a/src/git/merge.ts
+++ b/src/git/merge.ts
@@ -31,11 +31,16 @@ export async function getPRStats(branch: string): Promise<PRStats | undefined> {
   const log = logger.child({ module: "merge" });
   try {
     const json = await execGh([
-      "pr", "list",
-      "--head", branch,
-      "--state", "all",
-      "--json", "number,additions,deletions,changedFiles",
-      "--limit", "1",
+      "pr",
+      "list",
+      "--head",
+      branch,
+      "--state",
+      "all",
+      "--json",
+      "number,additions,deletions,changedFiles",
+      "--limit",
+      "1",
     ]);
     const prs = JSON.parse(json) as PRStats[];
     if (prs.length > 0) {
@@ -57,11 +62,16 @@ export async function getPRStatus(
   const log = logger.child({ module: "merge" });
   try {
     const json = await execGh([
-      "pr", "list",
-      "--head", branch,
-      "--state", "all",
-      "--json", "number,state",
-      "--limit", "1",
+      "pr",
+      "list",
+      "--head",
+      branch,
+      "--state",
+      "all",
+      "--json",
+      "number,state",
+      "--limit",
+      "1",
     ]);
     const prs = JSON.parse(json) as { number: number; state: "MERGED" | "CLOSED" | "OPEN" }[];
     if (prs.length > 0) {
@@ -87,11 +97,16 @@ export async function mergeIssuePR(
   let prNumber: number | undefined;
   try {
     const json = await execGh([
-      "pr", "list",
-      "--head", branch,
-      "--state", "open",
-      "--json", "number",
-      "--limit", "1",
+      "pr",
+      "list",
+      "--head",
+      branch,
+      "--state",
+      "open",
+      "--json",
+      "number",
+      "--limit",
+      "1",
     ]);
     const prs = JSON.parse(json) as { number: number }[];
     if (prs.length > 0) {
@@ -178,21 +193,20 @@ export async function mergeBranch(
     if (output.includes("CONFLICT") || output.includes("Merge conflict")) {
       // Gather conflict file list
       const conflictFiles = await getConflictFiles();
-      log.warn(
-        { source, target, conflictFiles },
-        "merge produced conflicts",
-      );
+      log.warn({ source, target, conflictFiles }, "merge produced conflicts");
 
       // Abort the failed merge
-      await execFile("git", ["merge", "--abort"]).catch((err) => log.debug({ err: String(err) }, "merge --abort failed (non-critical)"));
+      await execFile("git", ["merge", "--abort"]).catch((err) =>
+        log.debug({ err: String(err) }, "merge --abort failed (non-critical)"),
+      );
       return { success: false, conflictFiles };
     }
 
     // Abort any partial merge state
-    await execFile("git", ["merge", "--abort"]).catch((err) => log.debug({ err: String(err) }, "merge --abort cleanup failed"));
-    throw new Error(
-      `Failed to merge '${source}' into '${target}': ${message}`,
+    await execFile("git", ["merge", "--abort"]).catch((err) =>
+      log.debug({ err: String(err) }, "merge --abort cleanup failed"),
     );
+    throw new Error(`Failed to merge '${source}' into '${target}': ${message}`);
   }
 }
 
@@ -200,28 +214,16 @@ export async function mergeBranch(
  * Pre-merge conflict check without modifying the working tree.
  * Uses git merge-tree to detect conflicts.
  */
-export async function hasConflicts(
-  source: string,
-  target: string,
-): Promise<boolean> {
+export async function hasConflicts(source: string, target: string): Promise<boolean> {
   const log = logger.child({ module: "merge" });
 
   try {
     // Find the merge base
-    const { stdout: mergeBase } = await execFile("git", [
-      "merge-base",
-      target,
-      source,
-    ]);
+    const { stdout: mergeBase } = await execFile("git", ["merge-base", target, source]);
     const base = mergeBase.trim();
 
     // Use merge-tree to simulate the merge
-    const { stdout } = await execFile("git", [
-      "merge-tree",
-      base,
-      target,
-      source,
-    ]);
+    const { stdout } = await execFile("git", ["merge-tree", base, target, source]);
 
     // merge-tree outputs conflict markers when there are conflicts
     const conflicts = stdout.includes("<<<<<<");
@@ -229,9 +231,7 @@ export async function hasConflicts(
     return conflicts;
   } catch (err: unknown) {
     const message = (err as Error).message ?? "";
-    throw new Error(
-      `Failed to check conflicts between '${source}' and '${target}': ${message}`,
-    );
+    throw new Error(`Failed to check conflicts between '${source}' and '${target}': ${message}`);
   }
 }
 

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -16,9 +16,7 @@ export interface CreateWorktreeOptions {
  * If the branch already exists (e.g. from a previous failed run), it is
  * reset to the base ref so the worktree starts clean.
  */
-export async function createWorktree(
-  options: CreateWorktreeOptions,
-): Promise<void> {
+export async function createWorktree(options: CreateWorktreeOptions): Promise<void> {
   const { path, branch, base } = options;
   const log = logger.child({ module: "worktree" });
 
@@ -52,7 +50,9 @@ export async function createWorktree(
   } catch (err: unknown) {
     const message = (err as Error).message ?? "";
     // Clean up the branch on any failure
-    await execFile("git", ["branch", "-D", branch]).catch((err) => log.debug({ err: String(err) }, "branch cleanup failed (non-critical)"));
+    await execFile("git", ["branch", "-D", branch]).catch((err) =>
+      log.debug({ err: String(err) }, "branch cleanup failed (non-critical)"),
+    );
     throw new Error(`Failed to add worktree at '${path}': ${message}`);
   }
 }
@@ -68,19 +68,14 @@ export async function removeWorktree(worktreePath: string): Promise<void> {
     log.info({ path: worktreePath }, "worktree removed");
   } catch (err: unknown) {
     const message = (err as Error).message ?? "";
-    throw new Error(
-      `Failed to remove worktree at '${worktreePath}': ${message}`,
-    );
+    throw new Error(`Failed to remove worktree at '${worktreePath}': ${message}`);
   }
 }
 
 /**
  * Delete a local git branch.
  */
-export async function deleteBranch(
-  branch: string,
-  force: boolean = true,
-): Promise<void> {
+export async function deleteBranch(branch: string, force: boolean = true): Promise<void> {
   const log = logger.child({ module: "worktree" });
   const flag = force ? "-D" : "-d";
   await execFile("git", ["branch", flag, branch]);
@@ -93,11 +88,7 @@ export async function deleteBranch(
 export async function listWorktrees(): Promise<Worktree[]> {
   const log = logger.child({ module: "worktree" });
 
-  const { stdout } = await execFile("git", [
-    "worktree",
-    "list",
-    "--porcelain",
-  ]);
+  const { stdout } = await execFile("git", ["worktree", "list", "--porcelain"]);
 
   const worktrees: Worktree[] = [];
   let current: Partial<Worktree> = {};

--- a/src/github/issue-rate-limiter.ts
+++ b/src/github/issue-rate-limiter.ts
@@ -30,7 +30,7 @@ export async function createIssueRateLimited(
 
   const issue = await createIssue(options);
   state.issuesCreatedCount++;
-  
+
   log.debug(
     {
       number: issue.number,

--- a/src/github/issues.ts
+++ b/src/github/issues.ts
@@ -16,9 +16,14 @@ function isRetryable(error: unknown): boolean {
   if (errnoCode === "4" || (error as { code?: number }).code === 4) return false;
   // Only retry errors that look like transient network/API failures
   const message = error instanceof Error ? error.message : "";
-  if (message.includes("ETIMEDOUT") || message.includes("ECONNRESET") ||
-      message.includes("rate limit") || message.includes("502") ||
-      message.includes("503") || message.includes("timeout")) {
+  if (
+    message.includes("ETIMEDOUT") ||
+    message.includes("ECONNRESET") ||
+    message.includes("rate limit") ||
+    message.includes("502") ||
+    message.includes("503") ||
+    message.includes("timeout")
+  ) {
     return true;
   }
   return false;
@@ -37,9 +42,7 @@ export async function execGh(args: string[]): Promise<string> {
       lastError = error;
       const code = (error as NodeJS.ErrnoException).code;
       if (code === "ENOENT") {
-        throw new Error(
-          "gh CLI not found. Install it: https://cli.github.com/",
-        );
+        throw new Error("gh CLI not found. Install it: https://cli.github.com/");
       }
       const exitCode = (error as { code?: number | string }).code;
       if (exitCode === 4) {
@@ -97,15 +100,8 @@ export interface ListIssuesOptions {
 }
 
 /** List issues with optional filters. */
-export async function listIssues(
-  options: ListIssuesOptions = {},
-): Promise<GitHubIssue[]> {
-  const args = [
-    "issue",
-    "list",
-    "--json",
-    "number,title,body,labels,state,milestone",
-  ];
+export async function listIssues(options: ListIssuesOptions = {}): Promise<GitHubIssue[]> {
+  const args = ["issue", "list", "--json", "number,title,body,labels,state,milestone"];
 
   if (options.labels && options.labels.length > 0) {
     args.push("--label", options.labels.join(","));
@@ -132,9 +128,7 @@ export interface CreateIssueOptions {
 }
 
 /** Create a new issue and return its details. */
-export async function createIssue(
-  options: CreateIssueOptions,
-): Promise<GitHubIssue> {
+export async function createIssue(options: CreateIssueOptions): Promise<GitHubIssue> {
   // Validate required fields to prevent garbage issues
   if (!options.title || typeof options.title !== "string" || options.title.trim().length === 0) {
     throw new Error("Cannot create issue: title is required and must be a non-empty string");
@@ -148,21 +142,17 @@ export async function createIssue(
     const existing = await listIssues({ state: "open" });
     const duplicate = existing.find((i) => i.title === options.title);
     if (duplicate) {
-      logger.info({ number: duplicate.number, title: options.title }, "Skipping duplicate issue creation");
+      logger.info(
+        { number: duplicate.number, title: options.title },
+        "Skipping duplicate issue creation",
+      );
       return duplicate;
     }
   } catch {
     // Non-critical — proceed with creation if dedup check fails
   }
 
-  const args = [
-    "issue",
-    "create",
-    "--title",
-    options.title,
-    "--body",
-    options.body,
-  ];
+  const args = ["issue", "create", "--title", options.title, "--body", options.body];
 
   if (options.labels && options.labels.length > 0) {
     args.push("--label", options.labels.join(","));
@@ -184,10 +174,7 @@ export interface UpdateIssueOptions {
 }
 
 /** Update an existing issue. */
-export async function updateIssue(
-  number: number,
-  options: UpdateIssueOptions,
-): Promise<void> {
+export async function updateIssue(number: number, options: UpdateIssueOptions): Promise<void> {
   const args = ["issue", "edit", String(number)];
 
   if (options.title) {
@@ -207,10 +194,7 @@ export async function updateIssue(
 }
 
 /** Add a comment to an issue. */
-export async function addComment(
-  number: number,
-  body: string,
-): Promise<void> {
+export async function addComment(number: number, body: string): Promise<void> {
   await execGh(["issue", "comment", String(number), "--body", body]);
 }
 
@@ -220,9 +204,13 @@ export async function getComments(
   limit = 5,
 ): Promise<Array<{ body: string; createdAt: string }>> {
   const json = await execGh([
-    "issue", "view", String(number),
-    "--json", "comments",
-    "--jq", `.comments | sort_by(.createdAt) | reverse | .[:${limit}]`,
+    "issue",
+    "view",
+    String(number),
+    "--json",
+    "comments",
+    "--jq",
+    `.comments | sort_by(.createdAt) | reverse | .[:${limit}]`,
   ]);
   try {
     return JSON.parse(json) as Array<{ body: string; createdAt: string }>;

--- a/src/github/labels.ts
+++ b/src/github/labels.ts
@@ -12,27 +12,15 @@ export const STATUS_LABELS = [
 export type StatusLabel = (typeof STATUS_LABELS)[number];
 
 /** Add a label to an issue. */
-export async function setLabel(
-  issueNumber: number,
-  label: string,
-): Promise<void> {
+export async function setLabel(issueNumber: number, label: string): Promise<void> {
   logger.debug({ issueNumber, label }, "Adding label");
   await execGh(["issue", "edit", String(issueNumber), "--add-label", label]);
 }
 
 /** Remove a label from an issue. */
-export async function removeLabel(
-  issueNumber: number,
-  label: string,
-): Promise<void> {
+export async function removeLabel(issueNumber: number, label: string): Promise<void> {
   logger.debug({ issueNumber, label }, "Removing label");
-  await execGh([
-    "issue",
-    "edit",
-    String(issueNumber),
-    "--remove-label",
-    label,
-  ]);
+  await execGh(["issue", "edit", String(issueNumber), "--remove-label", label]);
 }
 
 /** Create a label if it doesn't already exist. */
@@ -42,14 +30,7 @@ export async function ensureLabelExists(
   description?: string,
 ): Promise<void> {
   try {
-    const json = await execGh([
-      "label",
-      "list",
-      "--search",
-      name,
-      "--json",
-      "name",
-    ]);
+    const json = await execGh(["label", "list", "--search", name, "--json", "name"]);
     const labels = JSON.parse(json) as { name: string }[];
     const exists = labels.some((l) => l.name === name);
 
@@ -75,16 +56,8 @@ export async function ensureLabelExists(
 }
 
 /** Get labels for a specific issue. */
-export async function getLabels(
-  issueNumber: number,
-): Promise<{ name: string }[]> {
-  const json = await execGh([
-    "issue",
-    "view",
-    String(issueNumber),
-    "--json",
-    "labels",
-  ]);
+export async function getLabels(issueNumber: number): Promise<{ name: string }[]> {
+  const json = await execGh(["issue", "view", String(issueNumber), "--json", "labels"]);
   const result = JSON.parse(json) as { labels?: { name: string }[] };
   return result.labels ?? [];
 }

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -82,12 +82,13 @@ export class HeartbeatSupervisor {
 
     // Check for stale sprint (phase hasn't changed in threshold time)
     const staleSinceMs = Date.now() - this.lastPhaseChangeAt;
-    const isStale = result.phase !== null
-      && result.phase !== "complete"
-      && result.phase !== "failed"
-      && result.phase !== "stopped"
-      && result.phase !== "init"
-      && staleSinceMs > this.config.staleThresholdMs;
+    const isStale =
+      result.phase !== null &&
+      result.phase !== "complete" &&
+      result.phase !== "failed" &&
+      result.phase !== "stopped" &&
+      result.phase !== "init" &&
+      staleSinceMs > this.config.staleThresholdMs;
 
     if (isStale && result.sprintNumber !== null && result.phase !== null) {
       this.events.emitTyped("heartbeat:stale", {
@@ -117,18 +118,26 @@ export class HeartbeatSupervisor {
       }
 
       // Find the highest-numbered state file
-      const files = fs.readdirSync(stateDir)
-        .filter((f) => f.startsWith(this.config.sprintSlug + "-") && f.endsWith("-state.json") && !f.endsWith(".lock"));
+      const files = fs
+        .readdirSync(stateDir)
+        .filter(
+          (f) =>
+            f.startsWith(this.config.sprintSlug + "-") &&
+            f.endsWith("-state.json") &&
+            !f.endsWith(".lock"),
+        );
 
       if (files.length === 0) {
         return { sprintNumber: null, phase: null };
       }
 
       // Extract sprint numbers and sort descending
-      const numbered = files.map((f) => {
-        const match = f.match(/-(\d+)-state\.json$/);
-        return match ? { file: f, num: parseInt(match[1], 10) } : null;
-      }).filter(Boolean) as { file: string; num: number }[];
+      const numbered = files
+        .map((f) => {
+          const match = f.match(/-(\d+)-state\.json$/);
+          return match ? { file: f, num: parseInt(match[1], 10) } : null;
+        })
+        .filter(Boolean) as { file: string; num: number }[];
 
       numbered.sort((a, b) => b.num - a.num);
       if (numbered.length === 0) {
@@ -191,7 +200,11 @@ export class HeartbeatSupervisor {
           }
         } catch {
           // Can't read lock file — remove it
-          try { fs.unlinkSync(lockPath); } catch { /* best effort */ }
+          try {
+            fs.unlinkSync(lockPath);
+          } catch {
+            /* best effort */
+          }
           foundOrphaned = true;
         }
       }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -52,7 +52,11 @@ function getErrorLogPath(): string | undefined {
 /**
  * Append a structured log entry to today's error log file.
  */
-export function appendErrorLog(level: "error" | "warn" | "info", message: string, context?: Record<string, unknown>): void {
+export function appendErrorLog(
+  level: "error" | "warn" | "info",
+  message: string,
+  context?: Record<string, unknown>,
+): void {
   const logPath = getErrorLogPath();
   if (!logPath) return;
   const entry = {
@@ -79,13 +83,7 @@ export function redirectLogToFile(filePath: string): void {
     name: logger.bindings().name ?? "sprint-runner",
     level: logger.level,
     redact: {
-      paths: [
-        "*.password",
-        "*.token",
-        "*.secret",
-        "*.apiKey",
-        "*.authorization",
-      ],
+      paths: ["*.password", "*.token", "*.secret", "*.apiKey", "*.authorization"],
       censor: "[REDACTED]",
     },
   };
@@ -103,22 +101,15 @@ export function createLogger(options: LoggerOptions = {}): Logger {
     pretty = process.env["NODE_ENV"] !== "production",
   } = options;
 
-  const transport = !logDestination && pretty
-    ? { target: "pino-pretty", options: { colorize: true } }
-    : undefined;
+  const transport =
+    !logDestination && pretty ? { target: "pino-pretty", options: { colorize: true } } : undefined;
 
   const pinoOptions = {
     name,
     level,
     transport,
     redact: {
-      paths: [
-        "*.password",
-        "*.token",
-        "*.secret",
-        "*.apiKey",
-        "*.authorization",
-      ],
+      paths: ["*.password", "*.token", "*.secret", "*.apiKey", "*.authorization"],
       censor: "[REDACTED]",
     },
   };

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -44,14 +44,14 @@ export function calculateSprintMetrics(result: SprintResult): SprintMetrics {
     .reduce((sum, r) => sum + r.points, 0);
   const velocity = pointsCompleted;
   const avgDuration =
-    planned > 0
-      ? Math.round(results.reduce((sum, r) => sum + r.duration_ms, 0) / planned)
-      : 0;
+    planned > 0 ? Math.round(results.reduce((sum, r) => sum + r.duration_ms, 0) / planned) : 0;
   const firstPassCount = results.filter((r) => r.retryCount === 0).length;
   const firstPassRate = percent(firstPassCount, planned);
   const driftIncidents = results.filter((r) =>
-    r.qualityDetails.checks.some((c) =>
-      (c.name === "scope_drift" || c.name === "scope-drift") && c.detail?.includes("unplanned")),
+    r.qualityDetails.checks.some(
+      (c) =>
+        (c.name === "scope_drift" || c.name === "scope-drift") && c.detail?.includes("unplanned"),
+    ),
   ).length;
 
   return {

--- a/src/notifications/sprint-notifications.ts
+++ b/src/notifications/sprint-notifications.ts
@@ -1,10 +1,15 @@
 import type { SprintEventBus } from "../events.js";
 import { sendNotification, type NtfyConfig } from "./ntfy.js";
 
+const attachedBuses = new WeakSet<SprintEventBus>();
+
 export function attachSprintNotifications(
   eventBus: SprintEventBus,
   ntfyConfig: NtfyConfig | undefined,
 ): void {
+  if (attachedBuses.has(eventBus)) return;
+  attachedBuses.add(eventBus);
+
   eventBus.onTyped("issue:fail", ({ issueNumber, reason }) => {
     sendNotification(
       ntfyConfig,
@@ -26,13 +31,7 @@ export function attachSprintNotifications(
   });
 
   eventBus.onTyped("sprint:error", ({ error }) => {
-    sendNotification(
-      ntfyConfig,
-      "Sprint Error",
-      error,
-      "urgent",
-      ["rotating_light"],
-    );
+    sendNotification(ntfyConfig, "Sprint Error", error, "urgent", ["rotating_light"]);
   });
 
   eventBus.onTyped("sprint:stopped", ({ sprintNumber }) => {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -22,13 +22,7 @@ import {
 } from "./state-manager.js";
 import { SprintEventBus } from "./events.js";
 import { attachSprintNotifications } from "./notifications/sprint-notifications.js";
-import type {
-  SprintConfig,
-  SprintPlan,
-  SprintResult,
-  ReviewResult,
-  RetroResult,
-} from "./types.js";
+import type { SprintConfig, SprintPlan, SprintResult, ReviewResult, RetroResult } from "./types.js";
 
 export type SprintPhase =
   | "init"
@@ -99,7 +93,6 @@ export class SprintRunner {
       startedAt: new Date(),
       issuesCreatedCount: 0,
     };
-    attachSprintNotifications(this.events, this.config.ntfy);
     this.log = defaultLogger.child({
       component: "sprint-runner",
       sprint: config.sprintNumber,
@@ -130,10 +123,20 @@ export class SprintRunner {
       const resuming = previous && previous.phase !== "complete" && previous.plan;
 
       if (resuming && previous.plan) {
-        this.state = { ...previous, error: undefined, issuesCreatedCount: previous.issuesCreatedCount ?? 0 };
+        this.state = {
+          ...previous,
+          error: undefined,
+          issuesCreatedCount: previous.issuesCreatedCount ?? 0,
+        };
         this.log.info({ resumeFrom: previous.phase }, "Resuming sprint from previous state");
-        this.events.emitTyped("sprint:start", { sprintNumber: this.config.sprintNumber, resumed: true });
-        this.events.emitTyped("log", { level: "info", message: `Resuming Sprint ${this.config.sprintNumber} from ${previous.phase} phase` });
+        this.events.emitTyped("sprint:start", {
+          sprintNumber: this.config.sprintNumber,
+          resumed: true,
+        });
+        this.events.emitTyped("log", {
+          level: "info",
+          message: `Resuming Sprint ${this.config.sprintNumber} from ${previous.phase} phase`,
+        });
         await this.client.connect();
 
         // Determine where to resume based on previous phase
@@ -147,7 +150,10 @@ export class SprintRunner {
         // Short-circuit if all issues are already done
         if (plan.sprint_issues.length === 0) {
           this.log.info("All issues already completed — skipping to complete");
-          this.events.emitTyped("log", { level: "info", message: "All issues done — completing sprint" });
+          this.events.emitTyped("log", {
+            level: "info",
+            message: "All issues done — completing sprint",
+          });
           this.transition("complete");
           await this.client.disconnect();
           this.persistState();
@@ -162,7 +168,11 @@ export class SprintRunner {
         if (!result || previous.phase === "execute") {
           if (this.hitlMode) {
             this.log.info("HITL mode — pausing before execution for stakeholder review");
-            this.events.emitTyped("log", { level: "info", message: "⏸ HITL: Pausing before execution — review the plan and resume in dashboard to continue" });
+            this.events.emitTyped("log", {
+              level: "info",
+              message:
+                "⏸ HITL: Pausing before execution — review the plan and resume in dashboard to continue",
+            });
             this.pause();
           }
           await this.checkInterrupted();
@@ -197,7 +207,14 @@ export class SprintRunner {
       // 1. init
       this.transition("init");
       this.events.emitTyped("sprint:start", { sprintNumber: this.config.sprintNumber });
-      createSprintLog(this.config.sprintNumber, `${this.config.sprintPrefix} cycle started`, 0, undefined, this.config.sprintPrefix, this.config.sprintSlug);
+      createSprintLog(
+        this.config.sprintNumber,
+        `${this.config.sprintPrefix} cycle started`,
+        0,
+        undefined,
+        this.config.sprintPrefix,
+        this.config.sprintSlug,
+      );
       await this.client.connect();
 
       // 2. plan
@@ -217,7 +234,10 @@ export class SprintRunner {
       // Short-circuit: skip execute/review/retro if no issues to work on
       if (plan.sprint_issues.length === 0) {
         this.log.info("No issues in sprint plan — skipping to complete");
-        this.events.emitTyped("log", { level: "info", message: "No issues in sprint — completing immediately" });
+        this.events.emitTyped("log", {
+          level: "info",
+          message: "No issues in sprint — completing immediately",
+        });
         this.transition("complete");
         await this.client.disconnect();
         this.persistState();
@@ -231,7 +251,11 @@ export class SprintRunner {
       // 3. execute
       if (this.hitlMode) {
         this.log.info("HITL mode — pausing before execution for stakeholder review");
-        this.events.emitTyped("log", { level: "info", message: "⏸ HITL: Pausing before execution — review the plan and resume in dashboard to continue" });
+        this.events.emitTyped("log", {
+          level: "info",
+          message:
+            "⏸ HITL: Pausing before execution — review the plan and resume in dashboard to continue",
+        });
         this.pause();
       }
       await this.checkInterrupted();
@@ -303,11 +327,18 @@ export class SprintRunner {
     const bus = eventBus ?? new SprintEventBus();
     const getLimit = typeof maxSprints === "function" ? maxSprints : () => maxSprints;
 
+    // Attach ntfy notifications once for the loop (not per-runner)
+    const sampleCfg = configBuilder(1);
+    attachSprintNotifications(bus, sampleCfg.ntfy);
+
     while (true) {
       const limit = getLimit();
       if (limit > 0 && results.length >= limit) {
         log.info({ completed: results.length, limit }, "Sprint limit reached — pausing");
-        bus.emitTyped("log", { level: "info", message: `Sprint limit reached (${results.length}/${limit}) — pausing` });
+        bus.emitTyped("log", {
+          level: "info",
+          message: `Sprint limit reached (${results.length}/${limit}) — pausing`,
+        });
         break;
       }
       // Use configBuilder to get prefix for milestone detection
@@ -317,13 +348,19 @@ export class SprintRunner {
         next = await getNextOpenMilestone(sampleConfig.sprintPrefix);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
-        log.error({ error: msg }, "Failed to detect next sprint milestone — check that a milestone like 'Sprint N' exists");
+        log.error(
+          { error: msg },
+          "Failed to detect next sprint milestone — check that a milestone like 'Sprint N' exists",
+        );
         bus.emitTyped("log", { level: "error", message: `Milestone detection failed: ${msg}` });
         break;
       }
       if (!next) {
         log.info("No open sprint milestones found — loop complete");
-        bus.emitTyped("log", { level: "info", message: "No open sprint milestones — loop complete" });
+        bus.emitTyped("log", {
+          level: "info",
+          message: "No open sprint milestones — loop complete",
+        });
         break;
       }
 
@@ -346,7 +383,10 @@ export class SprintRunner {
         }
       } else {
         log.warn({ phase: state.phase }, "Sprint did not complete — stopping loop");
-        bus.emitTyped("log", { level: "warn", message: `Sprint ${sprintNumber} failed — loop stopped` });
+        bus.emitTyped("log", {
+          level: "warn",
+          message: `Sprint ${sprintNumber} failed — loop stopped`,
+        });
         break;
       }
     }
@@ -377,12 +417,7 @@ export class SprintRunner {
       this.events.emitTyped("issue:start", { issue, model: workerModel });
     }
 
-    const result = await runParallelExecution(
-      this.client,
-      this.config,
-      plan,
-      this.events,
-    );
+    const result = await runParallelExecution(this.client, this.config, plan, this.events);
     this.state.result = result;
 
     // Emit issue:done / issue:fail for each result
@@ -396,7 +431,11 @@ export class SprintRunner {
       } else {
         this.events.emitTyped("issue:fail", {
           issueNumber: r.issueNumber,
-          reason: (r.qualityDetails?.checks ?? []).filter(c => !c.passed).map(c => c.name).join(", ") || "execution failed",
+          reason:
+            (r.qualityDetails?.checks ?? [])
+              .filter((c) => !c.passed)
+              .map((c) => c.name)
+              .join(", ") || "execution failed",
           duration_ms: r.duration_ms,
         });
       }
@@ -428,10 +467,12 @@ export class SprintRunner {
       planned: metrics.planned,
       done: metrics.completed,
       carry: metrics.failed,
-      hours: Math.round(metrics.avgDuration * metrics.planned / 3_600_000),
+      hours: Math.round((metrics.avgDuration * metrics.planned) / 3_600_000),
       issuesPerHr:
         metrics.avgDuration > 0
-          ? Math.round((metrics.completed / (metrics.avgDuration * metrics.planned / 3_600_000)) * 100) / 100
+          ? Math.round(
+              (metrics.completed / ((metrics.avgDuration * metrics.planned) / 3_600_000)) * 100,
+            ) / 100
           : 0,
       notes: review.summary,
     });
@@ -454,16 +495,17 @@ export class SprintRunner {
     );
     this.state.retro = retro;
     this.persistState();
-    this.log.info(
-      { improvements: retro.improvements.length },
-      "Sprint retro complete",
-    );
+    this.log.info({ improvements: retro.improvements.length }, "Sprint retro complete");
     return retro;
   }
 
   /** Pause the sprint runner */
   pause(): void {
-    if (this.state.phase !== "paused" && this.state.phase !== "failed" && this.state.phase !== "complete") {
+    if (
+      this.state.phase !== "paused" &&
+      this.state.phase !== "failed" &&
+      this.state.phase !== "complete"
+    ) {
       this.phaseBeforePause = this.state.phase;
       this.paused = true;
       this.state.phase = "paused";
@@ -505,7 +547,11 @@ export class SprintRunner {
       this.persistState();
       this.events.emitTyped("sprint:stopped", { sprintNumber: this.config.sprintNumber });
       // Release the lock in case no fullCycle() is running to do it
-      try { releaseLock(this.config); } catch { /* may not be locked */ }
+      try {
+        releaseLock(this.config);
+      } catch {
+        /* may not be locked */
+      }
     }
   }
 
@@ -531,14 +577,20 @@ export class SprintRunner {
       for (const issue of issues) {
         try {
           await execGh([
-            "api", "-X", "PATCH",
+            "api",
+            "-X",
+            "PATCH",
             `repos/{owner}/{repo}/issues/${issue.number}`,
-            "-f", "milestone=null",
+            "-f",
+            "milestone=null",
           ]);
           returnedIssues.push(issue.number);
           this.log.info({ issueNumber: issue.number }, "Returned issue to backlog");
         } catch (err) {
-          this.log.warn({ issueNumber: issue.number, err: String(err) }, "Failed to remove milestone from issue");
+          this.log.warn(
+            { issueNumber: issue.number, err: String(err) },
+            "Failed to remove milestone from issue",
+          );
         }
       }
 
@@ -547,7 +599,10 @@ export class SprintRunner {
         await closeMilestone(milestoneTitle);
         this.log.info({ milestone: milestoneTitle }, "Cancelled milestone closed");
       } catch (err) {
-        this.log.warn({ milestone: milestoneTitle, err: String(err) }, "Failed to close cancelled milestone");
+        this.log.warn(
+          { milestone: milestoneTitle, err: String(err) },
+          "Failed to close cancelled milestone",
+        );
       }
     } catch (err) {
       this.log.warn({ err: String(err) }, "Failed to list sprint issues during cancel");
@@ -594,19 +649,28 @@ export class SprintRunner {
         const details = await getIssue(issue.number);
         const labels = details.labels?.map((l) => l.name) ?? [];
         if (labels.includes("status:done")) {
-          this.log.warn({ issue: issue.number, title: issue.title }, "Skipping already-completed issue");
+          this.log.warn(
+            { issue: issue.number, title: issue.title },
+            "Skipping already-completed issue",
+          );
         } else {
           activeIssues.push(issue);
         }
       } catch (err: unknown) {
         // If we can't fetch the issue, keep it in the plan to be safe
-        this.log.warn({ issue: issue.number, err }, "Could not check issue status, keeping in plan");
+        this.log.warn(
+          { issue: issue.number, err },
+          "Could not check issue status, keeping in plan",
+        );
         activeIssues.push(issue);
       }
     }
     if (activeIssues.length < plan.sprint_issues.length) {
       this.log.info(
-        { removed: plan.sprint_issues.length - activeIssues.length, remaining: activeIssues.length },
+        {
+          removed: plan.sprint_issues.length - activeIssues.length,
+          remaining: activeIssues.length,
+        },
         "Filtered completed issues from sprint plan",
       );
       plan.sprint_issues = activeIssues;
@@ -650,7 +714,9 @@ export class SprintRunner {
       try {
         saveState(this.state, this.stateFilePath);
       } catch (retryErr: unknown) {
-        throw new Error(`State persistence failed after retry: ${retryErr instanceof Error ? retryErr.message : String(retryErr)}`);
+        throw new Error(
+          `State persistence failed after retry: ${retryErr instanceof Error ? retryErr.message : String(retryErr)}`,
+        );
       }
     }
   }

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -71,10 +71,7 @@ export function loadState(filePath: string): SprintState | null {
 
   const result = SprintStateSchema.safeParse(json);
   if (!result.success) {
-    log.warn(
-      { filePath, issues: result.error.issues },
-      "State file failed validation",
-    );
+    log.warn({ filePath, issues: result.error.issues }, "State file failed validation");
     return null;
   }
 

--- a/tests/acp/client.test.ts
+++ b/tests/acp/client.test.ts
@@ -38,9 +38,7 @@ vi.mock("@agentclientprotocol/sdk", async (importOriginal) => {
 });
 
 import { AcpClient } from "../../src/acp/client.js";
-import {
-  createPermissionHandler,
-} from "../../src/acp/permissions.js";
+import { createPermissionHandler } from "../../src/acp/permissions.js";
 import { createLogger } from "../../src/logger.js";
 
 function createMockProcess(): ChildProcess {
@@ -87,7 +85,10 @@ describe("AcpClient", () => {
     mockNewSession.mockResolvedValue({
       sessionId: "session-123",
       modes: {
-        availableModes: [{ id: "agent", name: "Agent" }, { id: "plan", name: "Plan" }],
+        availableModes: [
+          { id: "agent", name: "Agent" },
+          { id: "plan", name: "Plan" },
+        ],
         currentModeId: "agent",
       },
       models: {
@@ -134,9 +135,7 @@ describe("AcpClient", () => {
         expect.objectContaining({ stdio: ["pipe", "pipe", "pipe"] }),
       );
       expect(client.connected).toBe(true);
-      expect(mockInitialize).toHaveBeenCalledWith(
-        expect.objectContaining({ protocolVersion: 1 }),
-      );
+      expect(mockInitialize).toHaveBeenCalledWith(expect.objectContaining({ protocolVersion: 1 }));
 
       await client.disconnect();
     });
@@ -198,7 +197,10 @@ describe("AcpClient", () => {
       // Make initialize slow so connect() is in progress when disconnect() is called
       let resolveInit!: (value: unknown) => void;
       mockInitialize.mockImplementation(
-        () => new Promise((resolve) => { resolveInit = resolve; }),
+        () =>
+          new Promise((resolve) => {
+            resolveInit = resolve;
+          }),
       );
 
       mockSpawn.mockReturnValue(mockProc);
@@ -269,9 +271,7 @@ describe("AcpClient", () => {
       const client = new AcpClient({ logger: silentLogger });
       await client.connect();
 
-      const mcpServers = [
-        { type: "stdio" as const, command: "gh", args: ["mcp-server"] },
-      ];
+      const mcpServers = [{ type: "stdio" as const, command: "gh", args: ["mcp-server"] }];
       await client.createSession({ cwd: "/tmp", mcpServers });
 
       expect(mockNewSession).toHaveBeenCalledWith({
@@ -284,9 +284,7 @@ describe("AcpClient", () => {
 
     it("throws when not connected", async () => {
       const client = new AcpClient({ logger: silentLogger });
-      await expect(client.createSession({ cwd: "/tmp" })).rejects.toThrow(
-        "not connected",
-      );
+      await expect(client.createSession({ cwd: "/tmp" })).rejects.toThrow("not connected");
     });
   });
 
@@ -313,9 +311,7 @@ describe("AcpClient", () => {
 
     it("throws when not connected", async () => {
       const client = new AcpClient({ logger: silentLogger });
-      await expect(
-        client.sendPrompt("session-123", "test"),
-      ).rejects.toThrow("not connected");
+      await expect(client.sendPrompt("session-123", "test")).rejects.toThrow("not connected");
     });
 
     it("rejects on timeout", async () => {
@@ -331,9 +327,7 @@ describe("AcpClient", () => {
       await client.connect();
       await client.createSession({ cwd: "/tmp" });
 
-      await expect(
-        client.sendPrompt("session-123", "slow prompt"),
-      ).rejects.toThrow("timed out");
+      await expect(client.sendPrompt("session-123", "slow prompt")).rejects.toThrow("timed out");
 
       await client.disconnect();
     }, 30_000);
@@ -412,9 +406,7 @@ describe("AcpClient", () => {
       await client.connect();
       await client.createSession({ cwd: "/tmp" });
 
-      await expect(
-        client.sendPrompt("session-123", "Hello"),
-      ).rejects.toThrow("Invalid session");
+      await expect(client.sendPrompt("session-123", "Hello")).rejects.toThrow("Invalid session");
 
       expect(mockPrompt).toHaveBeenCalledTimes(1);
 
@@ -453,9 +445,7 @@ describe("AcpClient", () => {
       await client.createSession({ cwd: "/tmp" });
 
       // Should not throw
-      await expect(
-        client.endSession("session-123"),
-      ).resolves.toBeUndefined();
+      await expect(client.endSession("session-123")).resolves.toBeUndefined();
 
       await client.disconnect();
     });
@@ -479,14 +469,9 @@ describe("createPermissionHandler", () => {
   });
 
   it("auto-approves when autoApprove is true", async () => {
-    const handler = createPermissionHandler(
-      { autoApprove: true, allowPatterns: [] },
-      silentLogger,
-    );
+    const handler = createPermissionHandler({ autoApprove: true, allowPatterns: [] }, silentLogger);
 
-    const result = await handler(
-      makeRequest("bash", ["allow_once", "reject_once"]) as any,
-    );
+    const result = await handler(makeRequest("bash", ["allow_once", "reject_once"]) as any);
 
     expect(result.outcome).toEqual({
       outcome: "selected",
@@ -500,9 +485,7 @@ describe("createPermissionHandler", () => {
       silentLogger,
     );
 
-    const result = await handler(
-      makeRequest("bash", ["allow_once", "reject_once"]) as any,
-    );
+    const result = await handler(makeRequest("bash", ["allow_once", "reject_once"]) as any);
 
     expect(result.outcome).toEqual({
       outcome: "selected",
@@ -516,9 +499,7 @@ describe("createPermissionHandler", () => {
       silentLogger,
     );
 
-    const result = await handler(
-      makeRequest("bash", ["allow_once", "reject_once"]) as any,
-    );
+    const result = await handler(makeRequest("bash", ["allow_once", "reject_once"]) as any);
 
     expect(result.outcome).toEqual({
       outcome: "selected",
@@ -532,9 +513,7 @@ describe("createPermissionHandler", () => {
       silentLogger,
     );
 
-    const result = await handler(
-      makeRequest("bash", ["allow_once", "reject_once"]) as any,
-    );
+    const result = await handler(makeRequest("bash", ["allow_once", "reject_once"]) as any);
 
     expect(result.outcome).toEqual({
       outcome: "selected",
@@ -548,22 +527,15 @@ describe("createPermissionHandler", () => {
       silentLogger,
     );
 
-    const result = await handler(
-      makeRequest("bash", []) as any,
-    );
+    const result = await handler(makeRequest("bash", []) as any);
 
     expect(result.outcome).toEqual({ outcome: "cancelled" });
   });
 
   it("prefers allow_once over allow_always", async () => {
-    const handler = createPermissionHandler(
-      { autoApprove: true, allowPatterns: [] },
-      silentLogger,
-    );
+    const handler = createPermissionHandler({ autoApprove: true, allowPatterns: [] }, silentLogger);
 
-    const result = await handler(
-      makeRequest("bash", ["allow_always", "allow_once"]) as any,
-    );
+    const result = await handler(makeRequest("bash", ["allow_always", "allow_once"]) as any);
 
     // allow_once should be preferred (found first by find)
     expect(result.outcome).toEqual({

--- a/tests/acp/permissions.test.ts
+++ b/tests/acp/permissions.test.ts
@@ -31,10 +31,7 @@ const silentLog = {
 describe("createPermissionHandler", () => {
   describe("auto-approve", () => {
     it("approves when autoApprove is true", async () => {
-      const handler = createPermissionHandler(
-        { autoApprove: true, allowPatterns: [] },
-        silentLog,
-      );
+      const handler = createPermissionHandler({ autoApprove: true, allowPatterns: [] }, silentLog);
       const result = await handler(makeRequest("some_tool"));
       expect(result.outcome).toEqual({
         outcome: "selected",
@@ -43,10 +40,7 @@ describe("createPermissionHandler", () => {
     });
 
     it("prefers allow_once over allow_always", async () => {
-      const handler = createPermissionHandler(
-        { autoApprove: true, allowPatterns: [] },
-        silentLog,
-      );
+      const handler = createPermissionHandler({ autoApprove: true, allowPatterns: [] }, silentLog);
       const result = await handler(
         makeRequest("tool", [
           { kind: "allow_always", optionId: "always-1" },
@@ -60,10 +54,7 @@ describe("createPermissionHandler", () => {
     });
 
     it("falls back to allow_always when no allow_once", async () => {
-      const handler = createPermissionHandler(
-        { autoApprove: true, allowPatterns: [] },
-        silentLog,
-      );
+      const handler = createPermissionHandler({ autoApprove: true, allowPatterns: [] }, silentLog);
       const result = await handler(
         makeRequest("tool", [
           { kind: "allow_always", optionId: "always-1" },
@@ -123,10 +114,7 @@ describe("createPermissionHandler", () => {
 
   describe("rejection", () => {
     it("rejects when autoApprove is false and no patterns match", async () => {
-      const handler = createPermissionHandler(
-        DEFAULT_PERMISSION_CONFIG,
-        silentLog,
-      );
+      const handler = createPermissionHandler(DEFAULT_PERMISSION_CONFIG, silentLog);
       const result = await handler(makeRequest("dangerous_tool"));
       expect(result.outcome).toEqual({
         outcome: "selected",
@@ -135,10 +123,7 @@ describe("createPermissionHandler", () => {
     });
 
     it("prefers reject_once over reject_always", async () => {
-      const handler = createPermissionHandler(
-        DEFAULT_PERMISSION_CONFIG,
-        silentLog,
-      );
+      const handler = createPermissionHandler(DEFAULT_PERMISSION_CONFIG, silentLog);
       const result = await handler(
         makeRequest("tool", [
           { kind: "reject_always", optionId: "always-r" },
@@ -152,10 +137,7 @@ describe("createPermissionHandler", () => {
     });
 
     it("cancels when no allow or reject option exists", async () => {
-      const handler = createPermissionHandler(
-        DEFAULT_PERMISSION_CONFIG,
-        silentLog,
-      );
+      const handler = createPermissionHandler(DEFAULT_PERMISSION_CONFIG, silentLog);
       const result = await handler(makeRequest("tool", []));
       expect(result.outcome).toEqual({ outcome: "cancelled" });
     });
@@ -176,10 +158,7 @@ describe("createPermissionHandler", () => {
     });
 
     it("handles missing toolCall name gracefully", async () => {
-      const handler = createPermissionHandler(
-        { autoApprove: true, allowPatterns: [] },
-        silentLog,
-      );
+      const handler = createPermissionHandler({ autoApprove: true, allowPatterns: [] }, silentLog);
       const result = await handler({
         toolCall: {},
         options: [{ kind: "allow_once", optionId: "a1" }],
@@ -191,15 +170,8 @@ describe("createPermissionHandler", () => {
     });
 
     it("cancels when autoApprove is true but no allow option exists", async () => {
-      const handler = createPermissionHandler(
-        { autoApprove: true, allowPatterns: [] },
-        silentLog,
-      );
-      const result = await handler(
-        makeRequest("tool", [
-          { kind: "reject_once", optionId: "r1" },
-        ]),
-      );
+      const handler = createPermissionHandler({ autoApprove: true, allowPatterns: [] }, silentLog);
+      const result = await handler(makeRequest("tool", [{ kind: "reject_once", optionId: "r1" }]));
       // autoApprove can't approve without an allow option, falls to reject
       expect(result.outcome).toEqual({
         outcome: "selected",

--- a/tests/acp/session-config.test.ts
+++ b/tests/acp/session-config.test.ts
@@ -123,10 +123,7 @@ describe("loadInstructions", () => {
       .mockResolvedValueOnce("# Global Instructions" as never)
       .mockResolvedValueOnce("# Phase Instructions" as never);
 
-    const result = await loadInstructions(
-      ["global.md", "phase.md"],
-      "/project",
-    );
+    const result = await loadInstructions(["global.md", "phase.md"], "/project");
     expect(result).toBe("# Global Instructions\n\n# Phase Instructions");
   });
 
@@ -136,10 +133,7 @@ describe("loadInstructions", () => {
       .mockRejectedValueOnce(new Error("ENOENT") as never)
       .mockResolvedValueOnce("content-c" as never);
 
-    const result = await loadInstructions(
-      ["a.md", "missing.md", "c.md"],
-      "/project",
-    );
+    const result = await loadInstructions(["a.md", "missing.md", "c.md"], "/project");
     expect(result).toBe("content-a\n\ncontent-c");
   });
 
@@ -248,16 +242,11 @@ describe("resolveSessionConfig", () => {
 
   it("handles unknown phase gracefully", async () => {
     const config = makeConfig({
-      globalMcpServers: [
-        { type: "stdio", name: "g", command: "g", args: [] },
-      ],
+      globalMcpServers: [{ type: "stdio", name: "g", command: "g", args: [] }],
     });
 
     // Phase doesn't exist in config.phases — should use only global
-    const result = await resolveSessionConfig(
-      config,
-      "challenger" as CeremonyPhase,
-    );
+    const result = await resolveSessionConfig(config, "challenger" as CeremonyPhase);
     expect(result.mcpServers).toHaveLength(1);
     expect(result.mcpServers[0].name).toBe("g");
     expect(result.model).toBeUndefined();

--- a/tests/ceremonies/ceremony-coverage.test.ts
+++ b/tests/ceremonies/ceremony-coverage.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { AcpClient } from "../../src/acp/client.js";
-import type {
-  SprintConfig,
-  SprintResult,
-  ReviewResult,
-} from "../../src/types.js";
+import type { SprintConfig, SprintResult, ReviewResult } from "../../src/types.js";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
@@ -57,9 +53,7 @@ vi.mock("../../src/metrics.js", () => ({
 
 vi.mock("node:fs/promises", () => ({
   default: {
-    readFile: vi
-      .fn()
-      .mockResolvedValue("Template {{SPRINT_NUMBER}}"),
+    readFile: vi.fn().mockResolvedValue("Template {{SPRINT_NUMBER}}"),
   },
 }));
 
@@ -74,10 +68,14 @@ import { listIssues, createIssue } from "../../src/github/issues.js";
 
 function makeMockClient() {
   return {
-    createSession: vi.fn().mockResolvedValue({ sessionId: "session-1", availableModes: [], currentMode: "", availableModels: [], currentModel: "" }),
-    sendPrompt: vi
-      .fn()
-      .mockResolvedValue({ response: "", stopReason: "end_turn" }),
+    createSession: vi.fn().mockResolvedValue({
+      sessionId: "session-1",
+      availableModes: [],
+      currentMode: "",
+      availableModels: [],
+      currentModel: "",
+    }),
+    sendPrompt: vi.fn().mockResolvedValue({ response: "", stopReason: "end_turn" }),
     endSession: vi.fn().mockResolvedValue(undefined),
     setMode: vi.fn().mockResolvedValue(undefined),
     setModel: vi.fn().mockResolvedValue(undefined),
@@ -165,18 +163,14 @@ describe("runRefinement", () => {
     const client = makeMockClient();
     vi.mocked(client.sendPrompt).mockResolvedValueOnce({
       response: JSON.stringify({
-        refined_issues: [
-          { number: 1, title: "Feature A", ice_score: 320 },
-        ],
+        refined_issues: [{ number: 1, title: "Feature A", ice_score: 320 }],
       }),
       stopReason: "end_turn",
     });
 
     const result = await runRefinement(client, config);
 
-    expect(result).toEqual([
-      { number: 1, title: "Feature A", ice_score: 320 },
-    ]);
+    expect(result).toEqual([{ number: 1, title: "Feature A", ice_score: 320 }]);
     expect(client.endSession).toHaveBeenCalledWith("session-1");
   });
 
@@ -192,13 +186,9 @@ describe("runRefinement", () => {
     ] as never);
 
     const client = makeMockClient();
-    vi.mocked(client.sendPrompt).mockRejectedValueOnce(
-      new Error("ACP failure"),
-    );
+    vi.mocked(client.sendPrompt).mockRejectedValueOnce(new Error("ACP failure"));
 
-    await expect(runRefinement(client, config)).rejects.toThrow(
-      "ACP failure",
-    );
+    await expect(runRefinement(client, config)).rejects.toThrow("ACP failure");
     expect(client.endSession).toHaveBeenCalledWith("session-1");
   });
 });
@@ -231,13 +221,9 @@ describe("runSprintReview", () => {
 
   it("ends ACP session even on error", async () => {
     const client = makeMockClient();
-    vi.mocked(client.sendPrompt).mockRejectedValueOnce(
-      new Error("ACP failure"),
-    );
+    vi.mocked(client.sendPrompt).mockRejectedValueOnce(new Error("ACP failure"));
 
-    await expect(
-      runSprintReview(client, config, sprintResult),
-    ).rejects.toThrow("ACP failure");
+    await expect(runSprintReview(client, config, sprintResult)).rejects.toThrow("ACP failure");
     expect(client.endSession).toHaveBeenCalledWith("session-1");
   });
 });
@@ -257,12 +243,7 @@ describe("runSprintRetro", () => {
       stopReason: "end_turn",
     });
 
-    const result = await runSprintRetro(
-      client,
-      config,
-      sprintResult,
-      reviewResult,
-    );
+    const result = await runSprintRetro(client, config, sprintResult, reviewResult);
 
     expect(result).toMatchObject({
       wentWell: ["Good tests"],
@@ -300,13 +281,11 @@ describe("runSprintRetro", () => {
 
   it("ends ACP session even on error", async () => {
     const client = makeMockClient();
-    vi.mocked(client.sendPrompt).mockRejectedValueOnce(
-      new Error("ACP failure"),
-    );
+    vi.mocked(client.sendPrompt).mockRejectedValueOnce(new Error("ACP failure"));
 
-    await expect(
-      runSprintRetro(client, config, sprintResult, reviewResult),
-    ).rejects.toThrow("ACP failure");
+    await expect(runSprintRetro(client, config, sprintResult, reviewResult)).rejects.toThrow(
+      "ACP failure",
+    );
     expect(client.endSession).toHaveBeenCalledWith("session-1");
   });
 

--- a/tests/ceremonies/dep-graph.test.ts
+++ b/tests/ceremonies/dep-graph.test.ts
@@ -36,11 +36,7 @@ describe("buildExecutionGroups", () => {
   });
 
   it("handles linear dependencies (A → B → C)", () => {
-    const issues = [
-      makeIssue(3, [2]),
-      makeIssue(2, [1]),
-      makeIssue(1),
-    ];
+    const issues = [makeIssue(3, [2]), makeIssue(2, [1]), makeIssue(1)];
     const groups = buildExecutionGroups(issues);
     expect(groups).toHaveLength(3);
     expect(groups[0].issues).toEqual([1]);
@@ -51,26 +47,21 @@ describe("buildExecutionGroups", () => {
   it("handles diamond dependencies (A,B → C; D → C)", () => {
     // C depends on A and B; D also depends on C
     const issues = [
-      makeIssue(1),           // A — no deps
-      makeIssue(2),           // B — no deps
-      makeIssue(3, [1, 2]),   // C — depends on A, B
-      makeIssue(4, [3]),      // D — depends on C
+      makeIssue(1), // A — no deps
+      makeIssue(2), // B — no deps
+      makeIssue(3, [1, 2]), // C — depends on A, B
+      makeIssue(4, [3]), // D — depends on C
     ];
     const groups = buildExecutionGroups(issues);
     expect(groups).toHaveLength(3);
     expect(groups[0].issues).toEqual([1, 2]); // A, B parallel
-    expect(groups[1].issues).toEqual([3]);    // C after A, B
-    expect(groups[2].issues).toEqual([4]);    // D after C
+    expect(groups[1].issues).toEqual([3]); // C after A, B
+    expect(groups[2].issues).toEqual([4]); // D after C
   });
 
   it("throws on circular dependencies", () => {
-    const issues = [
-      makeIssue(1, [2]),
-      makeIssue(2, [1]),
-    ];
-    expect(() => buildExecutionGroups(issues)).toThrow(
-      /Circular dependencies detected/,
-    );
+    const issues = [makeIssue(1, [2]), makeIssue(2, [1])];
+    expect(() => buildExecutionGroups(issues)).toThrow(/Circular dependencies detected/);
   });
 
   it("ignores depends_on refs outside the issue set", () => {
@@ -99,11 +90,7 @@ describe("detectCircularDependencies", () => {
   });
 
   it("detects a 3-node cycle", () => {
-    const issues = [
-      makeIssue(1, [3]),
-      makeIssue(2, [1]),
-      makeIssue(3, [2]),
-    ];
+    const issues = [makeIssue(1, [3]), makeIssue(2, [1]), makeIssue(3, [2])];
     const cycles = detectCircularDependencies(issues);
     expect(cycles).not.toBeNull();
     expect(cycles!.length).toBeGreaterThan(0);
@@ -139,15 +126,10 @@ describe("validateDependencies", () => {
   });
 
   it("handles mixed valid and missing deps", () => {
-    const issues = [
-      makeIssue(1),
-      makeIssue(2, [1, 50]),
-    ];
+    const issues = [makeIssue(1), makeIssue(2, [1, 50])];
     const result = validateDependencies(issues);
     expect(result.valid).toBe(false);
-    expect(result.missingRefs).toEqual([
-      { issue: 2, missingDep: 50 },
-    ]);
+    expect(result.missingRefs).toEqual([{ issue: 2, missingDep: 50 }]);
   });
 });
 

--- a/tests/ceremonies/execution.test.ts
+++ b/tests/ceremonies/execution.test.ts
@@ -165,19 +165,15 @@ function makeIssue(overrides: Partial<SprintIssue> = {}): SprintIssue {
 }
 
 function makeMockClient() {
-  let callCount = 0;
   return {
-    createSession: vi
-      .fn()
-      .mockResolvedValue({
-        sessionId: "session-abc",
-        availableModes: [],
-        currentMode: "",
-        availableModels: [],
-        currentModel: "",
-      }),
+    createSession: vi.fn().mockResolvedValue({
+      sessionId: "session-abc",
+      availableModes: [],
+      currentMode: "",
+      availableModels: [],
+      currentModel: "",
+    }),
     sendPrompt: vi.fn().mockImplementation((_sid: string, prompt: string) => {
-      callCount++;
       // AC review prompts come from the acceptance-review template
       if (typeof prompt === "string" && prompt.includes("Review AC for issue")) {
         return Promise.resolve({

--- a/tests/ceremonies/merge-pipeline.test.ts
+++ b/tests/ceremonies/merge-pipeline.test.ts
@@ -34,9 +34,8 @@ vi.mock("../../src/logger.js", () => {
 const { mergeBranch } = await import("../../src/git/merge.js");
 const { deleteBranch } = await import("../../src/git/worktree.js");
 
-const { mergeCompletedBranches, resolveConflictsViaAcp } = await import(
-  "../../src/ceremonies/merge-pipeline.js"
-);
+const { mergeCompletedBranches, resolveConflictsViaAcp } =
+  await import("../../src/ceremonies/merge-pipeline.js");
 
 // --- Helpers ---
 
@@ -70,9 +69,7 @@ function makeConfig(overrides: Partial<SprintConfig> = {}): SprintConfig {
 
 const passingQuality: QualityResult = {
   passed: true,
-  checks: [
-    { name: "tests-pass", passed: true, detail: "Tests passed", category: "test" },
-  ],
+  checks: [{ name: "tests-pass", passed: true, detail: "Tests passed", category: "test" }],
 };
 
 function makeResult(overrides: Partial<IssueResult> = {}): IssueResult {
@@ -165,11 +162,7 @@ describe("mergeCompletedBranches", () => {
     vi.mocked(mergeBranch).mockResolvedValue({ success: true });
 
     const results = [makeResult({ issueNumber: 5, branch: "sprint/3/issue-5" })];
-    await mergeCompletedBranches(
-      makeConfig({ deleteBranchAfterMerge: true }),
-      results,
-      "main",
-    );
+    await mergeCompletedBranches(makeConfig({ deleteBranchAfterMerge: true }), results, "main");
 
     expect(deleteBranch).toHaveBeenCalledWith("sprint/3/issue-5");
   });
@@ -178,11 +171,7 @@ describe("mergeCompletedBranches", () => {
     vi.mocked(mergeBranch).mockResolvedValue({ success: true });
 
     const results = [makeResult({ issueNumber: 5, branch: "sprint/3/issue-5" })];
-    await mergeCompletedBranches(
-      makeConfig({ deleteBranchAfterMerge: false }),
-      results,
-      "main",
-    );
+    await mergeCompletedBranches(makeConfig({ deleteBranchAfterMerge: false }), results, "main");
 
     expect(deleteBranch).not.toHaveBeenCalled();
   });
@@ -229,9 +218,7 @@ describe("mergeCompletedBranches", () => {
   });
 
   it("returns empty results when no issues are eligible", async () => {
-    const results = [
-      makeResult({ issueNumber: 1, status: "failed", qualityGatePassed: false }),
-    ];
+    const results = [makeResult({ issueNumber: 1, status: "failed", qualityGatePassed: false })];
     const outcome = await mergeCompletedBranches(makeConfig(), results, "main");
 
     expect(mergeBranch).not.toHaveBeenCalled();

--- a/tests/ceremonies/parallel-dispatcher.test.ts
+++ b/tests/ceremonies/parallel-dispatcher.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type {
-  SprintConfig,
-  SprintPlan,
-  SprintIssue,
-  IssueResult,
-} from "../../src/types.js";
+import type { SprintConfig, SprintPlan, SprintIssue, IssueResult } from "../../src/types.js";
 
 // --- Mocks ---
 
@@ -139,7 +134,7 @@ function makeConfig(overrides: Partial<SprintConfig> = {}): SprintConfig {
     maxRetries: 1,
     enableChallenger: false,
     autoRevertDrift: false,
-  backlogLabels: [],
+    backlogLabels: [],
     autoMerge: true,
     squashMerge: true,
     deleteBranchAfterMerge: true,
@@ -183,20 +178,14 @@ describe("runParallelExecution", () => {
 
   it("executes a single group of parallel issues", async () => {
     const issues = [makeIssue(1), makeIssue(2), makeIssue(3)];
-    vi.mocked(buildExecutionGroups).mockReturnValue([
-      { group: 0, issues: [1, 2, 3] },
-    ]);
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1, 2, 3] }]);
     vi.mocked(executeIssue)
       .mockResolvedValueOnce(makeResult(1))
       .mockResolvedValueOnce(makeResult(2))
       .mockResolvedValueOnce(makeResult(3));
     vi.mocked(mergeIssuePR).mockResolvedValue({ success: true });
 
-    const result = await runParallelExecution(
-      mockClient,
-      makeConfig(),
-      makePlan(issues),
-    );
+    const result = await runParallelExecution(mockClient, makeConfig(), makePlan(issues));
 
     expect(result.results).toHaveLength(3);
     expect(result.sprint).toBe(1);
@@ -220,11 +209,7 @@ describe("runParallelExecution", () => {
     });
     vi.mocked(mergeIssuePR).mockResolvedValue({ success: true });
 
-    const result = await runParallelExecution(
-      mockClient,
-      makeConfig(),
-      makePlan(issues),
-    );
+    const result = await runParallelExecution(mockClient, makeConfig(), makePlan(issues));
 
     expect(result.results).toHaveLength(3);
     // Issue 1 must execute before issues 2 & 3
@@ -235,9 +220,7 @@ describe("runParallelExecution", () => {
 
   it("handles merge conflicts by marking issue as failed", async () => {
     const issues = [makeIssue(1), makeIssue(2)];
-    vi.mocked(buildExecutionGroups).mockReturnValue([
-      { group: 0, issues: [1, 2] },
-    ]);
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1, 2] }]);
     vi.mocked(executeIssue)
       .mockResolvedValueOnce(makeResult(1))
       .mockResolvedValueOnce(makeResult(2));
@@ -245,11 +228,7 @@ describe("runParallelExecution", () => {
       .mockResolvedValueOnce({ success: true })
       .mockResolvedValueOnce({ success: false, reason: "merge conflict" });
 
-    const result = await runParallelExecution(
-      mockClient,
-      makeConfig(),
-      makePlan(issues),
-    );
+    const result = await runParallelExecution(mockClient, makeConfig(), makePlan(issues));
 
     expect(result.mergeConflicts).toBe(1);
     const failedResult = result.results.find((r) => r.issueNumber === 2);
@@ -260,9 +239,7 @@ describe("runParallelExecution", () => {
 
   it("skips merging when autoMerge is disabled", async () => {
     const issues = [makeIssue(1)];
-    vi.mocked(buildExecutionGroups).mockReturnValue([
-      { group: 0, issues: [1] },
-    ]);
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1] }]);
     vi.mocked(executeIssue).mockResolvedValueOnce(makeResult(1));
 
     const result = await runParallelExecution(
@@ -278,9 +255,7 @@ describe("runParallelExecution", () => {
 
   it("respects concurrency limit via p-limit", async () => {
     const issues = [makeIssue(1), makeIssue(2), makeIssue(3), makeIssue(4)];
-    vi.mocked(buildExecutionGroups).mockReturnValue([
-      { group: 0, issues: [1, 2, 3, 4] },
-    ]);
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1, 2, 3, 4] }]);
 
     let concurrent = 0;
     let maxConcurrent = 0;
@@ -366,38 +341,26 @@ describe("runParallelExecution", () => {
 
   it("computes avgWorktreeLifetime from durations", async () => {
     const issues = [makeIssue(1), makeIssue(2)];
-    vi.mocked(buildExecutionGroups).mockReturnValue([
-      { group: 0, issues: [1, 2] },
-    ]);
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1, 2] }]);
     vi.mocked(executeIssue)
       .mockResolvedValueOnce({ ...makeResult(1), duration_ms: 2000 })
       .mockResolvedValueOnce({ ...makeResult(2), duration_ms: 4000 });
     vi.mocked(mergeIssuePR).mockResolvedValue({ success: true });
 
-    const result = await runParallelExecution(
-      mockClient,
-      makeConfig(),
-      makePlan(issues),
-    );
+    const result = await runParallelExecution(mockClient, makeConfig(), makePlan(issues));
 
     expect(result.avgWorktreeLifetime).toBe(3000);
   });
 
   it("tracks rejected executeIssue as failed IssueResult", async () => {
     const issues = [makeIssue(1), makeIssue(2)];
-    vi.mocked(buildExecutionGroups).mockReturnValue([
-      { group: 0, issues: [1, 2] },
-    ]);
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1, 2] }]);
     vi.mocked(executeIssue)
       .mockResolvedValueOnce(makeResult(1))
       .mockRejectedValueOnce(new Error("session crashed"));
     vi.mocked(mergeIssuePR).mockResolvedValue({ success: true });
 
-    const result = await runParallelExecution(
-      mockClient,
-      makeConfig(),
-      makePlan(issues),
-    );
+    const result = await runParallelExecution(mockClient, makeConfig(), makePlan(issues));
 
     expect(result.results).toHaveLength(2);
     const rejected = result.results.find((r) => r.issueNumber === 2)!;
@@ -410,20 +373,14 @@ describe("runParallelExecution", () => {
 
   it("counts fulfilled-failed and rejected correctly in mixed results", async () => {
     const issues = [makeIssue(1), makeIssue(2), makeIssue(3)];
-    vi.mocked(buildExecutionGroups).mockReturnValue([
-      { group: 0, issues: [1, 2, 3] },
-    ]);
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1, 2, 3] }]);
     vi.mocked(executeIssue)
-      .mockResolvedValueOnce(makeResult(1))              // fulfilled, completed
-      .mockResolvedValueOnce(makeResult(2, "failed"))     // fulfilled, failed
-      .mockRejectedValueOnce(new Error("timeout"));       // rejected
+      .mockResolvedValueOnce(makeResult(1)) // fulfilled, completed
+      .mockResolvedValueOnce(makeResult(2, "failed")) // fulfilled, failed
+      .mockRejectedValueOnce(new Error("timeout")); // rejected
     vi.mocked(mergeIssuePR).mockResolvedValue({ success: true });
 
-    const result = await runParallelExecution(
-      mockClient,
-      makeConfig(),
-      makePlan(issues),
-    );
+    const result = await runParallelExecution(mockClient, makeConfig(), makePlan(issues));
 
     expect(result.results).toHaveLength(3);
     const completed = result.results.filter((r) => r.status === "completed");
@@ -436,11 +393,7 @@ describe("runParallelExecution", () => {
   it("returns empty results for plan with no issues", async () => {
     vi.mocked(buildExecutionGroups).mockReturnValue([]);
 
-    const result = await runParallelExecution(
-      mockClient,
-      makeConfig(),
-      makePlan([]),
-    );
+    const result = await runParallelExecution(mockClient, makeConfig(), makePlan([]));
 
     expect(result.results).toHaveLength(0);
     expect(result.parallelizationRatio).toBe(1);
@@ -452,9 +405,7 @@ describe("runParallelExecution", () => {
 
   it("runs pre-merge verification before mergeIssuePR", async () => {
     const issues = [makeIssue(1)];
-    vi.mocked(buildExecutionGroups).mockReturnValue([
-      { group: 0, issues: [1] },
-    ]);
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1] }]);
     vi.mocked(executeIssue).mockResolvedValueOnce(makeResult(1));
     vi.mocked(mergeIssuePR).mockResolvedValue({ success: true });
 
@@ -468,9 +419,7 @@ describe("runParallelExecution", () => {
 
   it("blocks issue and skips merge when pre-merge verification detects conflicts", async () => {
     const issues = [makeIssue(1)];
-    vi.mocked(buildExecutionGroups).mockReturnValue([
-      { group: 0, issues: [1] },
-    ]);
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1] }]);
     vi.mocked(executeIssue).mockResolvedValueOnce(makeResult(1));
     vi.mocked(hasConflicts).mockResolvedValue(true);
 
@@ -486,18 +435,16 @@ describe("runParallelExecution", () => {
 
   it("blocks issue when tests fail in pre-merge verification", async () => {
     const issues = [makeIssue(1)];
-    vi.mocked(buildExecutionGroups).mockReturnValue([
-      { group: 0, issues: [1] },
-    ]);
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1] }]);
     vi.mocked(executeIssue).mockResolvedValueOnce(makeResult(1));
     // execFile: rebase calls (fetch, rebase, push) then pre-merge (fetch, merge, npm test fails)
     mockExecFileAsync
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git fetch
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git rebase
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git push
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // pre-merge: git fetch
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // pre-merge: git merge
-      .mockRejectedValueOnce(new Error("test failure"));  // pre-merge: npm test
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }) // rebase: git fetch
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }) // rebase: git rebase
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }) // rebase: git push
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }) // pre-merge: git fetch
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }) // pre-merge: git merge
+      .mockRejectedValueOnce(new Error("test failure")); // pre-merge: npm test
 
     const result = await runParallelExecution(mockClient, makeConfig(), makePlan(issues));
 
@@ -511,19 +458,17 @@ describe("runParallelExecution", () => {
 
   it("blocks issue when type check fails in pre-merge verification", async () => {
     const issues = [makeIssue(1)];
-    vi.mocked(buildExecutionGroups).mockReturnValue([
-      { group: 0, issues: [1] },
-    ]);
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1] }]);
     vi.mocked(executeIssue).mockResolvedValueOnce(makeResult(1));
     // execFile: rebase calls (fetch, rebase, push) then pre-merge (fetch, merge, tests ok, typecheck fails)
     mockExecFileAsync
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git fetch
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git rebase
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git push
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // pre-merge: git fetch
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // pre-merge: git merge
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // pre-merge: npm test
-      .mockRejectedValueOnce(new Error("type error"));    // pre-merge: tsc --noEmit
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }) // rebase: git fetch
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }) // rebase: git rebase
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }) // rebase: git push
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }) // pre-merge: git fetch
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }) // pre-merge: git merge
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }) // pre-merge: npm test
+      .mockRejectedValueOnce(new Error("type error")); // pre-merge: tsc --noEmit
 
     const result = await runParallelExecution(mockClient, makeConfig(), makePlan(issues));
 
@@ -535,9 +480,7 @@ describe("runParallelExecution", () => {
 
   it("proceeds with merge when pre-merge verification passes", async () => {
     const issues = [makeIssue(1)];
-    vi.mocked(buildExecutionGroups).mockReturnValue([
-      { group: 0, issues: [1] },
-    ]);
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1] }]);
     vi.mocked(executeIssue).mockResolvedValueOnce(makeResult(1));
     vi.mocked(mergeIssuePR).mockResolvedValue({ success: true });
 
@@ -553,17 +496,15 @@ describe("runParallelExecution", () => {
 
   it("cleans up worktree even when pre-merge verification fails", async () => {
     const issues = [makeIssue(1)];
-    vi.mocked(buildExecutionGroups).mockReturnValue([
-      { group: 0, issues: [1] },
-    ]);
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1] }]);
     vi.mocked(executeIssue).mockResolvedValueOnce(makeResult(1));
     mockExecFileAsync
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git fetch
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git rebase
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // rebase: git push
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // pre-merge: git fetch
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })  // pre-merge: git merge
-      .mockRejectedValueOnce(new Error("test failure"));  // pre-merge: npm test
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }) // rebase: git fetch
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }) // rebase: git rebase
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }) // rebase: git push
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }) // pre-merge: git fetch
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }) // pre-merge: git merge
+      .mockRejectedValueOnce(new Error("test failure")); // pre-merge: npm test
 
     await runParallelExecution(mockClient, makeConfig(), makePlan(issues));
 

--- a/tests/ceremonies/planning.test.ts
+++ b/tests/ceremonies/planning.test.ts
@@ -7,16 +7,12 @@ import type { SprintConfig, SprintPlan } from "../../src/types.js";
 
 describe("substitutePrompt", () => {
   it("replaces single placeholder", () => {
-    expect(substitutePrompt("Hello {{NAME}}", { NAME: "World" })).toBe(
-      "Hello World",
-    );
+    expect(substitutePrompt("Hello {{NAME}}", { NAME: "World" })).toBe("Hello World");
   });
 
   it("replaces multiple distinct placeholders", () => {
     const tpl = "Sprint {{NUM}} for {{PROJECT}}";
-    expect(substitutePrompt(tpl, { NUM: "5", PROJECT: "myapp" })).toBe(
-      "Sprint 5 for myapp",
-    );
+    expect(substitutePrompt(tpl, { NUM: "5", PROJECT: "myapp" })).toBe("Sprint 5 for myapp");
   });
 
   it("replaces repeated occurrences of the same placeholder", () => {
@@ -48,7 +44,7 @@ describe("extractJson", () => {
   });
 
   it("extracts JSON array from text", () => {
-    const text = 'Here is the data: [1,2,3] and done.';
+    const text = "Here is the data: [1,2,3] and done.";
     expect(extractJson(text)).toEqual([1, 2, 3]);
   });
 
@@ -125,25 +121,26 @@ vi.mock("../../src/documentation/velocity.js", () => ({
 }));
 vi.mock("../../src/logger.js", () => {
   const noop = () => {};
-  const childLogger = { info: noop, debug: noop, warn: noop, error: noop, child: () => childLogger };
+  const childLogger = {
+    info: noop,
+    debug: noop,
+    warn: noop,
+    error: noop,
+    child: () => childLogger,
+  };
   return { logger: childLogger };
 });
 vi.mock("node:fs/promises", () => ({
   default: {
-    readFile: vi.fn().mockResolvedValue(
-      "Sprint {{SPRINT_NUMBER}} plan for {{PROJECT_NAME}}",
-    ),
+    readFile: vi.fn().mockResolvedValue("Sprint {{SPRINT_NUMBER}} plan for {{PROJECT_NAME}}"),
   },
 }));
 
 const { listIssues } = await import("../../src/github/issues.js");
 const { setLabel } = await import("../../src/github/labels.js");
-const { getMilestone, createMilestone, setMilestone } = await import(
-  "../../src/github/milestones.js"
-);
-const { createSprintLog } = await import(
-  "../../src/documentation/sprint-log.js"
-);
+const { getMilestone, createMilestone, setMilestone } =
+  await import("../../src/github/milestones.js");
+const { createSprintLog } = await import("../../src/documentation/sprint-log.js");
 
 function makeConfig(overrides: Partial<SprintConfig> = {}): SprintConfig {
   return {
@@ -160,7 +157,7 @@ function makeConfig(overrides: Partial<SprintConfig> = {}): SprintConfig {
     maxRetries: 1,
     enableChallenger: false,
     autoRevertDrift: false,
-  backlogLabels: [],
+    backlogLabels: [],
     autoMerge: true,
     squashMerge: true,
     deleteBranchAfterMerge: true,
@@ -202,7 +199,13 @@ const planResponse: SprintPlan = {
 
 function makeMockClient() {
   return {
-    createSession: vi.fn().mockResolvedValue({ sessionId: "session-123", availableModes: [], currentMode: "", availableModels: [], currentModel: "" }),
+    createSession: vi.fn().mockResolvedValue({
+      sessionId: "session-123",
+      availableModes: [],
+      currentMode: "",
+      availableModels: [],
+      currentModel: "",
+    }),
     sendPrompt: vi.fn().mockResolvedValue({
       response: "```json\n" + JSON.stringify(planResponse) + "\n```",
       stopReason: "end_turn",
@@ -257,7 +260,14 @@ describe("runSprintPlanning", () => {
     expect(createMilestone).toHaveBeenCalledOnce();
 
     // Sprint log created
-    expect(createSprintLog).toHaveBeenCalledWith(3, planResponse.rationale, 2, undefined, "Sprint", "sprint");
+    expect(createSprintLog).toHaveBeenCalledWith(
+      3,
+      planResponse.rationale,
+      2,
+      undefined,
+      "Sprint",
+      "sprint",
+    );
   });
 
   it("skips milestone creation when it already exists", async () => {
@@ -285,9 +295,7 @@ describe("runSprintPlanning", () => {
     vi.mocked(listIssues).mockResolvedValue([]);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await expect(runSprintPlanning(mockClient as any, makeConfig())).rejects.toThrow(
-      "timeout",
-    );
+    await expect(runSprintPlanning(mockClient as any, makeConfig())).rejects.toThrow("timeout");
 
     expect(mockClient.endSession).toHaveBeenCalledWith("session-123");
   });

--- a/tests/ceremonies/quality-retry.test.ts
+++ b/tests/ceremonies/quality-retry.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type {
-  SprintConfig,
-  SprintIssue,
-  QualityResult,
-} from "../../src/types.js";
+import type { SprintConfig, SprintIssue, QualityResult } from "../../src/types.js";
 
 vi.mock("../../src/acp/session-config.js", () => ({
   resolveSessionConfig: vi.fn().mockResolvedValue({
@@ -29,13 +25,10 @@ vi.mock("../../src/logger.js", () => {
   return { logger: childLogger, appendErrorLog: noop };
 });
 
-const { runQualityGate } = await import(
-  "../../src/enforcement/quality-gate.js"
-);
+const { runQualityGate } = await import("../../src/enforcement/quality-gate.js");
 
-const { handleQualityFailure, buildQualityGateConfig, DEFAULT_QUALITY_GATE_CONFIG } = await import(
-  "../../src/ceremonies/quality-retry.js"
-);
+const { handleQualityFailure, buildQualityGateConfig, DEFAULT_QUALITY_GATE_CONFIG } =
+  await import("../../src/ceremonies/quality-retry.js");
 
 // --- Helpers ---
 
@@ -82,7 +75,13 @@ function makeIssue(overrides: Partial<SprintIssue> = {}): SprintIssue {
 
 function makeMockClient() {
   return {
-    createSession: vi.fn().mockResolvedValue({ sessionId: "session-abc", availableModes: [], currentMode: "", availableModels: [], currentModel: "" }),
+    createSession: vi.fn().mockResolvedValue({
+      sessionId: "session-abc",
+      availableModes: [],
+      currentMode: "",
+      availableModels: [],
+      currentModel: "",
+    }),
     sendPrompt: vi.fn().mockResolvedValue({
       response: "Done implementing issue",
       stopReason: "end_turn",

--- a/tests/ceremonies/refinement.test.ts
+++ b/tests/ceremonies/refinement.test.ts
@@ -82,9 +82,13 @@ const refinementResponse = {
 
 function makeMockClient() {
   return {
-    createSession: vi
-      .fn()
-      .mockResolvedValue({ sessionId: "session-ref-1", availableModes: [], currentMode: "", availableModels: [], currentModel: "" }),
+    createSession: vi.fn().mockResolvedValue({
+      sessionId: "session-ref-1",
+      availableModes: [],
+      currentMode: "",
+      availableModels: [],
+      currentModel: "",
+    }),
     sendPrompt: vi.fn().mockResolvedValue({
       response: "```json\n" + JSON.stringify(refinementResponse) + "\n```",
       stopReason: "end_turn",

--- a/tests/ceremonies/retro.test.ts
+++ b/tests/ceremonies/retro.test.ts
@@ -163,9 +163,13 @@ const retroResponse = {
 
 function makeMockClient() {
   return {
-    createSession: vi
-      .fn()
-      .mockResolvedValue({ sessionId: "session-ret-1", availableModes: [], currentMode: "", availableModels: [], currentModel: "" }),
+    createSession: vi.fn().mockResolvedValue({
+      sessionId: "session-ret-1",
+      availableModes: [],
+      currentMode: "",
+      availableModels: [],
+      currentModel: "",
+    }),
     sendPrompt: vi.fn().mockResolvedValue({
       response: "```json\n" + JSON.stringify(retroResponse) + "\n```",
       stopReason: "end_turn",
@@ -442,7 +446,9 @@ describe("runSprintRetro", () => {
     expect(mockClient.sendPrompt).toHaveBeenCalledTimes(1);
 
     // Logger warn should have been called for non-auto-applicable
-    const childLogger = (logger as unknown as { child: () => { warn: ReturnType<typeof vi.fn> } }).child();
+    const childLogger = (
+      logger as unknown as { child: () => { warn: ReturnType<typeof vi.fn> } }
+    ).child();
     expect(childLogger.warn).toHaveBeenCalledWith(
       { title: "Manual change needed", target: "process" },
       "Skipping non-auto-applicable improvement",

--- a/tests/ceremonies/review.test.ts
+++ b/tests/ceremonies/review.test.ts
@@ -44,7 +44,9 @@ vi.mock("node:fs/promises", () => ({
   default: {
     readFile: vi
       .fn()
-      .mockResolvedValue("Review for sprint {{SPRINT_NUMBER}} project {{PROJECT_NAME}} flagged:{{FLAGGED_PRS}}"),
+      .mockResolvedValue(
+        "Review for sprint {{SPRINT_NUMBER}} project {{PROJECT_NAME}} flagged:{{FLAGGED_PRS}}",
+      ),
   },
 }));
 
@@ -115,9 +117,13 @@ const reviewResponse = {
 
 function makeMockClient() {
   return {
-    createSession: vi
-      .fn()
-      .mockResolvedValue({ sessionId: "session-rev-1", availableModes: [], currentMode: "", availableModels: [], currentModel: "" }),
+    createSession: vi.fn().mockResolvedValue({
+      sessionId: "session-rev-1",
+      availableModes: [],
+      currentMode: "",
+      availableModels: [],
+      currentModel: "",
+    }),
     sendPrompt: vi.fn().mockResolvedValue({
       response: "```json\n" + JSON.stringify(reviewResponse) + "\n```",
       stopReason: "end_turn",
@@ -219,7 +225,7 @@ describe("runSprintReview", () => {
   it("flags closed-without-merge PRs in review prompt", async () => {
     const mockClient = makeMockClient();
     const { getPRStatus } = await import("../../src/git/merge.js");
-    
+
     vi.mocked(getPRStatus).mockResolvedValueOnce({ prNumber: 123, state: "CLOSED" });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -234,7 +240,7 @@ describe("runSprintReview", () => {
   it("passes review when all PRs are merged", async () => {
     const mockClient = makeMockClient();
     const { getPRStatus } = await import("../../src/git/merge.js");
-    
+
     vi.mocked(getPRStatus).mockResolvedValueOnce({ prNumber: 456, state: "MERGED" });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -249,7 +255,7 @@ describe("runSprintReview", () => {
   it("handles missing PRs gracefully", async () => {
     const mockClient = makeMockClient();
     const { getPRStatus } = await import("../../src/git/merge.js");
-    
+
     vi.mocked(getPRStatus).mockResolvedValueOnce(undefined);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/cli/helpers.test.ts
+++ b/tests/cli/helpers.test.ts
@@ -5,7 +5,10 @@ import type { ConfigFile } from "../../src/config.js";
 vi.mock("../../src/config.js", () => ({
   loadConfig: vi.fn(),
   prefixToSlug: vi.fn((p: string) =>
-    p.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, ""),
+    p
+      .toLowerCase()
+      .replace(/\s+/g, "-")
+      .replace(/[^a-z0-9-]/g, ""),
   ),
 }));
 

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -38,7 +38,13 @@ describe("initProject", () => {
     initProject({ targetPath: tmpDir });
 
     for (const role of ["refiner", "planner", "reviewer", "researcher", "general", "retro"]) {
-      const instructionsPath = path.join(tmpDir, ".aiscrum", "roles", role, "copilot-instructions.md");
+      const instructionsPath = path.join(
+        tmpDir,
+        ".aiscrum",
+        "roles",
+        role,
+        "copilot-instructions.md",
+      );
       expect(fs.existsSync(instructionsPath), `${role} instructions missing`).toBe(true);
     }
   });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -96,9 +96,7 @@ project:
   });
 
   it("throws on missing config file", () => {
-    expect(() => loadConfig("/nonexistent/path.yaml")).toThrow(
-      "Config file not found",
-    );
+    expect(() => loadConfig("/nonexistent/path.yaml")).toThrow("Config file not found");
   });
 
   it("throws on invalid config (missing required project.name)", () => {
@@ -190,10 +188,14 @@ copilot:
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "config-qg-"));
     const configFile = path.join(dir, "config.yaml");
 
-    fs.writeFileSync(configFile, `
+    fs.writeFileSync(
+      configFile,
+      `
 project:
   name: "qg-test"
-`, "utf-8");
+`,
+      "utf-8",
+    );
 
     const config = loadConfig(configFile);
     expect(config.quality_gates.require_tests).toBe(true);
@@ -207,13 +209,17 @@ project:
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "config-inline-"));
     const configFile = path.join(dir, "config.yaml");
 
-    fs.writeFileSync(configFile, `
+    fs.writeFileSync(
+      configFile,
+      `
 project:
   name: "inline-test"
 quality_gates:
   require_tests: false
   max_diff_lines: 100
-`, "utf-8");
+`,
+      "utf-8",
+    );
 
     const config = loadConfig(configFile);
     expect(config.quality_gates.require_tests).toBe(false);

--- a/tests/dashboard/chat-manager.test.ts
+++ b/tests/dashboard/chat-manager.test.ts
@@ -108,7 +108,10 @@ describe("ChatManager", () => {
       const updated = manager.getSession(session.id)!;
       expect(updated.messages).toHaveLength(2);
       expect(updated.messages[0]).toMatchObject({ role: "user", content: "Hello" });
-      expect(updated.messages[1]).toMatchObject({ role: "assistant", content: "Hello from assistant" });
+      expect(updated.messages[1]).toMatchObject({
+        role: "assistant",
+        content: "Hello from assistant",
+      });
     });
 
     it("throws when session does not exist", async () => {
@@ -199,9 +202,7 @@ describe("ChatManager", () => {
     it("propagates ACP sendPrompt errors", async () => {
       const session = await manager.createSession("general");
 
-      vi.mocked(AcpClient.prototype.sendPrompt).mockRejectedValueOnce(
-        new Error("ACP timeout"),
-      );
+      vi.mocked(AcpClient.prototype.sendPrompt).mockRejectedValueOnce(new Error("ACP timeout"));
 
       await expect(manager.sendMessage(session.id, "test")).rejects.toThrow("ACP timeout");
     });
@@ -222,26 +223,28 @@ describe("ChatManager", () => {
       const chunks: { sessionId: string; text: string }[] = [];
 
       // Capture the onStreamChunk passed to AcpClient constructor
-      vi.mocked(AcpClient).mockImplementationOnce((opts: { onStreamChunk?: (id: string, text: string) => void }) => {
-        // Store the internal callback for later invocation
-        const instance = {
-          connect: vi.fn().mockResolvedValue(undefined),
-          createSession: vi.fn().mockResolvedValue({
-            sessionId: "acp-stream-1",
-            currentModel: "gpt-4",
-          }),
-          setMode: vi.fn().mockResolvedValue(undefined),
-          sendPrompt: vi.fn().mockImplementation(async () => {
-            // Simulate streaming by calling the internal callback
-            opts.onStreamChunk?.("acp-stream-1", "chunk1");
-            opts.onStreamChunk?.("acp-stream-1", "chunk2");
-            return { response: "chunk1chunk2", stopReason: "end" };
-          }),
-          endSession: vi.fn().mockResolvedValue(undefined),
-          disconnect: vi.fn().mockResolvedValue(undefined),
-        };
-        return instance as unknown as AcpClient;
-      });
+      vi.mocked(AcpClient).mockImplementationOnce(
+        (opts: { onStreamChunk?: (id: string, text: string) => void }) => {
+          // Store the internal callback for later invocation
+          const instance = {
+            connect: vi.fn().mockResolvedValue(undefined),
+            createSession: vi.fn().mockResolvedValue({
+              sessionId: "acp-stream-1",
+              currentModel: "gpt-4",
+            }),
+            setMode: vi.fn().mockResolvedValue(undefined),
+            sendPrompt: vi.fn().mockImplementation(async () => {
+              // Simulate streaming by calling the internal callback
+              opts.onStreamChunk?.("acp-stream-1", "chunk1");
+              opts.onStreamChunk?.("acp-stream-1", "chunk2");
+              return { response: "chunk1chunk2", stopReason: "end" };
+            }),
+            endSession: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
+          };
+          return instance as unknown as AcpClient;
+        },
+      );
 
       const mgr = new ChatManager({
         projectPath: "/tmp/test",

--- a/tests/dashboard/session-control.test.ts
+++ b/tests/dashboard/session-control.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("../../src/logger.js", () => {
   const noop = vi.fn();
-  return { logger: { child: () => ({ info: noop, warn: noop, error: noop, debug: noop }) }, appendErrorLog: noop, getErrorLogDir: () => undefined };
+  return {
+    logger: { child: () => ({ info: noop, warn: noop, error: noop, debug: noop }) },
+    appendErrorLog: noop,
+    getErrorLogDir: () => undefined,
+  };
 });
 
 import { SessionController } from "../../src/dashboard/session-control.js";

--- a/tests/dashboard/session-logger.test.ts
+++ b/tests/dashboard/session-logger.test.ts
@@ -22,7 +22,11 @@ function makeSession(overrides?: Partial<ChatSession>): ChatSession {
     createdAt: new Date("2026-02-28T14:00:00Z"),
     messages: [
       { role: "user", content: "Refine issue #10", timestamp: new Date("2026-02-28T14:00:01Z") },
-      { role: "assistant", content: "I'll read the issue first.", timestamp: new Date("2026-02-28T14:00:02Z") },
+      {
+        role: "assistant",
+        content: "I'll read the issue first.",
+        timestamp: new Date("2026-02-28T14:00:02Z"),
+      },
     ],
     ...overrides,
   };

--- a/tests/dashboard/sprint-history.test.ts
+++ b/tests/dashboard/sprint-history.test.ts
@@ -71,33 +71,25 @@ describe("loadSprintHistory", () => {
   });
 
   it("computes avgDuration as (hours / done) * 60", () => {
-    mockedReadVelocity.mockReturnValue([
-      makeEntry({ hours: 6, done: 3 }),
-    ]);
+    mockedReadVelocity.mockReturnValue([makeEntry({ hours: 6, done: 3 })]);
     const [entry] = loadSprintHistory();
     expect(entry!.metrics.avgDuration).toBe(120); // (6/3)*60
   });
 
   it("sets avgDuration to 0 when hours is 0", () => {
-    mockedReadVelocity.mockReturnValue([
-      makeEntry({ hours: 0, done: 5 }),
-    ]);
+    mockedReadVelocity.mockReturnValue([makeEntry({ hours: 0, done: 5 })]);
     const [entry] = loadSprintHistory();
     expect(entry!.metrics.avgDuration).toBe(0);
   });
 
   it("sets avgDuration to 0 when done is 0", () => {
-    mockedReadVelocity.mockReturnValue([
-      makeEntry({ hours: 4, done: 0 }),
-    ]);
+    mockedReadVelocity.mockReturnValue([makeEntry({ hours: 4, done: 0 })]);
     const [entry] = loadSprintHistory();
     expect(entry!.metrics.avgDuration).toBe(0);
   });
 
   it("sets firstPassRate to 0 when planned is 0", () => {
-    mockedReadVelocity.mockReturnValue([
-      makeEntry({ planned: 0, done: 0 }),
-    ]);
+    mockedReadVelocity.mockReturnValue([makeEntry({ planned: 0, done: 0 })]);
     const [entry] = loadSprintHistory();
     expect(entry!.metrics.firstPassRate).toBe(0);
   });

--- a/tests/dashboard/ws-server.test.ts
+++ b/tests/dashboard/ws-server.test.ts
@@ -9,8 +9,13 @@ function waitForCondition(check: () => boolean, timeoutMs = 5000, intervalMs = 5
   return new Promise((resolve, reject) => {
     const start = Date.now();
     const poll = setInterval(() => {
-      if (check()) { clearInterval(poll); resolve(); }
-      else if (Date.now() - start > timeoutMs) { clearInterval(poll); reject(new Error("Timeout waiting for condition")); }
+      if (check()) {
+        clearInterval(poll);
+        resolve();
+      } else if (Date.now() - start > timeoutMs) {
+        clearInterval(poll);
+        reject(new Error("Timeout waiting for condition"));
+      }
     }, intervalMs);
   });
 }
@@ -41,9 +46,7 @@ function makeOptions(overrides?: Partial<DashboardServerOptions>): DashboardServ
     host: "127.0.0.1",
     eventBus: bus,
     getState: () => state,
-    getIssues: () => [
-      { number: 1, title: "Test issue", status: "planned" },
-    ],
+    getIssues: () => [{ number: 1, title: "Test issue", status: "planned" }],
     ...overrides,
   };
 }
@@ -119,7 +122,10 @@ describe("DashboardWebServer", () => {
         }
       });
       ws.on("error", reject);
-      setTimeout(() => { ws.close(); reject(new Error("timeout")); }, 5000);
+      setTimeout(() => {
+        ws.close();
+        reject(new Error("timeout"));
+      }, 5000);
     });
 
     // First message: sprint state
@@ -161,7 +167,10 @@ describe("DashboardWebServer", () => {
         resolve();
       });
       ws.on("error", reject);
-      setTimeout(() => { ws.close(); reject(new Error("timeout")); }, 5000);
+      setTimeout(() => {
+        ws.close();
+        reject(new Error("timeout"));
+      }, 5000);
     });
 
     expect(events[0]).toMatchObject({
@@ -173,7 +182,9 @@ describe("DashboardWebServer", () => {
 
   it("handles client sprint:start message", async () => {
     let started = false;
-    options.onStart = () => { started = true; };
+    options.onStart = () => {
+      started = true;
+    };
     server = new DashboardWebServer(options);
 
     await server.start();
@@ -187,8 +198,14 @@ describe("DashboardWebServer", () => {
       });
       ws.on("error", reject);
       waitForCondition(() => started)
-        .then(() => { ws.close(); resolve(); })
-        .catch(() => { ws.close(); reject(new Error("timeout waiting for sprint:start handler")); });
+        .then(() => {
+          ws.close();
+          resolve();
+        })
+        .catch(() => {
+          ws.close();
+          reject(new Error("timeout waiting for sprint:start handler"));
+        });
     });
 
     expect(started).toBe(true);
@@ -209,7 +226,7 @@ describe("DashboardWebServer", () => {
     const port = getPort(server);
     const res = await fetch(`http://127.0.0.1:${port}/api/sprints`);
     expect(res.status).toBe(200);
-    const data = await res.json() as { sprintNumber: number; phase: string; isActive: boolean }[];
+    const data = (await res.json()) as { sprintNumber: number; phase: string; isActive: boolean }[];
     // Should at least include the active sprint from getState
     expect(Array.isArray(data)).toBe(true);
   });
@@ -221,7 +238,7 @@ describe("DashboardWebServer", () => {
     const port = getPort(server);
     const res = await fetch(`http://127.0.0.1:${port}/api/sprints/1/state`);
     expect(res.status).toBe(200);
-    const data = await res.json() as { sprintNumber: number; phase: string };
+    const data = (await res.json()) as { sprintNumber: number; phase: string };
     expect(data.sprintNumber).toBe(1);
     expect(data.phase).toBe("init");
   });
@@ -231,7 +248,7 @@ describe("DashboardWebServer", () => {
     const port = getPort(server);
     const res = await fetch(`http://127.0.0.1:${port}/api/sprints/999/state`);
     expect(res.status).toBe(200);
-    const data = await res.json() as { sprintNumber: number; phase: string };
+    const data = (await res.json()) as { sprintNumber: number; phase: string };
     expect(data.sprintNumber).toBe(999);
     expect(data.phase).toBe("init");
   });
@@ -253,7 +270,7 @@ describe("DashboardWebServer", () => {
     await server.start();
     const port = getPort(server);
     const res = await fetch(`http://127.0.0.1:${port}/api/sprints`);
-    const data = await res.json() as { sprintNumber: number; isActive: boolean }[];
+    const data = (await res.json()) as { sprintNumber: number; isActive: boolean }[];
     const active = data.find((s) => s.sprintNumber === 3);
     expect(active).toBeDefined();
     expect(active!.isActive).toBe(true);
@@ -265,7 +282,7 @@ describe("DashboardWebServer", () => {
     await server.start();
     const port = getPort(server);
     const res = await fetch(`http://127.0.0.1:${port}/api/sprints`);
-    const data = await res.json() as { sprintNumber: number }[];
+    const data = (await res.json()) as { sprintNumber: number }[];
     const numbers = data.map((s) => s.sprintNumber);
     // Should have sprint 1, 2, 3 (gaps filled)
     expect(numbers).toContain(1);
@@ -280,7 +297,7 @@ describe("DashboardWebServer", () => {
     const port = getPort(server);
     const res = await fetch(`http://127.0.0.1:${port}/api/sprints/999/state`);
     expect(res.status).toBe(200);
-    const data = await res.json() as { sprintNumber: number; phase: string };
+    const data = (await res.json()) as { sprintNumber: number; phase: string };
     expect(data.sprintNumber).toBe(999);
     expect(data.phase).toBe("init");
   });
@@ -291,7 +308,7 @@ describe("DashboardWebServer", () => {
     await server.start();
     const port = getPort(server);
     const res = await fetch(`http://127.0.0.1:${port}/api/sprints`);
-    const data = await res.json() as { sprintNumber: number }[];
+    const data = (await res.json()) as { sprintNumber: number }[];
     for (let i = 1; i < data.length; i++) {
       expect(data[i].sprintNumber).toBeGreaterThan(data[i - 1].sprintNumber);
     }
@@ -347,7 +364,7 @@ describe("DashboardWebServer", () => {
 
     // Check session appears in API
     const res = await fetch(`http://127.0.0.1:${port}/api/sessions`);
-    const data = await res.json() as { sessionId: string; role: string; issueNumber: number }[];
+    const data = (await res.json()) as { sessionId: string; role: string; issueNumber: number }[];
     expect(data).toHaveLength(1);
     expect(data[0].sessionId).toBe("test-session-1");
     expect(data[0].role).toBe("worker");
@@ -358,7 +375,7 @@ describe("DashboardWebServer", () => {
 
     // Session should still be in list but with endedAt
     const res2 = await fetch(`http://127.0.0.1:${port}/api/sessions`);
-    const data2 = await res2.json() as { endedAt: number | undefined }[];
+    const data2 = (await res2.json()) as { endedAt: number | undefined }[];
     expect(data2).toHaveLength(1);
     expect(data2[0].endedAt).toBeDefined();
   });
@@ -367,7 +384,12 @@ describe("DashboardWebServer", () => {
 
   it("sends fresh state and issues on sprint:switch", async () => {
     options = makeOptions({ activeSprintNumber: 2 });
-    const state: SprintState = { version: "1", sprintNumber: 2, phase: "execute", startedAt: new Date() };
+    const state: SprintState = {
+      version: "1",
+      sprintNumber: 2,
+      phase: "execute",
+      startedAt: new Date(),
+    };
     options.getState = () => state;
     server = new DashboardWebServer(options);
     await server.start();
@@ -397,7 +419,10 @@ describe("DashboardWebServer", () => {
         }
       });
       ws.on("error", reject);
-      setTimeout(() => { ws.close(); reject(new Error("timeout")); }, 5000);
+      setTimeout(() => {
+        ws.close();
+        reject(new Error("timeout"));
+      }, 5000);
     });
 
     // Should receive fresh state, issues, and switch confirmation
@@ -407,9 +432,7 @@ describe("DashboardWebServer", () => {
   });
 
   it("broadcasts updated issues on sprint:planned event", async () => {
-    const testIssues = [
-      { number: 10, title: "Test Issue", status: "planned" },
-    ];
+    const testIssues = [{ number: 10, title: "Test Issue", status: "planned" }];
     options = makeOptions({ activeSprintNumber: 1 });
     options.getIssues = () => testIssues;
     server = new DashboardWebServer(options);
@@ -441,7 +464,10 @@ describe("DashboardWebServer", () => {
         }
       });
       ws.on("error", reject);
-      setTimeout(() => { ws.close(); reject(new Error("timeout")); }, 5000);
+      setTimeout(() => {
+        ws.close();
+        reject(new Error("timeout"));
+      }, 5000);
     });
 
     expect(receivedIssues).toHaveLength(1);
@@ -466,7 +492,7 @@ describe("DashboardWebServer", () => {
 
     const res = await fetch(`http://127.0.0.1:${port}/api/sprints/1/state`);
     expect(res.status).toBe(200);
-    const data = await res.json() as { sprintNumber: number; phase: string };
+    const data = (await res.json()) as { sprintNumber: number; phase: string };
     expect(data.sprintNumber).toBe(1);
     expect(data.phase).toBe("complete");
 
@@ -479,7 +505,11 @@ describe("DashboardWebServer", () => {
 
   it("handles sprint:pause message and calls onPause", async () => {
     let paused = false;
-    options = makeOptions({ onPause: () => { paused = true; } });
+    options = makeOptions({
+      onPause: () => {
+        paused = true;
+      },
+    });
     server = new DashboardWebServer(options);
     await server.start();
     const port = getPort(server);
@@ -491,8 +521,14 @@ describe("DashboardWebServer", () => {
       });
       ws.on("error", reject);
       waitForCondition(() => paused)
-        .then(() => { ws.close(); resolve(); })
-        .catch(() => { ws.close(); reject(new Error("timeout waiting for onPause")); });
+        .then(() => {
+          ws.close();
+          resolve();
+        })
+        .catch(() => {
+          ws.close();
+          reject(new Error("timeout waiting for onPause"));
+        });
     });
 
     expect(paused).toBe(true);
@@ -500,7 +536,11 @@ describe("DashboardWebServer", () => {
 
   it("handles sprint:resume message and calls onResume", async () => {
     let resumed = false;
-    options = makeOptions({ onResume: () => { resumed = true; } });
+    options = makeOptions({
+      onResume: () => {
+        resumed = true;
+      },
+    });
     server = new DashboardWebServer(options);
     await server.start();
     const port = getPort(server);
@@ -512,8 +552,14 @@ describe("DashboardWebServer", () => {
       });
       ws.on("error", reject);
       waitForCondition(() => resumed)
-        .then(() => { ws.close(); resolve(); })
-        .catch(() => { ws.close(); reject(new Error("timeout waiting for onResume")); });
+        .then(() => {
+          ws.close();
+          resolve();
+        })
+        .catch(() => {
+          ws.close();
+          reject(new Error("timeout waiting for onResume"));
+        });
     });
 
     expect(resumed).toBe(true);
@@ -521,7 +567,11 @@ describe("DashboardWebServer", () => {
 
   it("handles sprint:stop message and calls onStop", async () => {
     let stopped = false;
-    options = makeOptions({ onStop: () => { stopped = true; } });
+    options = makeOptions({
+      onStop: () => {
+        stopped = true;
+      },
+    });
     server = new DashboardWebServer(options);
     await server.start();
     const port = getPort(server);
@@ -533,8 +583,14 @@ describe("DashboardWebServer", () => {
       });
       ws.on("error", reject);
       waitForCondition(() => stopped)
-        .then(() => { ws.close(); resolve(); })
-        .catch(() => { ws.close(); reject(new Error("timeout waiting for onStop")); });
+        .then(() => {
+          ws.close();
+          resolve();
+        })
+        .catch(() => {
+          ws.close();
+          reject(new Error("timeout waiting for onStop"));
+        });
     });
 
     expect(stopped).toBe(true);
@@ -542,7 +598,11 @@ describe("DashboardWebServer", () => {
 
   it("handles mode:set message, calls onModeChange, and broadcasts event", async () => {
     let modeReceived: string | null = null;
-    options = makeOptions({ onModeChange: (mode) => { modeReceived = mode; } });
+    options = makeOptions({
+      onModeChange: (mode) => {
+        modeReceived = mode;
+      },
+    });
     server = new DashboardWebServer(options);
     await server.start();
     const port = getPort(server);
@@ -568,7 +628,10 @@ describe("DashboardWebServer", () => {
         resolve();
       });
       ws.on("error", reject);
-      setTimeout(() => { ws.close(); reject(new Error("timeout")); }, 5000);
+      setTimeout(() => {
+        ws.close();
+        reject(new Error("timeout"));
+      }, 5000);
     });
 
     expect(modeReceived).toBe("hitl");
@@ -581,7 +644,11 @@ describe("DashboardWebServer", () => {
 
   it("ignores mode:set with invalid mode value", async () => {
     let modeCalled = false;
-    options = makeOptions({ onModeChange: () => { modeCalled = true; } });
+    options = makeOptions({
+      onModeChange: () => {
+        modeCalled = true;
+      },
+    });
     server = new DashboardWebServer(options);
     await server.start();
     const port = getPort(server);
@@ -590,7 +657,10 @@ describe("DashboardWebServer", () => {
     await new Promise<void>((resolve) => {
       ws.on("open", () => {
         ws.send(JSON.stringify({ type: "mode:set", mode: "invalid" }));
-        setTimeout(() => { ws.close(); resolve(); }, 300);
+        setTimeout(() => {
+          ws.close();
+          resolve();
+        }, 300);
       });
     });
 
@@ -642,7 +712,10 @@ describe("DashboardWebServer", () => {
         ws.send(JSON.stringify({ type: "sprint:pause" }));
         ws.send(JSON.stringify({ type: "sprint:resume" }));
         ws.send(JSON.stringify({ type: "sprint:stop" }));
-        setTimeout(() => { ws.close(); resolve(); }, 300);
+        setTimeout(() => {
+          ws.close();
+          resolve();
+        }, 300);
       });
     });
 

--- a/tests/documentation/huddle.test.ts
+++ b/tests/documentation/huddle.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { HuddleEntry } from "../../src/types.js";
-import {
-  formatHuddleComment,
-  formatSprintLogEntry,
-} from "../../src/documentation/huddle.js";
+import { formatHuddleComment, formatSprintLogEntry } from "../../src/documentation/huddle.js";
 
 function makeEntry(overrides: Partial<HuddleEntry> = {}): HuddleEntry {
   return {
@@ -75,9 +72,7 @@ describe("formatSprintLogEntry", () => {
       status: "failed",
       qualityResult: {
         passed: false,
-        checks: [
-          { name: "types", passed: false, detail: "5 type errors", category: "type" },
-        ],
+        checks: [{ name: "types", passed: false, detail: "5 type errors", category: "type" }],
       },
     });
     const result = formatSprintLogEntry(entry);

--- a/tests/e2e/bugfix-verification.spec.ts
+++ b/tests/e2e/bugfix-verification.spec.ts
@@ -98,7 +98,7 @@ test.describe("Sprint Report Fixes", () => {
     await navigateToTab(page, "📊", "Report");
     await page.waitForTimeout(2000);
     const reportActions = page.locator(".report-actions");
-    if (await reportActions.count() > 0) {
+    if ((await reportActions.count()) > 0) {
       // If report has data, buttons should be visible and enabled
       const copyBtn = page.locator("button", { hasText: "Copy Markdown" });
       await expect(copyBtn).toBeVisible();
@@ -262,7 +262,10 @@ test.describe("Header Controls Verification", () => {
   test("sprint limit dropdown shows current value", async ({ page }) => {
     await page.goto("/");
     await page.waitForSelector(".phase-badge", { timeout: 10_000 });
-    const select = page.locator("select").filter({ hasText: /Infinite|Sprint/ }).last();
+    const select = page
+      .locator("select")
+      .filter({ hasText: /Infinite|Sprint/ })
+      .last();
     const value = await select.inputValue();
     // Value should be a valid number string
     expect(["0", "1", "2", "3", "5", "10"]).toContain(value);

--- a/tests/e2e/dashboard-ui.spec.ts
+++ b/tests/e2e/dashboard-ui.spec.ts
@@ -8,9 +8,15 @@ import { test, expect } from "@playwright/test";
 
 // Helper: navigate to a tab by its exact icon+label (e.g. "🏃 Sprint")
 const TAB_ICONS: Record<string, string> = {
-  "Sprint": "🏃", "Sprint Backlog": "📦", "Backlog": "📋",
-  "Blocked": "🚧", "Decisions": "⚖️", "Ideas": "💡",
-  "Report": "📊", "Logs": "📜", "Settings": "⚙️",
+  Sprint: "🏃",
+  "Sprint Backlog": "📦",
+  Backlog: "📋",
+  Blocked: "🚧",
+  Decisions: "⚖️",
+  Ideas: "💡",
+  Report: "📊",
+  Logs: "📜",
+  Settings: "⚙️",
 };
 async function navigateToTab(page: import("@playwright/test").Page, label: string) {
   await page.waitForSelector(".tab-nav", { timeout: 10_000 });
@@ -165,7 +171,9 @@ test.describe("Settings Page", () => {
 
   test("config values are editable", async ({ page }) => {
     // Find a text input and verify it's editable
-    const inputs = page.locator(".settings-table input[type='text'], .settings-table input[type='number']");
+    const inputs = page.locator(
+      ".settings-table input[type='text'], .settings-table input[type='number']",
+    );
     const count = await inputs.count();
     expect(count).toBeGreaterThan(0);
     const first = inputs.first();

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -61,7 +61,16 @@ test.describe("Dashboard Sprint Navigation", () => {
   test("phase badge shows a valid phase", async ({ page }) => {
     const badge = page.locator(".phase-badge");
     const text = await badge.textContent();
-    expect(["INIT", "PLAN", "EXECUTE", "REVIEW", "RETRO", "COMPLETE", "FAILED", "PAUSED"]).toContain(text);
+    expect([
+      "INIT",
+      "PLAN",
+      "EXECUTE",
+      "REVIEW",
+      "RETRO",
+      "COMPLETE",
+      "FAILED",
+      "PAUSED",
+    ]).toContain(text);
   });
 
   test("chat panel exists in sprint view", async ({ page }) => {

--- a/tests/e2e/interactions.spec.ts
+++ b/tests/e2e/interactions.spec.ts
@@ -4,9 +4,15 @@
 import { test, expect } from "@playwright/test";
 
 const TAB_ICONS: Record<string, string> = {
-  "Sprint": "🏃", "Sprint Backlog": "📦", "Backlog": "📋",
-  "Blocked": "🚧", "Decisions": "⚖️", "Ideas": "💡",
-  "Report": "📊", "Logs": "📜", "Settings": "⚙️",
+  Sprint: "🏃",
+  "Sprint Backlog": "📦",
+  Backlog: "📋",
+  Blocked: "🚧",
+  Decisions: "⚖️",
+  Ideas: "💡",
+  Report: "📊",
+  Logs: "📜",
+  Settings: "⚙️",
 };
 async function navigateToTab(page: import("@playwright/test").Page, label: string) {
   await page.waitForSelector(".tab-nav", { timeout: 10_000 });
@@ -33,17 +39,17 @@ test.describe("Sprint Report Deep", () => {
     const copyBtn = page.locator("button", { hasText: /Copy/ });
     const downloadBtn = page.locator("button", { hasText: /Download/ });
     // These may only appear when report data exists
-    if (await copyBtn.count() > 0) {
+    if ((await copyBtn.count()) > 0) {
       await expect(copyBtn.first()).toBeVisible();
     }
-    if (await downloadBtn.count() > 0) {
+    if ((await downloadBtn.count()) > 0) {
       await expect(downloadBtn.first()).toBeVisible();
     }
   });
 
   test("report sections are collapsible", async ({ page }) => {
     const sectionHeaders = page.locator(".report-section-header");
-    if (await sectionHeaders.count() > 0) {
+    if ((await sectionHeaders.count()) > 0) {
       const first = sectionHeaders.first();
       await first.click();
       await page.waitForTimeout(300);
@@ -55,7 +61,7 @@ test.describe("Sprint Report Deep", () => {
 
   test("summary cards show sprint metrics", async ({ page }) => {
     const cards = page.locator(".summary-card");
-    if (await cards.count() > 0) {
+    if ((await cards.count()) > 0) {
       const count = await cards.count();
       expect(count).toBeGreaterThanOrEqual(3);
     }
@@ -126,7 +132,7 @@ test.describe("Side Panel Chat", () => {
     await input.fill("/");
     await page.waitForTimeout(500);
     const slashMenu = page.locator(".slash-menu");
-    if (await slashMenu.count() > 0) {
+    if ((await slashMenu.count()) > 0) {
       await expect(slashMenu).toBeVisible();
     }
   });
@@ -140,7 +146,7 @@ test.describe("Backlog Tab Actions", () => {
     await navigateToTab(page, "Backlog");
     await page.waitForTimeout(2000);
     const refreshBtn = page.locator("button", { hasText: "↻" });
-    if (await refreshBtn.count() > 0) {
+    if ((await refreshBtn.count()) > 0) {
       await expect(refreshBtn.first()).toBeVisible();
     }
   });
@@ -150,7 +156,7 @@ test.describe("Backlog Tab Actions", () => {
     await navigateToTab(page, "Backlog");
     await page.waitForTimeout(2000);
     const select = page.locator(".sprint-select");
-    if (await select.count() > 0) {
+    if ((await select.count()) > 0) {
       await expect(select).toBeVisible();
     }
   });
@@ -160,7 +166,7 @@ test.describe("Backlog Tab Actions", () => {
     await navigateToTab(page, "Backlog");
     await page.waitForTimeout(2000);
     const planBtn = page.locator(".tab-list .btn-primary");
-    if (await planBtn.count() > 0) {
+    if ((await planBtn.count()) > 0) {
       await expect(planBtn.first()).toBeVisible();
     }
   });
@@ -172,7 +178,7 @@ test.describe("Blocked Tab Actions", () => {
     await navigateToTab(page, "Blocked");
     await page.waitForTimeout(2000);
     const refreshBtn = page.locator("button", { hasText: /↻\s*Refresh/ });
-    if (await refreshBtn.count() > 0) {
+    if ((await refreshBtn.count()) > 0) {
       await expect(refreshBtn.first()).toBeVisible();
     }
   });
@@ -182,7 +188,7 @@ test.describe("Blocked Tab Actions", () => {
     await navigateToTab(page, "Blocked");
     await page.waitForTimeout(2000);
     const discussBtn = page.locator("button", { hasText: /💬/ });
-    if (await discussBtn.count() > 0) {
+    if ((await discussBtn.count()) > 0) {
       await expect(discussBtn.first()).toBeVisible();
     }
   });
@@ -194,7 +200,7 @@ test.describe("Decisions Tab Actions", () => {
     await navigateToTab(page, "Decisions");
     await page.waitForTimeout(2000);
     const refreshBtn = page.locator("button", { hasText: /↻\s*Refresh/ });
-    if (await refreshBtn.count() > 0) {
+    if ((await refreshBtn.count()) > 0) {
       await expect(refreshBtn.first()).toBeVisible();
     }
   });
@@ -204,7 +210,7 @@ test.describe("Decisions Tab Actions", () => {
     await navigateToTab(page, "Decisions");
     await page.waitForTimeout(2000);
     const discussBtn = page.locator("button", { hasText: /💬/ });
-    if (await discussBtn.count() > 0) {
+    if ((await discussBtn.count()) > 0) {
       await expect(discussBtn.first()).toBeVisible();
     }
   });
@@ -216,7 +222,7 @@ test.describe("Ideas Tab Actions", () => {
     await navigateToTab(page, "Ideas");
     await page.waitForTimeout(2000);
     const refreshBtn = page.locator("button", { hasText: /↻\s*Refresh/ });
-    if (await refreshBtn.count() > 0) {
+    if ((await refreshBtn.count()) > 0) {
       await expect(refreshBtn.first()).toBeVisible();
     }
   });
@@ -226,7 +232,7 @@ test.describe("Ideas Tab Actions", () => {
     await navigateToTab(page, "Ideas");
     await page.waitForTimeout(2000);
     const refineBtn = page.locator("button", { hasText: /🔬/ });
-    if (await refineBtn.count() > 0) {
+    if ((await refineBtn.count()) > 0) {
       await expect(refineBtn.first()).toBeVisible();
     }
   });

--- a/tests/e2e/round3-verification.spec.ts
+++ b/tests/e2e/round3-verification.spec.ts
@@ -36,7 +36,7 @@ test.describe("External Link Security", () => {
     await page.goto("/");
     await page.waitForSelector(".phase-badge", { timeout: 10_000 });
     const sprintLink = page.locator("#sprint-label a[target='_blank']");
-    if (await sprintLink.count() > 0) {
+    if ((await sprintLink.count()) > 0) {
       const rel = await sprintLink.getAttribute("rel");
       expect(rel).toContain("noreferrer");
     }
@@ -98,7 +98,7 @@ test.describe("IssueCard Rendering", () => {
     await navigateToTab(page, "📋", "Backlog");
     await page.waitForTimeout(2000);
     const items = page.locator(".tab-list-item");
-    if (await items.count() > 0) {
+    if ((await items.count()) > 0) {
       // First item should have a visible number
       const firstNumber = items.first().locator(".item-number");
       await expect(firstNumber).toBeVisible();
@@ -117,7 +117,7 @@ test.describe("IssueCard Rendering", () => {
     await navigateToTab(page, "📋", "Backlog");
     await page.waitForTimeout(2000);
     const expandBtn = page.locator(".item-expand-toggle").first();
-    if (await expandBtn.count() > 0) {
+    if ((await expandBtn.count()) > 0) {
       // Initially collapsed
       const detail = page.locator(".item-detail").first();
       await expect(detail).not.toBeVisible();
@@ -137,7 +137,7 @@ test.describe("IssueCard Rendering", () => {
     await navigateToTab(page, "📋", "Backlog");
     await page.waitForTimeout(2000);
     const expandBtn = page.locator(".item-expand-toggle").first();
-    if (await expandBtn.count() > 0) {
+    if ((await expandBtn.count()) > 0) {
       await expandBtn.click();
       await page.waitForTimeout(300);
       // Should show either body content or empty message
@@ -151,7 +151,7 @@ test.describe("IssueCard Rendering", () => {
     await navigateToTab(page, "📋", "Backlog");
     await page.waitForTimeout(2000);
     const labels = page.locator(".label-badge");
-    if (await labels.count() > 0) {
+    if ((await labels.count()) > 0) {
       await expect(labels.first()).toBeVisible();
       const text = await labels.first().textContent();
       expect(text!.length).toBeGreaterThan(0);
@@ -185,7 +185,7 @@ test.describe("Sprint Navigation", () => {
     await page.waitForSelector(".phase-badge", { timeout: 10_000 });
     await page.waitForTimeout(3000);
     const issueItems = page.locator(".issue-item");
-    if (await issueItems.count() > 0) {
+    if ((await issueItems.count()) > 0) {
       const icon = issueItems.first().locator(".issue-icon");
       await expect(icon).toBeVisible();
       const text = await icon.textContent();
@@ -203,7 +203,7 @@ test.describe("Sprint Backlog Tab", () => {
     await navigateToTab(page, "📦", "Sprint Backlog");
     await page.waitForTimeout(2000);
     const heading = page.locator("h2");
-    if (await heading.count() > 0) {
+    if ((await heading.count()) > 0) {
       const text = await heading.first().textContent();
       // Either shows "Sprint N Backlog" or empty state
       if (text?.includes("Sprint")) {
@@ -217,7 +217,7 @@ test.describe("Sprint Backlog Tab", () => {
     await navigateToTab(page, "📦", "Sprint Backlog");
     await page.waitForTimeout(2000);
     const refreshBtn = page.locator("button", { hasText: "↻" });
-    if (await refreshBtn.count() > 0) {
+    if ((await refreshBtn.count()) > 0) {
       await refreshBtn.first().click();
       // Should show loading briefly
       await page.waitForTimeout(500);
@@ -232,7 +232,7 @@ test.describe("Sprint Backlog Tab", () => {
     await navigateToTab(page, "📦", "Sprint Backlog");
     await page.waitForTimeout(2000);
     const removeBtn = page.locator(".btn-danger", { hasText: "Remove" });
-    if (await removeBtn.count() > 0) {
+    if ((await removeBtn.count()) > 0) {
       await expect(removeBtn.first()).toBeVisible();
     }
   });

--- a/tests/e2e/settings-deep.spec.ts
+++ b/tests/e2e/settings-deep.spec.ts
@@ -14,7 +14,9 @@ async function goToSettings(page: import("@playwright/test").Page) {
 }
 
 test.describe("Settings Toggles", () => {
-  test.beforeEach(async ({ page }) => { await goToSettings(page); });
+  test.beforeEach(async ({ page }) => {
+    await goToSettings(page);
+  });
 
   test("toggle buttons are clickable and change state", async ({ page }) => {
     const toggles = page.locator(".settings-toggle");
@@ -32,7 +34,9 @@ test.describe("Settings Toggles", () => {
 });
 
 test.describe("Settings Sections Collapse", () => {
-  test.beforeEach(async ({ page }) => { await goToSettings(page); });
+  test.beforeEach(async ({ page }) => {
+    await goToSettings(page);
+  });
 
   test("sections can be collapsed and expanded", async ({ page }) => {
     const headers = page.locator(".settings-section-header");
@@ -53,7 +57,9 @@ test.describe("Settings Sections Collapse", () => {
 });
 
 test.describe("Settings Save & Reset", () => {
-  test.beforeEach(async ({ page }) => { await goToSettings(page); });
+  test.beforeEach(async ({ page }) => {
+    await goToSettings(page);
+  });
 
   test("save button exists and is initially not dirty", async ({ page }) => {
     const saveBtn = page.locator("button", { hasText: /💾\s*Save/i });
@@ -152,7 +158,7 @@ test.describe("Agent Roles Editor", () => {
   test("role has model selector", async ({ page }) => {
     await page.waitForTimeout(2000);
     const modelSelect = page.locator(".role-config-row select").first();
-    if (await modelSelect.count() > 0) {
+    if ((await modelSelect.count()) > 0) {
       await expect(modelSelect).toBeVisible();
       const options = modelSelect.locator("option");
       const count = await options.count();
@@ -163,7 +169,7 @@ test.describe("Agent Roles Editor", () => {
   test("role has mode selector (autonomous/manual)", async ({ page }) => {
     await page.waitForTimeout(2000);
     const modeSelect = page.locator("select").filter({ hasText: /autonomous|manual/i });
-    if (await modeSelect.count() > 0) {
+    if ((await modeSelect.count()) > 0) {
       await expect(modeSelect.first()).toBeVisible();
     }
   });
@@ -189,7 +195,7 @@ test.describe("Skills Editor", () => {
       await roleHeaders.nth(i).click();
       await page.waitForTimeout(500);
       const skillCards = page.locator(".role-skill-card");
-      if (await skillCards.count() > 0) {
+      if ((await skillCards.count()) > 0) {
         foundSkills = true;
         break;
       }
@@ -209,7 +215,7 @@ test.describe("Skills Editor", () => {
       await roleHeaders.nth(i).click();
       await page.waitForTimeout(500);
       const skillHeader = page.locator(".role-skill-card-header");
-      if (await skillHeader.count() > 0) {
+      if ((await skillHeader.count()) > 0) {
         await skillHeader.first().click();
         const textarea = page.locator(".role-skill-textarea");
         await expect(textarea.first()).toBeVisible({ timeout: 2_000 });
@@ -223,7 +229,9 @@ test.describe("Skills Editor", () => {
 });
 
 test.describe("Quality Gates Editor", () => {
-  test.beforeEach(async ({ page }) => { await goToSettings(page); });
+  test.beforeEach(async ({ page }) => {
+    await goToSettings(page);
+  });
 
   test("quality gate section can be expanded", async ({ page }) => {
     // Find the Quality Gates section header and expand it
@@ -244,7 +252,7 @@ test.describe("Quality Gates Editor", () => {
     await qgHeader.click();
     await page.waitForTimeout(500);
     const textarea = page.locator(".qg-command-textarea");
-    if (await textarea.count() > 0) {
+    if ((await textarea.count()) > 0) {
       await expect(textarea.first()).toBeEditable();
     }
   });
@@ -256,7 +264,7 @@ test.describe("Quality Gates Editor", () => {
     await qgHeader.click();
     await page.waitForTimeout(500);
     const toggles = page.locator(".qg-card .settings-toggle");
-    if (await toggles.count() > 0) {
+    if ((await toggles.count()) > 0) {
       const first = toggles.first();
       const initialText = await first.textContent();
       await first.click();
@@ -269,12 +277,14 @@ test.describe("Quality Gates Editor", () => {
 });
 
 test.describe("Placeholder Help", () => {
-  test.beforeEach(async ({ page }) => { await goToSettings(page); });
+  test.beforeEach(async ({ page }) => {
+    await goToSettings(page);
+  });
 
   test("placeholder help toggle expands variable list", async ({ page }) => {
     await page.waitForTimeout(2000);
     const helpToggle = page.locator(".placeholder-help-toggle");
-    if (await helpToggle.count() > 0) {
+    if ((await helpToggle.count()) > 0) {
       await helpToggle.first().click();
       const helpList = page.locator(".placeholder-help-list");
       await expect(helpList.first()).toBeVisible({ timeout: 2_000 });

--- a/tests/e2e/sprint-controls.spec.ts
+++ b/tests/e2e/sprint-controls.spec.ts
@@ -31,7 +31,7 @@ test.describe("Sprint Control Buttons", () => {
   test("Start button has correct class", async ({ page }) => {
     await waitForDashboard(page);
     const startBtn = page.locator("button.btn-primary", { hasText: "Start" });
-    if (await startBtn.count() > 0) {
+    if ((await startBtn.count()) > 0) {
       await expect(startBtn).toHaveClass(/btn-primary/);
     }
   });
@@ -58,7 +58,7 @@ test.describe("Sprint Control Buttons", () => {
     await waitForDashboard(page);
     await page.waitForTimeout(3000);
     const startBtn = page.locator("button", { hasText: "▶ Start" });
-    if (await startBtn.count() > 0) {
+    if ((await startBtn.count()) > 0) {
       // When idle, Start should always be enabled regardless of which sprint is viewed
       await expect(startBtn).toBeEnabled();
     }
@@ -76,12 +76,14 @@ test.describe("Sprint Control Buttons", () => {
   test("clicking Start sends sprint:start message via WebSocket", async ({ page }) => {
     await waitForDashboard(page);
     const startBtn = page.locator("button", { hasText: "▶ Start" });
-    if (await startBtn.count() > 0 && await startBtn.isEnabled()) {
+    if ((await startBtn.count()) > 0 && (await startBtn.isEnabled())) {
       // Set up WebSocket message listener
       await page.evaluate(() => {
         const origSend = WebSocket.prototype.send;
         (window as unknown as Record<string, string[]>).__wsMsgs = [];
-        WebSocket.prototype.send = function (data: string | ArrayBufferLike | Blob | ArrayBufferView) {
+        WebSocket.prototype.send = function (
+          data: string | ArrayBufferLike | Blob | ArrayBufferView,
+        ) {
           if (typeof data === "string") {
             (window as unknown as Record<string, string[]>).__wsMsgs.push(data);
           }
@@ -92,7 +94,9 @@ test.describe("Sprint Control Buttons", () => {
       await startBtn.click();
       await page.waitForTimeout(500);
 
-      const messages = await page.evaluate(() => (window as unknown as Record<string, string[]>).__wsMsgs);
+      const messages = await page.evaluate(
+        () => (window as unknown as Record<string, string[]>).__wsMsgs,
+      );
       const startMsg = messages.find((m: string) => m.includes("sprint:start"));
       expect(startMsg).toBeDefined();
       const parsed = JSON.parse(startMsg!);
@@ -127,7 +131,9 @@ test.describe("Execution Mode Selector", () => {
     await page.evaluate(() => {
       const origSend = WebSocket.prototype.send;
       (window as unknown as Record<string, string[]>).__wsMsgs = [];
-      WebSocket.prototype.send = function (data: string | ArrayBufferLike | Blob | ArrayBufferView) {
+      WebSocket.prototype.send = function (
+        data: string | ArrayBufferLike | Blob | ArrayBufferView,
+      ) {
         if (typeof data === "string") {
           (window as unknown as Record<string, string[]>).__wsMsgs.push(data);
         }
@@ -139,7 +145,9 @@ test.describe("Execution Mode Selector", () => {
     await modeSelect.selectOption("hitl");
     await page.waitForTimeout(500);
 
-    const messages = await page.evaluate(() => (window as unknown as Record<string, string[]>).__wsMsgs);
+    const messages = await page.evaluate(
+      () => (window as unknown as Record<string, string[]>).__wsMsgs,
+    );
     const modeMsg = messages.find((m: string) => m.includes("mode:set"));
     expect(modeMsg).toBeDefined();
     const parsed = JSON.parse(modeMsg!);
@@ -176,7 +184,9 @@ test.describe("Sprint Limit Selector", () => {
     await page.evaluate(() => {
       const origSend = WebSocket.prototype.send;
       (window as unknown as Record<string, string[]>).__wsMsgs = [];
-      WebSocket.prototype.send = function (data: string | ArrayBufferLike | Blob | ArrayBufferView) {
+      WebSocket.prototype.send = function (
+        data: string | ArrayBufferLike | Blob | ArrayBufferView,
+      ) {
         if (typeof data === "string") {
           (window as unknown as Record<string, string[]>).__wsMsgs.push(data);
         }
@@ -188,7 +198,9 @@ test.describe("Sprint Limit Selector", () => {
     await limitSelect.selectOption("3");
     await page.waitForTimeout(500);
 
-    const messages = await page.evaluate(() => (window as unknown as Record<string, string[]>).__wsMsgs);
+    const messages = await page.evaluate(
+      () => (window as unknown as Record<string, string[]>).__wsMsgs,
+    );
     const limitMsg = messages.find((m: string) => m.includes("sprint:set-limit"));
     expect(limitMsg).toBeDefined();
     const parsed = JSON.parse(limitMsg!);
@@ -240,7 +252,16 @@ test.describe("Phase Stepper", () => {
     const badge = page.locator(".phase-badge");
     const text = await badge.textContent();
     // Phase should be one of the known values
-    expect(["INIT", "PLAN", "EXECUTE", "REVIEW", "RETRO", "COMPLETE", "FAILED", "PAUSED"]).toContain(text);
+    expect([
+      "INIT",
+      "PLAN",
+      "EXECUTE",
+      "REVIEW",
+      "RETRO",
+      "COMPLETE",
+      "FAILED",
+      "PAUSED",
+    ]).toContain(text);
   });
 });
 

--- a/tests/enforcement/challenger.test.ts
+++ b/tests/enforcement/challenger.test.ts
@@ -46,15 +46,13 @@ function makeMockClient(
   response = '```json\n{"decision":"approved","reasoning":"Looks good","feedback":"All clear"}\n```',
 ) {
   return {
-    createSession: vi
-      .fn()
-      .mockResolvedValue({
-        sessionId: "session-1",
-        availableModes: [],
-        currentMode: "",
-        availableModels: [],
-        currentModel: "",
-      }),
+    createSession: vi.fn().mockResolvedValue({
+      sessionId: "session-1",
+      availableModes: [],
+      currentMode: "",
+      availableModels: [],
+      currentModel: "",
+    }),
     sendPrompt: vi.fn().mockResolvedValue({ response, stopReason: "end_turn" }),
     endSession: vi.fn().mockResolvedValue(undefined),
     setMode: vi.fn().mockResolvedValue(undefined),

--- a/tests/enforcement/drift-control.test.ts
+++ b/tests/enforcement/drift-control.test.ts
@@ -11,10 +11,7 @@ vi.mock("../../src/logger.js", () => ({
   },
 }));
 
-import {
-  checkIssueDrift,
-  holisticDriftCheck,
-} from "../../src/enforcement/drift-control.js";
+import { checkIssueDrift, holisticDriftCheck } from "../../src/enforcement/drift-control.js";
 
 describe("checkIssueDrift", () => {
   it("should report no drift when all files are in scope", async () => {
@@ -57,10 +54,7 @@ describe("checkIssueDrift", () => {
 
 describe("holisticDriftCheck", () => {
   it("should report zero drift when all changes are planned", async () => {
-    const report = await holisticDriftCheck(
-      ["src/a.ts", "src/b.ts"],
-      ["src/a.ts", "src/b.ts"],
-    );
+    const report = await holisticDriftCheck(["src/a.ts", "src/b.ts"], ["src/a.ts", "src/b.ts"]);
 
     expect(report.totalFilesChanged).toBe(2);
     expect(report.plannedChanges).toBe(2);
@@ -90,10 +84,7 @@ describe("holisticDriftCheck", () => {
   });
 
   it("should skip drift check when no expectedFiles defined", async () => {
-    const report = await holisticDriftCheck(
-      ["src/a.ts", "src/b.ts"],
-      [],
-    );
+    const report = await holisticDriftCheck(["src/a.ts", "src/b.ts"], []);
 
     // All changes treated as planned when expectedFiles is empty
     expect(report.driftPercentage).toBe(0);
@@ -102,10 +93,7 @@ describe("holisticDriftCheck", () => {
   });
 
   it("should handle all files being planned with extras expected", async () => {
-    const report = await holisticDriftCheck(
-      ["src/a.ts"],
-      ["src/a.ts", "src/b.ts", "src/c.ts"],
-    );
+    const report = await holisticDriftCheck(["src/a.ts"], ["src/a.ts", "src/b.ts", "src/c.ts"]);
 
     expect(report.totalFilesChanged).toBe(1);
     expect(report.plannedChanges).toBe(1);

--- a/tests/enforcement/escalation.test.ts
+++ b/tests/enforcement/escalation.test.ts
@@ -45,8 +45,11 @@ describe("sanitizeForHttp", () => {
 
 const { execFileSpy } = vi.hoisted(() => {
   const execFileSpy = vi.fn(
-    (_cmd: string, _args: string[], cb: (err: Error | null, stdout: string, stderr: string) => void) =>
-      cb(null, "", ""),
+    (
+      _cmd: string,
+      _args: string[],
+      cb: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => cb(null, "", ""),
   );
   return { execFileSpy };
 });
@@ -127,7 +130,11 @@ describe("MUST escalation pause", () => {
   };
 
   it("emits sprint:paused when level is must and eventBus is provided", async () => {
-    const mockEventBus = { emitTyped: vi.fn(), onTyped: vi.fn(), removeAllListeners: vi.fn() } as unknown as SprintEventBus;
+    const mockEventBus = {
+      emitTyped: vi.fn(),
+      onTyped: vi.fn(),
+      removeAllListeners: vi.fn(),
+    } as unknown as SprintEventBus;
 
     await escalateToStakeholder(mustEvent, { ntfyEnabled: false }, mockEventBus);
 
@@ -135,7 +142,11 @@ describe("MUST escalation pause", () => {
   });
 
   it("does NOT emit sprint:paused when level is should", async () => {
-    const mockEventBus = { emitTyped: vi.fn(), onTyped: vi.fn(), removeAllListeners: vi.fn() } as unknown as SprintEventBus;
+    const mockEventBus = {
+      emitTyped: vi.fn(),
+      onTyped: vi.fn(),
+      removeAllListeners: vi.fn(),
+    } as unknown as SprintEventBus;
     const shouldEvent: EscalationEvent = { ...mustEvent, level: "should" };
 
     await escalateToStakeholder(shouldEvent, { ntfyEnabled: false }, mockEventBus);
@@ -144,8 +155,6 @@ describe("MUST escalation pause", () => {
   });
 
   it("does not error when level is must but eventBus is not provided", async () => {
-    await expect(
-      escalateToStakeholder(mustEvent, { ntfyEnabled: false }),
-    ).resolves.toBeUndefined();
+    await expect(escalateToStakeholder(mustEvent, { ntfyEnabled: false })).resolves.toBeUndefined();
   });
 });

--- a/tests/enforcement/quality-gate.test.ts
+++ b/tests/enforcement/quality-gate.test.ts
@@ -54,42 +54,52 @@ function makeConfig(overrides: Partial<QualityGateConfig> = {}): QualityGateConf
 }
 
 function mockExecSuccess(): void {
-  mockExecFile.mockImplementation(
-    ((_cmd: unknown, _args: unknown, _opts: unknown, cb?: (...a: unknown[]) => void) => {
-      if (cb) {
-        cb(null, { stdout: "ok", stderr: "" });
-      } else {
-        // promisify path — return value is ignored; promisify wraps the callback
-        // We need to handle the 3-arg case (cmd, args, callback) for promisify
-        const lastArg = _opts;
-        if (typeof lastArg === "function") {
-          (lastArg as (...a: unknown[]) => void)(null, { stdout: "ok", stderr: "" });
-        }
+  mockExecFile.mockImplementation(((
+    _cmd: unknown,
+    _args: unknown,
+    _opts: unknown,
+    cb?: (...a: unknown[]) => void,
+  ) => {
+    if (cb) {
+      cb(null, { stdout: "ok", stderr: "" });
+    } else {
+      // promisify path — return value is ignored; promisify wraps the callback
+      // We need to handle the 3-arg case (cmd, args, callback) for promisify
+      const lastArg = _opts;
+      if (typeof lastArg === "function") {
+        (lastArg as (...a: unknown[]) => void)(null, { stdout: "ok", stderr: "" });
       }
-    }) as unknown as typeof execFile,
-  );
+    }
+  }) as unknown as typeof execFile);
 }
 
 function mockExecFailure(): void {
-  mockExecFile.mockImplementation(
-    ((_cmd: unknown, _args: unknown, _opts: unknown, cb?: (...a: unknown[]) => void) => {
-      const err = new Error("command failed");
-      if (cb) {
-        cb(err);
-      } else {
-        const lastArg = _opts;
-        if (typeof lastArg === "function") {
-          lastArg(err);
-        }
+  mockExecFile.mockImplementation(((
+    _cmd: unknown,
+    _args: unknown,
+    _opts: unknown,
+    cb?: (...a: unknown[]) => void,
+  ) => {
+    const err = new Error("command failed");
+    if (cb) {
+      cb(err);
+    } else {
+      const lastArg = _opts;
+      if (typeof lastArg === "function") {
+        lastArg(err);
       }
-    }) as unknown as typeof execFile,
-  );
+    }
+  }) as unknown as typeof execFile);
 }
 
 describe("runQualityGate", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockDiffStat.mockResolvedValue({ linesChanged: 100, filesChanged: 3, files: ["a.ts", "b.ts", "c.ts"] });
+    mockDiffStat.mockResolvedValue({
+      linesChanged: 100,
+      filesChanged: 3,
+      files: ["a.ts", "b.ts", "c.ts"],
+    });
   });
 
   it("should pass when all checks succeed", async () => {
@@ -156,7 +166,12 @@ describe("runQualityGate", () => {
     mockDiffStat.mockResolvedValue({ linesChanged: 10, filesChanged: 1, files: ["a.ts"] });
 
     const result = await runQualityGate(
-      makeConfig({ requireTests: false, requireLint: false, requireTypes: false, requireBuild: false }),
+      makeConfig({
+        requireTests: false,
+        requireLint: false,
+        requireTypes: false,
+        requireBuild: false,
+      }),
       "/tmp/wt",
       "feat/1",
       "main",

--- a/tests/git/diff-analysis.test.ts
+++ b/tests/git/diff-analysis.test.ts
@@ -4,11 +4,7 @@ import { promisify } from "node:util";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
-import {
-  diffStat,
-  getChangedFiles,
-  isNewOrModified,
-} from "../../src/git/diff-analysis.js";
+import { diffStat, getChangedFiles, isNewOrModified } from "../../src/git/diff-analysis.js";
 
 const execFile = promisify(execFileCb);
 
@@ -20,9 +16,7 @@ describe("diff-analysis", () => {
     originalCwd = process.cwd();
 
     // Create a temporary directory with a real git repo
-    repoDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), "git-diff-analysis-test-"),
-    );
+    repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-diff-analysis-test-"));
     process.chdir(repoDir);
 
     // Initialize a git repo with an initial commit on main
@@ -37,10 +31,7 @@ describe("diff-analysis", () => {
     // Create a feature branch with changes
     await execFile("git", ["checkout", "-b", "feature/diff-test"]);
     await fs.writeFile(path.join(repoDir, "new-file.ts"), "export const x = 1;\n");
-    await fs.writeFile(
-      path.join(repoDir, "existing.txt"),
-      "line1\nline2\nline3\n",
-    );
+    await fs.writeFile(path.join(repoDir, "existing.txt"), "line1\nline2\nline3\n");
     await execFile("git", ["add", "."]);
     await execFile("git", ["commit", "-m", "add changes"]);
 
@@ -94,29 +85,17 @@ describe("diff-analysis", () => {
 
   describe("isNewOrModified", () => {
     it("returns true for a changed file", async () => {
-      const result = await isNewOrModified(
-        "new-file.ts",
-        "feature/diff-test",
-        "main",
-      );
+      const result = await isNewOrModified("new-file.ts", "feature/diff-test", "main");
       expect(result).toBe(true);
     });
 
     it("returns true for a modified file", async () => {
-      const result = await isNewOrModified(
-        "existing.txt",
-        "feature/diff-test",
-        "main",
-      );
+      const result = await isNewOrModified("existing.txt", "feature/diff-test", "main");
       expect(result).toBe(true);
     });
 
     it("returns false for an untouched file", async () => {
-      const result = await isNewOrModified(
-        "README.md",
-        "feature/diff-test",
-        "main",
-      );
+      const result = await isNewOrModified("README.md", "feature/diff-test", "main");
       expect(result).toBe(false);
     });
   });

--- a/tests/git/merge-pr.test.ts
+++ b/tests/git/merge-pr.test.ts
@@ -8,25 +8,21 @@ vi.mock("node:child_process", () => ({
 const mockExecFile = vi.mocked(cp.execFile);
 
 function mockExecFileSuccess(stdout: string): void {
-  mockExecFile.mockImplementation(
-    ((_cmd: unknown, _args: unknown, callback: unknown) => {
-      (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
-        null,
-        { stdout, stderr: "" },
-      );
-    }) as typeof cp.execFile,
-  );
+  mockExecFile.mockImplementation(((_cmd: unknown, _args: unknown, callback: unknown) => {
+    (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(null, {
+      stdout,
+      stderr: "",
+    });
+  }) as typeof cp.execFile);
 }
 
 function mockExecFileError(err: Error): void {
-  mockExecFile.mockImplementation(
-    ((_cmd: unknown, _args: unknown, callback: unknown) => {
-      (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
-        err,
-        { stdout: "", stderr: err.message },
-      );
-    }) as typeof cp.execFile,
-  );
+  mockExecFile.mockImplementation(((_cmd: unknown, _args: unknown, callback: unknown) => {
+    (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(err, {
+      stdout: "",
+      stderr: err.message,
+    });
+  }) as typeof cp.execFile);
 }
 
 beforeEach(() => {
@@ -64,18 +60,14 @@ describe("mergeIssuePR", () => {
   it("finds and merges a PR by branch name", async () => {
     const { mergeIssuePR } = await import("../../src/git/merge.js");
     let callCount = 0;
-    mockExecFile.mockImplementation(
-      ((_cmd: unknown, _args: unknown, callback: unknown) => {
-        callCount++;
-        const data = callCount === 1
-          ? JSON.stringify([{ number: 10 }])
-          : "";
-        (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
-          null,
-          { stdout: data, stderr: "" },
-        );
-      }) as typeof cp.execFile,
-    );
+    mockExecFile.mockImplementation(((_cmd: unknown, _args: unknown, callback: unknown) => {
+      callCount++;
+      const data = callCount === 1 ? JSON.stringify([{ number: 10 }]) : "";
+      (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(null, {
+        stdout: data,
+        stderr: "",
+      });
+    }) as typeof cp.execFile);
 
     const result = await mergeIssuePR("sprint/1/issue-5");
     expect(result.success).toBe(true);
@@ -104,17 +96,15 @@ describe("mergeIssuePR", () => {
     const { mergeIssuePR } = await import("../../src/git/merge.js");
     let mergeArgs: unknown[] = [];
     let callCount = 0;
-    mockExecFile.mockImplementation(
-      ((_cmd: unknown, args: unknown, callback: unknown) => {
-        callCount++;
-        if (callCount === 2) mergeArgs = args as unknown[];
-        const data = callCount === 1 ? JSON.stringify([{ number: 7 }]) : "";
-        (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
-          null,
-          { stdout: data, stderr: "" },
-        );
-      }) as typeof cp.execFile,
-    );
+    mockExecFile.mockImplementation(((_cmd: unknown, args: unknown, callback: unknown) => {
+      callCount++;
+      if (callCount === 2) mergeArgs = args as unknown[];
+      const data = callCount === 1 ? JSON.stringify([{ number: 7 }]) : "";
+      (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(null, {
+        stdout: data,
+        stderr: "",
+      });
+    }) as typeof cp.execFile);
 
     await mergeIssuePR("feat-branch", { squash: true, deleteBranch: true });
     expect(mergeArgs).toContain("--squash");
@@ -124,22 +114,20 @@ describe("mergeIssuePR", () => {
   it("returns failure with reason when merge command fails", async () => {
     const { mergeIssuePR } = await import("../../src/git/merge.js");
     let callCount = 0;
-    mockExecFile.mockImplementation(
-      ((_cmd: unknown, _args: unknown, callback: unknown) => {
-        callCount++;
-        if (callCount === 1) {
-          (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
-            null,
-            { stdout: JSON.stringify([{ number: 15 }]), stderr: "" },
-          );
-        } else {
-          (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
-            new Error("merge conflict"),
-            { stdout: "", stderr: "merge conflict" },
-          );
-        }
-      }) as typeof cp.execFile,
-    );
+    mockExecFile.mockImplementation(((_cmd: unknown, _args: unknown, callback: unknown) => {
+      callCount++;
+      if (callCount === 1) {
+        (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
+          null,
+          { stdout: JSON.stringify([{ number: 15 }]), stderr: "" },
+        );
+      } else {
+        (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
+          new Error("merge conflict"),
+          { stdout: "", stderr: "merge conflict" },
+        );
+      }
+    }) as typeof cp.execFile);
 
     const result = await mergeIssuePR("conflict-branch");
     expect(result.success).toBe(false);

--- a/tests/git/merge.test.ts
+++ b/tests/git/merge.test.ts
@@ -15,9 +15,7 @@ describe("merge", () => {
   beforeEach(async () => {
     originalCwd = process.cwd();
 
-    repoDir = await fs.realpath(
-      await fs.mkdtemp(path.join(os.tmpdir(), "git-merge-test-")),
-    );
+    repoDir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "git-merge-test-")));
     process.chdir(repoDir);
 
     await execFile("git", ["init", "-b", "main"]);
@@ -100,9 +98,7 @@ describe("merge", () => {
     });
 
     it("throws when merging a non-existent branch", async () => {
-      await expect(
-        mergeBranch("nonexistent-branch", "main"),
-      ).rejects.toThrow("Failed to merge");
+      await expect(mergeBranch("nonexistent-branch", "main")).rejects.toThrow("Failed to merge");
     });
   });
 
@@ -136,9 +132,9 @@ describe("merge", () => {
     });
 
     it("throws when checking conflicts with a non-existent branch", async () => {
-      await expect(
-        hasConflicts("nonexistent", "main"),
-      ).rejects.toThrow("Failed to check conflicts");
+      await expect(hasConflicts("nonexistent", "main")).rejects.toThrow(
+        "Failed to check conflicts",
+      );
     });
   });
 });

--- a/tests/git/worktree.test.ts
+++ b/tests/git/worktree.test.ts
@@ -4,11 +4,7 @@ import { promisify } from "node:util";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
-import {
-  createWorktree,
-  removeWorktree,
-  listWorktrees,
-} from "../../src/git/worktree.js";
+import { createWorktree, removeWorktree, listWorktrees } from "../../src/git/worktree.js";
 
 const execFile = promisify(execFileCb);
 
@@ -21,9 +17,7 @@ describe("worktree", () => {
 
     // Create a temporary directory with a real git repo
     // Use realpath to resolve macOS /tmp -> /private/tmp symlinks
-    repoDir = await fs.realpath(
-      await fs.mkdtemp(path.join(os.tmpdir(), "git-worktree-test-")),
-    );
+    repoDir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "git-worktree-test-")));
     process.chdir(repoDir);
 
     // Initialize a git repo with an initial commit
@@ -202,9 +196,7 @@ describe("worktree", () => {
     });
 
     it("throws when removing a non-existent worktree", async () => {
-      await expect(
-        removeWorktree(path.join(repoDir, "nonexistent")),
-      ).rejects.toThrow();
+      await expect(removeWorktree(path.join(repoDir, "nonexistent"))).rejects.toThrow();
     });
 
     it("removes worktree even with uncommitted changes (force)", async () => {

--- a/tests/github/issue-rate-limiter.test.ts
+++ b/tests/github/issue-rate-limiter.test.ts
@@ -9,7 +9,9 @@ vi.mock("../../src/github/issues.js", () => ({
 const mockCreateIssue = vi.mocked(issues.createIssue);
 const mockIssue = { number: 1, title: "Test", body: "Body", labels: [] as string[], state: "OPEN" };
 
-beforeEach(() => { vi.restoreAllMocks(); });
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("createIssueRateLimited", () => {
   it("allows creation when under limit and increments counter", async () => {
@@ -58,8 +60,16 @@ describe("createIssueRateLimited", () => {
     const state = { issuesCreatedCount: 0 };
     mockCreateIssue.mockResolvedValue({ ...mockIssue, labels: ["bug", "high"] });
 
-    await createIssueRateLimited({ title: "Test", body: "Body", labels: ["bug", "high"] }, state, 10);
+    await createIssueRateLimited(
+      { title: "Test", body: "Body", labels: ["bug", "high"] },
+      state,
+      10,
+    );
 
-    expect(mockCreateIssue).toHaveBeenCalledWith({ title: "Test", body: "Body", labels: ["bug", "high"] });
+    expect(mockCreateIssue).toHaveBeenCalledWith({
+      title: "Test",
+      body: "Body",
+      labels: ["bug", "high"],
+    });
   });
 });

--- a/tests/github/issues.test.ts
+++ b/tests/github/issues.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as cp from "node:child_process";
-import { getIssue, addComment, getComments, listIssues, createIssue, execGh } from "../../src/github/issues.js";
+import {
+  getIssue,
+  addComment,
+  getComments,
+  listIssues,
+  createIssue,
+  execGh,
+} from "../../src/github/issues.js";
 
 vi.mock("node:child_process", () => ({
   execFile: vi.fn(),
@@ -9,36 +16,30 @@ vi.mock("node:child_process", () => ({
 const mockExecFile = vi.mocked(cp.execFile);
 
 function mockExecFileSuccess(stdout: string): void {
-  mockExecFile.mockImplementation(
-    ((_cmd: unknown, _args: unknown, callback: unknown) => {
-      (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
-        null,
-        { stdout, stderr: "" },
-      );
-    }) as typeof cp.execFile,
-  );
+  mockExecFile.mockImplementation(((_cmd: unknown, _args: unknown, callback: unknown) => {
+    (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(null, {
+      stdout,
+      stderr: "",
+    });
+  }) as typeof cp.execFile);
 }
 
 function mockExecFileError(message: string): void {
-  mockExecFile.mockImplementation(
-    ((_cmd: unknown, _args: unknown, callback: unknown) => {
-      (callback as (err: Error | null) => void)(new Error(message));
-    }) as typeof cp.execFile,
-  );
+  mockExecFile.mockImplementation(((_cmd: unknown, _args: unknown, callback: unknown) => {
+    (callback as (err: Error | null) => void)(new Error(message));
+  }) as typeof cp.execFile);
 }
 
 function mockExecFileErrorWithCode(message: string, code: string | number): void {
-  mockExecFile.mockImplementation(
-    ((_cmd: unknown, _args: unknown, callback: unknown) => {
-      const err = new Error(message) as NodeJS.ErrnoException;
-      err.code = String(code);
-      // For numeric exit codes, set as number to match child_process behavior
-      if (typeof code === "number") {
-        (err as unknown as Record<string, unknown>).code = code;
-      }
-      (callback as (err: Error | null) => void)(err);
-    }) as typeof cp.execFile,
-  );
+  mockExecFile.mockImplementation(((_cmd: unknown, _args: unknown, callback: unknown) => {
+    const err = new Error(message) as NodeJS.ErrnoException;
+    err.code = String(code);
+    // For numeric exit codes, set as number to match child_process behavior
+    if (typeof code === "number") {
+      (err as unknown as Record<string, unknown>).code = code;
+    }
+    (callback as (err: Error | null) => void)(err);
+  }) as typeof cp.execFile);
 }
 
 beforeEach(() => {
@@ -50,11 +51,7 @@ describe("execGh", () => {
     mockExecFileSuccess('{"ok": true}');
     const result = await execGh(["issue", "list"]);
     expect(result).toBe('{"ok": true}');
-    expect(mockExecFile).toHaveBeenCalledWith(
-      "gh",
-      ["issue", "list"],
-      expect.any(Function),
-    );
+    expect(mockExecFile).toHaveBeenCalledWith("gh", ["issue", "list"], expect.any(Function));
   });
 
   it("throws on failure with descriptive message", async () => {
@@ -133,7 +130,15 @@ describe("getComments", () => {
     expect(result).toEqual(comments);
     expect(mockExecFile).toHaveBeenCalledWith(
       "gh",
-      ["issue", "view", "42", "--json", "comments", "--jq", ".comments | sort_by(.createdAt) | reverse | .[:5]"],
+      [
+        "issue",
+        "view",
+        "42",
+        "--json",
+        "comments",
+        "--jq",
+        ".comments | sort_by(.createdAt) | reverse | .[:5]",
+      ],
       expect.any(Function),
     );
   });
@@ -153,9 +158,7 @@ describe("getComments", () => {
 
 describe("listIssues", () => {
   it("lists issues without filters", async () => {
-    const issues = [
-      { number: 1, title: "A", body: "", labels: [], state: "OPEN" },
-    ];
+    const issues = [{ number: 1, title: "A", body: "", labels: [], state: "OPEN" }];
     mockExecFileSuccess(JSON.stringify(issues));
 
     const result = await listIssues();
@@ -174,10 +177,14 @@ describe("listIssues", () => {
     expect(mockExecFile).toHaveBeenCalledWith(
       "gh",
       [
-        "issue", "list",
-        "--json", "number,title,body,labels,state,milestone",
-        "--label", "bug,urgent",
-        "--state", "open",
+        "issue",
+        "list",
+        "--json",
+        "number,title,body,labels,state,milestone",
+        "--label",
+        "bug,urgent",
+        "--state",
+        "open",
       ],
       expect.any(Function),
     );
@@ -190,9 +197,12 @@ describe("listIssues", () => {
     expect(mockExecFile).toHaveBeenCalledWith(
       "gh",
       [
-        "issue", "list",
-        "--json", "number,title,body,labels,state,milestone",
-        "--milestone", "Sprint 1",
+        "issue",
+        "list",
+        "--json",
+        "number,title,body,labels,state,milestone",
+        "--milestone",
+        "Sprint 1",
       ],
       expect.any(Function),
     );
@@ -201,15 +211,13 @@ describe("listIssues", () => {
 
 describe("createIssue", () => {
   it("rejects empty title", async () => {
-    await expect(createIssue({ title: "", body: "desc" })).rejects.toThrow(
-      "title is required",
-    );
+    await expect(createIssue({ title: "", body: "desc" })).rejects.toThrow("title is required");
   });
 
   it("rejects undefined title", async () => {
-    await expect(createIssue({ title: undefined as unknown as string, body: "desc" })).rejects.toThrow(
-      "title is required",
-    );
+    await expect(
+      createIssue({ title: undefined as unknown as string, body: "desc" }),
+    ).rejects.toThrow("title is required");
   });
 
   it("rejects empty body", async () => {
@@ -220,25 +228,31 @@ describe("createIssue", () => {
 
   it("skips creation if duplicate open issue exists", async () => {
     const existing = [
-      { number: 42, title: "chore(process): Fix something", body: "desc", labels: [], state: "OPEN" },
+      {
+        number: 42,
+        title: "chore(process): Fix something",
+        body: "desc",
+        labels: [],
+        state: "OPEN",
+      },
     ];
     // First call: listIssues for dedup check; second call would be createIssue (should not happen)
     let callCount = 0;
-    mockExecFile.mockImplementation(
-      ((_cmd: unknown, args: unknown, callback: unknown) => {
-        callCount++;
-        const argList = args as string[];
-        if (argList[0] === "issue" && argList[1] === "list") {
-          (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
-            null, { stdout: JSON.stringify(existing), stderr: "" },
-          );
-        } else {
-          (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
-            null, { stdout: "", stderr: "" },
-          );
-        }
-      }) as typeof cp.execFile,
-    );
+    mockExecFile.mockImplementation(((_cmd: unknown, args: unknown, callback: unknown) => {
+      callCount++;
+      const argList = args as string[];
+      if (argList[0] === "issue" && argList[1] === "list") {
+        (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
+          null,
+          { stdout: JSON.stringify(existing), stderr: "" },
+        );
+      } else {
+        (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
+          null,
+          { stdout: "", stderr: "" },
+        );
+      }
+    }) as typeof cp.execFile);
 
     const result = await createIssue({ title: "chore(process): Fix something", body: "desc" });
     expect(result.number).toBe(42);

--- a/tests/github/labels.test.ts
+++ b/tests/github/labels.test.ts
@@ -8,12 +8,7 @@ vi.mock("../../src/logger.js", () => ({
 }));
 
 import { execGh } from "../../src/github/issues.js";
-import {
-  setLabel,
-  removeLabel,
-  getLabels,
-  ensureLabelExists,
-} from "../../src/github/labels.js";
+import { setLabel, removeLabel, getLabels, ensureLabelExists } from "../../src/github/labels.js";
 
 const mockExecGh = vi.mocked(execGh);
 
@@ -25,24 +20,12 @@ describe("labels", () => {
 
   it("setLabel calls gh issue edit with --add-label", async () => {
     await setLabel(42, "bug");
-    expect(mockExecGh).toHaveBeenCalledWith([
-      "issue",
-      "edit",
-      "42",
-      "--add-label",
-      "bug",
-    ]);
+    expect(mockExecGh).toHaveBeenCalledWith(["issue", "edit", "42", "--add-label", "bug"]);
   });
 
   it("removeLabel calls gh issue edit with --remove-label", async () => {
     await removeLabel(42, "bug");
-    expect(mockExecGh).toHaveBeenCalledWith([
-      "issue",
-      "edit",
-      "42",
-      "--remove-label",
-      "bug",
-    ]);
+    expect(mockExecGh).toHaveBeenCalledWith(["issue", "edit", "42", "--remove-label", "bug"]);
   });
 
   it("getLabels returns parsed label array", async () => {
@@ -55,12 +38,7 @@ describe("labels", () => {
     mockExecGh.mockResolvedValueOnce("[]"); // list call
     await ensureLabelExists("new-label");
     expect(mockExecGh).toHaveBeenCalledTimes(2);
-    expect(mockExecGh).toHaveBeenNthCalledWith(2, [
-      "label",
-      "create",
-      "new-label",
-      "--force",
-    ]);
+    expect(mockExecGh).toHaveBeenNthCalledWith(2, ["label", "create", "new-label", "--force"]);
   });
 
   it("ensureLabelExists skips creation when label exists", async () => {

--- a/tests/github/milestones.test.ts
+++ b/tests/github/milestones.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as cp from "node:child_process";
-import { getMilestone, getNextOpenMilestone, parseSprintFromTitle, createMilestone, setMilestone, closeMilestone, listSprintMilestones } from "../../src/github/milestones.js";
+import {
+  getMilestone,
+  getNextOpenMilestone,
+  parseSprintFromTitle,
+  createMilestone,
+  setMilestone,
+  closeMilestone,
+  listSprintMilestones,
+} from "../../src/github/milestones.js";
 
 vi.mock("node:child_process", () => ({
   execFile: vi.fn(),
@@ -9,25 +17,21 @@ vi.mock("node:child_process", () => ({
 const mockExecFile = vi.mocked(cp.execFile);
 
 function mockExecFileSuccess(stdout: string): void {
-  mockExecFile.mockImplementation(
-    ((_cmd: unknown, _args: unknown, callback: unknown) => {
-      (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
-        null,
-        { stdout, stderr: "" },
-      );
-    }) as typeof cp.execFile,
-  );
+  mockExecFile.mockImplementation(((_cmd: unknown, _args: unknown, callback: unknown) => {
+    (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(null, {
+      stdout,
+      stderr: "",
+    });
+  }) as typeof cp.execFile);
 }
 
 function mockExecFileError(err: Error): void {
-  mockExecFile.mockImplementation(
-    ((_cmd: unknown, _args: unknown, callback: unknown) => {
-      (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
-        err,
-        { stdout: "", stderr: err.message },
-      );
-    }) as typeof cp.execFile,
-  );
+  mockExecFile.mockImplementation(((_cmd: unknown, _args: unknown, callback: unknown) => {
+    (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(err, {
+      stdout: "",
+      stderr: err.message,
+    });
+  }) as typeof cp.execFile);
 }
 
 beforeEach(() => {
@@ -62,9 +66,7 @@ describe("getMilestone", () => {
   });
 
   it("returns undefined when milestone not found", async () => {
-    const milestones = [
-      { title: "Sprint 1", number: 1, description: "", state: "open" },
-    ];
+    const milestones = [{ title: "Sprint 1", number: 1, description: "", state: "open" }];
     mockExecFileSuccess(JSON.stringify(milestones));
 
     const result = await getMilestone("Nonexistent");
@@ -194,18 +196,17 @@ describe("closeMilestone", () => {
   it("closes a milestone by title", async () => {
     // First call: getMilestone lookup, second call: PATCH
     let callCount = 0;
-    mockExecFile.mockImplementation(
-      ((_cmd: unknown, _args: unknown, callback: unknown) => {
-        callCount++;
-        const data = callCount === 1
+    mockExecFile.mockImplementation(((_cmd: unknown, _args: unknown, callback: unknown) => {
+      callCount++;
+      const data =
+        callCount === 1
           ? JSON.stringify([{ title: "Sprint 2", number: 2, description: "", state: "open" }])
           : "";
-        (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
-          null,
-          { stdout: data, stderr: "" },
-        );
-      }) as typeof cp.execFile,
-    );
+      (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(null, {
+        stdout: data,
+        stderr: "",
+      });
+    }) as typeof cp.execFile);
 
     await closeMilestone("Sprint 2");
     expect(callCount).toBe(2);
@@ -221,18 +222,17 @@ describe("closeMilestone", () => {
 describe("listSprintMilestones", () => {
   it("returns sorted sprint milestones from both open and closed states", async () => {
     let callCount = 0;
-    mockExecFile.mockImplementation(
-      ((_cmd: unknown, _args: unknown, callback: unknown) => {
-        callCount++;
-        const data = callCount === 1
+    mockExecFile.mockImplementation(((_cmd: unknown, _args: unknown, callback: unknown) => {
+      callCount++;
+      const data =
+        callCount === 1
           ? JSON.stringify([{ title: "Sprint 3", number: 3, description: "", state: "open" }])
           : JSON.stringify([{ title: "Sprint 1", number: 1, description: "", state: "closed" }]);
-        (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
-          null,
-          { stdout: data, stderr: "" },
-        );
-      }) as typeof cp.execFile,
-    );
+      (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(null, {
+        stdout: data,
+        stderr: "",
+      });
+    }) as typeof cp.execFile);
 
     const result = await listSprintMilestones();
     expect(result).toHaveLength(2);
@@ -242,22 +242,25 @@ describe("listSprintMilestones", () => {
 
   it("handles API failure for one state gracefully", async () => {
     let callCount = 0;
-    mockExecFile.mockImplementation(
-      ((_cmd: unknown, _args: unknown, callback: unknown) => {
-        callCount++;
-        if (callCount === 1) {
-          (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
-            null,
-            { stdout: JSON.stringify([{ title: "Sprint 2", number: 2, description: "", state: "open" }]), stderr: "" },
-          );
-        } else {
-          (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
-            new Error("API error"),
-            { stdout: "", stderr: "API error" },
-          );
-        }
-      }) as typeof cp.execFile,
-    );
+    mockExecFile.mockImplementation(((_cmd: unknown, _args: unknown, callback: unknown) => {
+      callCount++;
+      if (callCount === 1) {
+        (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
+          null,
+          {
+            stdout: JSON.stringify([
+              { title: "Sprint 2", number: 2, description: "", state: "open" },
+            ]),
+            stderr: "",
+          },
+        );
+      } else {
+        (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
+          new Error("API error"),
+          { stdout: "", stderr: "API error" },
+        );
+      }
+    }) as typeof cp.execFile);
 
     const result = await listSprintMilestones();
     expect(result).toHaveLength(1);
@@ -266,21 +269,20 @@ describe("listSprintMilestones", () => {
 
   it("filters non-sprint milestones", async () => {
     let callCount = 0;
-    mockExecFile.mockImplementation(
-      ((_cmd: unknown, _args: unknown, callback: unknown) => {
-        callCount++;
-        const data = callCount === 1
+    mockExecFile.mockImplementation(((_cmd: unknown, _args: unknown, callback: unknown) => {
+      callCount++;
+      const data =
+        callCount === 1
           ? JSON.stringify([
               { title: "Sprint 1", number: 1, description: "", state: "open" },
               { title: "Backlog", number: 2, description: "", state: "open" },
             ])
           : JSON.stringify([]);
-        (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
-          null,
-          { stdout: data, stderr: "" },
-        );
-      }) as typeof cp.execFile,
-    );
+      (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(null, {
+        stdout: data,
+        stderr: "",
+      });
+    }) as typeof cp.execFile);
 
     const result = await listSprintMilestones();
     expect(result).toHaveLength(1);
@@ -289,18 +291,17 @@ describe("listSprintMilestones", () => {
 
   it("uses custom prefix", async () => {
     let callCount = 0;
-    mockExecFile.mockImplementation(
-      ((_cmd: unknown, _args: unknown, callback: unknown) => {
-        callCount++;
-        const data = callCount === 1
+    mockExecFile.mockImplementation(((_cmd: unknown, _args: unknown, callback: unknown) => {
+      callCount++;
+      const data =
+        callCount === 1
           ? JSON.stringify([{ title: "Iteration 5", number: 5, description: "", state: "open" }])
           : JSON.stringify([]);
-        (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(
-          null,
-          { stdout: data, stderr: "" },
-        );
-      }) as typeof cp.execFile,
-    );
+      (callback as (err: Error | null, result: { stdout: string; stderr: string }) => void)(null, {
+        stdout: data,
+        stderr: "",
+      });
+    }) as typeof cp.execFile);
 
     const result = await listSprintMilestones("Iteration");
     expect(result).toHaveLength(1);

--- a/tests/heartbeat.test.ts
+++ b/tests/heartbeat.test.ts
@@ -143,10 +143,7 @@ describe("HeartbeatSupervisor", () => {
     const staleEvents: unknown[] = [];
     bus.onTyped("heartbeat:stale", (p) => staleEvents.push(p));
 
-    const supervisor = new HeartbeatSupervisor(
-      makeConfig({ staleThresholdMs: 0 }),
-      bus,
-    );
+    const supervisor = new HeartbeatSupervisor(makeConfig({ staleThresholdMs: 0 }), bus);
     await supervisor.tick();
     await supervisor.tick();
 

--- a/tests/integration/sprint-cycle.test.ts
+++ b/tests/integration/sprint-cycle.test.ts
@@ -19,7 +19,15 @@ vi.mock("../../src/ceremonies/planning.js", () => ({
   runSprintPlanning: vi.fn().mockResolvedValue({
     sprintNumber: 1,
     sprint_issues: [
-      { number: 1, title: "Issue 1", ice_score: 8, depends_on: [], acceptanceCriteria: "AC", expectedFiles: ["src/a.ts"], points: 3 },
+      {
+        number: 1,
+        title: "Issue 1",
+        ice_score: 8,
+        depends_on: [],
+        acceptanceCriteria: "AC",
+        expectedFiles: ["src/a.ts"],
+        points: 3,
+      },
     ],
     execution_groups: [[1]],
     estimated_points: 3,
@@ -30,52 +38,120 @@ vi.mock("../../src/ceremonies/planning.js", () => ({
 vi.mock("../../src/ceremonies/parallel-dispatcher.js", () => ({
   runParallelExecution: vi.fn().mockResolvedValue({
     results: [
-      { issueNumber: 1, status: "completed", qualityGatePassed: true, qualityDetails: { passed: true, checks: [] }, branch: "feat/1-test", duration_ms: 10000, filesChanged: ["src/a.ts"], retryCount: 0, points: 3 },
+      {
+        issueNumber: 1,
+        status: "completed",
+        qualityGatePassed: true,
+        qualityDetails: { passed: true, checks: [] },
+        branch: "feat/1-test",
+        duration_ms: 10000,
+        filesChanged: ["src/a.ts"],
+        retryCount: 0,
+        points: 3,
+      },
     ],
-    sprint: 1, parallelizationRatio: 1, avgWorktreeLifetime: 10000, mergeConflicts: 0,
+    sprint: 1,
+    parallelizationRatio: 1,
+    avgWorktreeLifetime: 10000,
+    mergeConflicts: 0,
   }),
 }));
 
 vi.mock("../../src/ceremonies/review.js", () => ({
   runSprintReview: vi.fn().mockResolvedValue({
-    summary: "Good sprint", demoItems: ["Feature A"], velocityUpdate: "3 points", openItems: [],
+    summary: "Good sprint",
+    demoItems: ["Feature A"],
+    velocityUpdate: "3 points",
+    openItems: [],
   }),
 }));
 
 vi.mock("../../src/ceremonies/retro.js", () => ({
   runSprintRetro: vi.fn().mockResolvedValue({
-    wentWell: ["Good"], wentBadly: ["Slow"], improvements: [], previousImprovementsChecked: true,
+    wentWell: ["Good"],
+    wentBadly: ["Slow"],
+    improvements: [],
+    previousImprovementsChecked: true,
   }),
 }));
 
-vi.mock("../../src/documentation/sprint-log.js", () => ({ createSprintLog: vi.fn().mockReturnValue("docs/sprints/sprint-1-log.md") }));
+vi.mock("../../src/documentation/sprint-log.js", () => ({
+  createSprintLog: vi.fn().mockReturnValue("docs/sprints/sprint-1-log.md"),
+}));
 vi.mock("../../src/documentation/velocity.js", () => ({ appendVelocity: vi.fn() }));
 vi.mock("../../src/metrics.js", () => ({
   calculateSprintMetrics: vi.fn().mockReturnValue({
-    planned: 1, completed: 1, failed: 0, pointsPlanned: 3, pointsCompleted: 3,
-    velocity: 3, avgDuration: 10000, firstPassRate: 100, driftIncidents: 0,
+    planned: 1,
+    completed: 1,
+    failed: 0,
+    pointsPlanned: 3,
+    pointsCompleted: 3,
+    velocity: 3,
+    avgDuration: 10000,
+    firstPassRate: 100,
+    driftIncidents: 0,
   }),
 }));
-vi.mock("../../src/enforcement/drift-control.js", () => ({ holisticDriftCheck: vi.fn().mockResolvedValue({ totalFilesChanged: 1, plannedChanges: 1, unplannedChanges: [], driftPercentage: 0 }) }));
-vi.mock("../../src/enforcement/escalation.js", () => ({ escalateToStakeholder: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../../src/enforcement/drift-control.js", () => ({
+  holisticDriftCheck: vi.fn().mockResolvedValue({
+    totalFilesChanged: 1,
+    plannedChanges: 1,
+    unplannedChanges: [],
+    driftPercentage: 0,
+  }),
+}));
+vi.mock("../../src/enforcement/escalation.js", () => ({
+  escalateToStakeholder: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock("../../src/logger.js", () => {
   const noop = vi.fn();
-  const childLogger = { info: noop, warn: noop, error: noop, debug: noop, child: vi.fn().mockReturnThis() };
-  return { logger: { info: noop, warn: noop, error: noop, debug: noop, child: vi.fn().mockReturnValue(childLogger) }, createLogger: vi.fn().mockReturnValue(childLogger), appendErrorLog: noop };
+  const childLogger = {
+    info: noop,
+    warn: noop,
+    error: noop,
+    debug: noop,
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    logger: {
+      info: noop,
+      warn: noop,
+      error: noop,
+      debug: noop,
+      child: vi.fn().mockReturnValue(childLogger),
+    },
+    createLogger: vi.fn().mockReturnValue(childLogger),
+    appendErrorLog: noop,
+  };
 });
 
 // --- Helpers ---
 
 function makeConfig(overrides: Partial<SprintConfig> = {}): SprintConfig {
   return {
-    sprintNumber: 1, sprintPrefix: "Sprint", sprintSlug: "sprint",
-    projectPath: os.tmpdir(), baseBranch: "main", worktreeBase: "../sprint-worktrees",
-    branchPattern: "{prefix}/{sprint}/issue-{issue}", maxParallelSessions: 4,
-    maxIssuesPerSprint: 8, maxDriftIncidents: 2, maxRetries: 2,
-    enableChallenger: false, autoRevertDrift: false, backlogLabels: [],
-    autoMerge: true, squashMerge: true, deleteBranchAfterMerge: true,
-    sessionTimeoutMs: 600000, customInstructions: "", globalMcpServers: [],
-    globalInstructions: [], phases: {}, ...overrides,
+    sprintNumber: 1,
+    sprintPrefix: "Sprint",
+    sprintSlug: "sprint",
+    projectPath: os.tmpdir(),
+    baseBranch: "main",
+    worktreeBase: "../sprint-worktrees",
+    branchPattern: "{prefix}/{sprint}/issue-{issue}",
+    maxParallelSessions: 4,
+    maxIssuesPerSprint: 8,
+    maxDriftIncidents: 2,
+    maxRetries: 2,
+    enableChallenger: false,
+    autoRevertDrift: false,
+    backlogLabels: [],
+    autoMerge: true,
+    squashMerge: true,
+    deleteBranchAfterMerge: true,
+    sessionTimeoutMs: 600000,
+    customInstructions: "",
+    globalMcpServers: [],
+    globalInstructions: [],
+    phases: {},
+    ...overrides,
   };
 }
 

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  calculateSprintMetrics,
-  topFailedGates,
-  formatDuration,
-  percent,
-} from "../src/metrics.js";
+import { calculateSprintMetrics, topFailedGates, formatDuration, percent } from "../src/metrics.js";
 import type { SprintResult, IssueResult } from "../src/types.js";
 
 function makeIssue(overrides: Partial<IssueResult> = {}): IssueResult {
@@ -98,21 +93,42 @@ describe("calculateSprintMetrics", () => {
         issueNumber: 1,
         qualityDetails: {
           passed: true,
-          checks: [{ name: "scope-drift", passed: true, detail: "⚠️ 2 unplanned files (non-blocking): index.html, src/footer.ts", category: "diff" }],
+          checks: [
+            {
+              name: "scope-drift",
+              passed: true,
+              detail: "⚠️ 2 unplanned files (non-blocking): index.html, src/footer.ts",
+              category: "diff",
+            },
+          ],
         },
       }),
       makeIssue({
         issueNumber: 2,
         qualityDetails: {
           passed: true,
-          checks: [{ name: "scope-drift", passed: true, detail: "All 3 changed files within expected scope", category: "diff" }],
+          checks: [
+            {
+              name: "scope-drift",
+              passed: true,
+              detail: "All 3 changed files within expected scope",
+              category: "diff",
+            },
+          ],
         },
       }),
       makeIssue({
         issueNumber: 3,
         qualityDetails: {
           passed: true,
-          checks: [{ name: "scope-drift", passed: true, detail: "⚠️ 1 unplanned files (non-blocking): style.css", category: "diff" }],
+          checks: [
+            {
+              name: "scope-drift",
+              passed: true,
+              detail: "⚠️ 1 unplanned files (non-blocking): style.css",
+              category: "diff",
+            },
+          ],
         },
       }),
     ]);

--- a/tests/notifications/ntfy.test.ts
+++ b/tests/notifications/ntfy.test.ts
@@ -16,9 +16,7 @@ describe("sendNotification", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response("ok", { status: 200 }),
-    );
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("ok", { status: 200 }));
   });
 
   it("does NOT call fetch when disabled", async () => {
@@ -58,10 +56,7 @@ describe("sendNotification", () => {
       priority: "default",
     };
 
-    await sendNotification(config, "Test Title", "Test body", "high", [
-      "warning",
-      "fire",
-    ]);
+    await sendNotification(config, "Test Title", "Test body", "high", ["warning", "fire"]);
 
     expect(fetchSpy).toHaveBeenCalledOnce();
     const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
@@ -85,8 +80,10 @@ describe("sendNotification", () => {
 
     await sendNotification(config, "Title", "Body");
 
-    const headers = (fetchSpy.mock.calls[0] as [string, RequestInit])[1]
-      .headers as Record<string, string>;
+    const headers = (fetchSpy.mock.calls[0] as [string, RequestInit])[1].headers as Record<
+      string,
+      string
+    >;
     expect(headers.Priority).toBe("low");
   });
 
@@ -100,9 +97,7 @@ describe("sendNotification", () => {
     };
 
     // Should not throw
-    await expect(
-      sendNotification(config, "Title", "Body"),
-    ).resolves.toBeUndefined();
+    await expect(sendNotification(config, "Title", "Body")).resolves.toBeUndefined();
   });
 
   it("logs warning and does NOT throw when fetch throws", async () => {
@@ -114,8 +109,6 @@ describe("sendNotification", () => {
       priority: "default",
     };
 
-    await expect(
-      sendNotification(config, "Title", "Body"),
-    ).resolves.toBeUndefined();
+    await expect(sendNotification(config, "Title", "Body")).resolves.toBeUndefined();
   });
 });

--- a/tests/notifications/sprint-notifications.test.ts
+++ b/tests/notifications/sprint-notifications.test.ts
@@ -90,4 +90,13 @@ describe("attachSprintNotifications", () => {
 
     expect(mockSendNotification).toHaveBeenCalledTimes(3);
   });
+
+  it("does not attach duplicate listeners when called multiple times on same bus", () => {
+    // beforeEach already called attachSprintNotifications once
+    attachSprintNotifications(bus, ntfyConfig);
+    attachSprintNotifications(bus, ntfyConfig);
+
+    bus.emitTyped("sprint:complete", { sprintNumber: 1 });
+    expect(mockSendNotification).toHaveBeenCalledOnce();
+  });
 });

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -153,7 +153,7 @@ function makeConfig(overrides: Partial<SprintConfig> = {}): SprintConfig {
     maxRetries: 2,
     enableChallenger: false,
     autoRevertDrift: false,
-  backlogLabels: [],
+    backlogLabels: [],
     autoMerge: true,
     squashMerge: true,
     deleteBranchAfterMerge: true,
@@ -656,10 +656,7 @@ describe("sprintLoop", { timeout: 30000 }, () => {
     const sprintStarts: number[] = [];
     bus.onTyped("sprint:start", ({ sprintNumber }) => sprintStarts.push(sprintNumber));
 
-    const results = await SprintRunner.sprintLoop(
-      (n) => makeConfig({ sprintNumber: n }),
-      bus,
-    );
+    const results = await SprintRunner.sprintLoop((n) => makeConfig({ sprintNumber: n }), bus);
 
     expect(results).toHaveLength(2);
     expect(results[0]!.phase).toBe("complete");
@@ -676,11 +673,7 @@ describe("sprintLoop", { timeout: 30000 }, () => {
     vi.mocked(closeMilestone).mockResolvedValue(undefined);
 
     const bus = new SprintEventBus();
-    const results = await SprintRunner.sprintLoop(
-      (n) => makeConfig({ sprintNumber: n }),
-      bus,
-      2,
-    );
+    const results = await SprintRunner.sprintLoop((n) => makeConfig({ sprintNumber: n }), bus, 2);
 
     expect(results).toHaveLength(2);
     expect(results[0]!.phase).toBe("complete");
@@ -727,10 +720,7 @@ describe("sprintLoop", { timeout: 30000 }, () => {
     vi.mocked(runSprintPlanning).mockRejectedValueOnce(new Error("ACP down"));
 
     const bus = new SprintEventBus();
-    const results = await SprintRunner.sprintLoop(
-      (n) => makeConfig({ sprintNumber: n }),
-      bus,
-    );
+    const results = await SprintRunner.sprintLoop((n) => makeConfig({ sprintNumber: n }), bus);
 
     expect(results).toHaveLength(1);
     expect(results[0]!.phase).toBe("failed");
@@ -748,10 +738,7 @@ describe("sprintLoop", { timeout: 30000 }, () => {
     const logs: string[] = [];
     bus.onTyped("log", ({ message }) => logs.push(message));
 
-    await SprintRunner.sprintLoop(
-      (n) => makeConfig({ sprintNumber: n }),
-      bus,
-    );
+    await SprintRunner.sprintLoop((n) => makeConfig({ sprintNumber: n }), bus);
 
     expect(logs.some((m) => m.includes("Starting Sprint 1"))).toBe(true);
     expect(logs.some((m) => m.includes("No open sprint milestones"))).toBe(true);
@@ -767,11 +754,7 @@ describe("sprintLoop", { timeout: 30000 }, () => {
     const logs: string[] = [];
     bus.onTyped("log", ({ message }) => logs.push(message));
 
-    await SprintRunner.sprintLoop(
-      (n) => makeConfig({ sprintNumber: n }),
-      bus,
-      1,
-    );
+    await SprintRunner.sprintLoop((n) => makeConfig({ sprintNumber: n }), bus, 1);
 
     expect(logs.some((m) => m.includes("Sprint limit reached"))).toBe(true);
   });

--- a/tests/state-manager.test.ts
+++ b/tests/state-manager.test.ts
@@ -105,9 +105,7 @@ describe("getStatePath", () => {
     const config = makeConfig("/my/project");
     const result = getStatePath(config);
 
-    expect(result).toBe(
-      path.join("/my/project", "docs", "sprints", "alpha-3-state.json"),
-    );
+    expect(result).toBe(path.join("/my/project", "docs", "sprints", "alpha-3-state.json"));
   });
 });
 


### PR DESCRIPTION
## Problem
Each new `SprintRunner` created in `sprintLoop` called `attachSprintNotifications()` in its constructor, re-attaching event listeners to the **shared** `EventBus`. After N sprints, every notification was sent N times.

## Root Cause
`attachSprintNotifications` was called inside the `SprintRunner` constructor. Since `sprintLoop` creates a new runner per sprint iteration (all sharing the same bus), listeners accumulated.

## Fix
1. **Moved** `attachSprintNotifications` out of the constructor
2. **Added** a `WeakSet` guard making the function idempotent — safe to call multiple times on the same bus
3. **Call sites**: once in `sprintLoop` (before the loop) and once in `commands.ts` (dashboard init)
4. **Test**: new test verifies calling attach 3x on same bus only triggers 1 notification

Also includes:
- Prettier formatting for 80+ files (pre-existing drift)
- Removed unused `callCount` variable in execution test

## Tests
607 tests pass (1 new dedup test)