### PR TITLE
fix: planning retry on timeout + increase session timeout

### DIFF
--- a/.aiscrum/config.test.yaml
+++ b/.aiscrum/config.test.yaml
@@ -12,7 +12,7 @@ project:
 copilot:
   executable: "copilot"
   max_parallel_sessions: 2
-  session_timeout_ms: 300000
+  session_timeout_ms: 600000
   auto_approve_tools: true
 
   mcp_servers:

--- a/src/ceremonies/planning.ts
+++ b/src/ceremonies/planning.ts
@@ -65,8 +65,30 @@ export async function runSprintPlanning(
     if (sessionConfig.model) {
       await client.setModel(sessionId, sessionConfig.model);
     }
-    const result = await client.sendPrompt(sessionId, fullPrompt, config.sessionTimeoutMs);
-    const plan = SprintPlanSchema.parse(extractJson(result.response)) as SprintPlan;
+    // Retry planning once on timeout or parse failure
+    const MAX_PLANNING_ATTEMPTS = 2;
+    let plan: SprintPlan | undefined;
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= MAX_PLANNING_ATTEMPTS; attempt++) {
+      try {
+        const result = await client.sendPrompt(sessionId, fullPrompt, config.sessionTimeoutMs);
+        plan = SprintPlanSchema.parse(extractJson(result.response)) as SprintPlan;
+        break;
+      } catch (err: unknown) {
+        lastError = err;
+        const msg = err instanceof Error ? err.message : String(err);
+        if (attempt < MAX_PLANNING_ATTEMPTS) {
+          log.warn({ attempt, error: msg }, "Planning attempt failed — retrying");
+          eventBus?.emitTyped("log", {
+            level: "warn",
+            message: `Planning attempt ${attempt} failed (${msg.slice(0, 100)}), retrying…`,
+          });
+        }
+      }
+    }
+    if (!plan) {
+      throw lastError;
+    }
 
     // Enforce max_issues — LLM may return more than requested
     if (plan.sprint_issues.length > config.maxIssuesPerSprint) {

--- a/tests/ceremonies/planning.test.ts
+++ b/tests/ceremonies/planning.test.ts
@@ -289,7 +289,7 @@ describe("runSprintPlanning", () => {
     expect(createMilestone).not.toHaveBeenCalled();
   });
 
-  it("ends session even when prompt fails", async () => {
+  it("ends session even when all planning attempts fail", async () => {
     const mockClient = makeMockClient();
     mockClient.sendPrompt.mockRejectedValue(new Error("timeout"));
     vi.mocked(listIssues).mockResolvedValue([]);
@@ -297,6 +297,35 @@ describe("runSprintPlanning", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await expect(runSprintPlanning(mockClient as any, makeConfig())).rejects.toThrow("timeout");
 
+    // Retried once before giving up
+    expect(mockClient.sendPrompt).toHaveBeenCalledTimes(2);
     expect(mockClient.endSession).toHaveBeenCalledWith("session-123");
+  });
+
+  it("retries planning on first failure and succeeds on second attempt", async () => {
+    const mockClient = makeMockClient();
+    mockClient.sendPrompt
+      .mockRejectedValueOnce(new Error("Prompt timed out"))
+      .mockResolvedValueOnce({
+        response: "```json\n" + JSON.stringify(planResponse) + "\n```",
+        stopReason: "end_turn",
+      });
+    vi.mocked(listIssues).mockResolvedValue([]);
+    vi.mocked(getMilestone).mockResolvedValue({
+      title: "Sprint 3",
+      number: 1,
+      description: "",
+      state: "open",
+    });
+    vi.mocked(setLabel).mockResolvedValue(undefined);
+    vi.mocked(setMilestone).mockResolvedValue(undefined);
+    vi.mocked(createSprintLog).mockReturnValue("/tmp/log.md");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const plan = await runSprintPlanning(mockClient as any, makeConfig());
+
+    expect(mockClient.sendPrompt).toHaveBeenCalledTimes(2);
+    expect(plan.sprintNumber).toBe(3);
+    expect(plan.sprint_issues).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Problem
Sprint 2 failed because the planning ACP session timed out after 300s. The planner returned no JSON, causing `No JSON found in response` → sprint marked as failed.

## Fixes
1. **Planning retry** — if `sendPrompt` times out or returns unparseable response, retry once before failing. Logs a warning with the error on first failure.
2. **Timeout increase** — `session_timeout_ms` raised from 300s to 600s in test config (matches the code default).

## Tests
- Updated existing failure test to verify 2 attempts before giving up
- New test: first attempt fails, second succeeds → plan returned correctly
- 608 tests pass (1 new)