### PR TITLE
fix: activity feed auto-scrolls and shows only viewed sprint

### DIFF
--- a/src/dashboard/frontend/src/components/ActivityFeed.tsx
+++ b/src/dashboard/frontend/src/components/ActivityFeed.tsx
@@ -1,8 +1,14 @@
+import { useEffect, useRef } from "react";
 import { useDashboardStore } from "../store";
 import "./ActivityFeed.css";
 
 export function ActivityFeed() {
   const activities = useDashboardStore((s) => s.activities);
+  const bottomRef = useRef<HTMLLIElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [activities]);
 
   return (
     <div id="activity-panel" className="activity-container">
@@ -22,6 +28,7 @@ export function ActivityFeed() {
         {activities.length === 0 && (
           <li className="empty-state">No activity yet. Start a sprint to see progress.</li>
         )}
+        <li ref={bottomRef} style={{ height: 0 }} aria-hidden />
       </ul>
     </div>
   );

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -774,10 +774,29 @@ function addActivity(
   detail: string | null,
   status: Activity["status"],
 ): void {
+  const entry: Activity = { type, label, detail, status, time: new Date() };
+
+  // If viewing a different sprint than the active one, buffer the activity
+  // in the cache so it doesn't pollute the viewed sprint's feed.
+  if (
+    store.activeSprintNumber > 0 &&
+    store.viewingSprintNumber > 0 &&
+    store.viewingSprintNumber !== store.activeSprintNumber
+  ) {
+    const cached = activityCache.get(store.activeSprintNumber) ?? [];
+    const updated = cached.map((a) =>
+      a.status === "active" && a.type === type ? { ...a, status: "done" as const } : a,
+    );
+    updated.push(entry);
+    if (updated.length > 500) updated.splice(0, updated.length - 500);
+    activityCache.set(store.activeSprintNumber, updated);
+    return;
+  }
+
   const activities = store.activities.map((a) =>
     a.status === "active" && a.type === type ? { ...a, status: "done" as const } : a,
   );
-  activities.push({ type, label, detail, status, time: new Date() });
+  activities.push(entry);
   // Cap at 500 entries to prevent unbounded memory growth
   if (activities.length > 500) {
     activities.splice(0, activities.length - 500);


### PR DESCRIPTION
## Changes

### Auto-scroll
ActivityFeed now auto-scrolls to the latest entry when new activities arrive, using a `useRef` + `useEffect` with smooth scroll behavior.

### Sprint-scoped activities
When viewing a historical sprint while a different sprint is active, incoming events are buffered in `activityCache` for the active sprint instead of polluting the viewed sprint's feed. Switching back to the active sprint shows all buffered activities.

**Before:** Viewing Sprint 1 while Sprint 2 runs → Sprint 2's activities appear in Sprint 1's feed
**After:** Each sprint's activity feed stays isolated

## Files Changed
- `src/dashboard/frontend/src/components/ActivityFeed.tsx` — auto-scroll ref
- `src/dashboard/frontend/src/store.ts` — sprint-scoped `addActivity` guard