### PR TITLE
fix: dashboard UI bugs — layout shifts, colors, scroll, button size

### DIFF
--- a/src/dashboard/frontend/src/components/ActivityFeed.tsx
+++ b/src/dashboard/frontend/src/components/ActivityFeed.tsx
@@ -6,9 +6,14 @@ export function ActivityFeed() {
   const activities = useDashboardStore((s) => s.activities);
   const bottomRef = useRef<HTMLLIElement>(null);
 
+  // Scroll to bottom on new entries and on initial mount (tab switch)
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [activities]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "auto" });
+  }, []);
 
   return (
     <div id="activity-panel" className="activity-container">

--- a/src/dashboard/frontend/src/components/Header.css
+++ b/src/dashboard/frontend/src/components/Header.css
@@ -111,3 +111,10 @@
   background: rgba(46, 160, 67, 0.15);
   border-color: #3fb950;
 }
+
+.header-controls {
+  display: flex;
+  gap: 4px;
+  min-width: 120px;
+  justify-content: flex-end;
+}

--- a/src/dashboard/frontend/src/components/Header.tsx
+++ b/src/dashboard/frontend/src/components/Header.tsx
@@ -152,11 +152,13 @@ export function Header() {
           <option value="10">10 Sprints</option>
         </select>
 
-        {idle && <button className="btn btn-primary" onClick={() => send({ type: "sprint:start" })}>▶ Start</button>}
-        {running && isViewingActive && <button className="btn btn-small" onClick={() => send({ type: "sprint:pause" })}>⏸ Pause</button>}
-        {paused && isViewingActive && <button className="btn btn-small" onClick={() => send({ type: "sprint:resume" })}>▶ Resume</button>}
-        {(running || paused) && isViewingActive && <button className="btn btn-danger btn-small" onClick={() => { if (confirm("Stop sprint?")) send({ type: "sprint:stop" }); }}>⏹ Stop</button>}
-        {(running || paused) && isViewingActive && <button className="btn btn-danger btn-small" onClick={() => { if (confirm("Cancel sprint and return items to backlog?")) send({ type: "sprint:cancel" }); }}>✕ Cancel</button>}
+        <div className="header-controls">
+          {idle && <button className="btn btn-primary btn-small" onClick={() => send({ type: "sprint:start" })}>▶ Start</button>}
+          {running && isViewingActive && <button className="btn btn-small" onClick={() => send({ type: "sprint:pause" })}>⏸ Pause</button>}
+          {paused && isViewingActive && <button className="btn btn-small" onClick={() => send({ type: "sprint:resume" })}>▶ Resume</button>}
+          {(running || paused) && isViewingActive && <button className="btn btn-danger btn-small" onClick={() => { if (confirm("Stop sprint?")) send({ type: "sprint:stop" }); }}>⏹ Stop</button>}
+          {(running || paused) && isViewingActive && <button className="btn btn-danger btn-small" onClick={() => { if (confirm("Cancel sprint and return items to backlog?")) send({ type: "sprint:cancel" }); }}>✕ Cancel</button>}
+        </div>
       </div>
 
       <div className="phase-stepper">

--- a/src/dashboard/frontend/src/components/SessionPanel.css
+++ b/src/dashboard/frontend/src/components/SessionPanel.css
@@ -63,11 +63,24 @@
   border-radius: 3px;
   margin-left: auto;
 }
-.btn-tiny {
-  padding: 2px 6px;
-  font-size: 10px;
-  line-height: 1.2;
+
+.session-stop-btn {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: 3px;
+  background: var(--red);
+  color: #fff;
+  font-size: 8px;
+  line-height: 18px;
+  text-align: center;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.15s;
 }
+.session-stop-btn:hover { opacity: 1; }
 
 /* Session viewer */
 .session-viewer {

--- a/src/dashboard/frontend/src/components/SessionPanel.tsx
+++ b/src/dashboard/frontend/src/components/SessionPanel.tsx
@@ -66,15 +66,16 @@ export function SessionPanel() {
                 {isViewing && <span className="session-viewing-badge">viewing</span>}
                 {isActive && isViewing && (
                   <button
-                    className="btn btn-danger btn-tiny"
+                    className="session-stop-btn"
                     onClick={(e) => {
                       e.stopPropagation();
                       if (confirm("Stop this session?")) {
                         send({ type: "session:stop", sessionId: s.sessionId });
                       }
                     }}
+                    title="Stop session"
                   >
-                    Stop
+                    ■
                   </button>
                 )}
               </div>

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -206,9 +206,21 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
       break;
     }
 
-    case "sprint:issues":
-      set({ issues: (msg.payload as SprintIssue[]) || [] });
+    case "sprint:issues": {
+      const incoming = (msg.payload as SprintIssue[]) || [];
+      const current = get().issues;
+      // Preserve runtime status/step/failReason from existing issues
+      const statusMap = new Map(current.map((i) => [i.number, i]));
+      const merged = incoming.map((i) => {
+        const prev = statusMap.get(i.number);
+        if (prev && prev.status !== "planned" && prev.status !== i.status) {
+          return { ...i, status: prev.status, step: prev.step, failReason: prev.failReason };
+        }
+        return i;
+      });
+      set({ issues: merged });
       break;
+    }
 
     case "sprint:switched": {
       const p = msg.payload as { activeSprintNumber?: number } | undefined;


### PR DESCRIPTION
Fixes 4 dashboard UI bugs found during test sprint run:

| Issue | Fix |
|-------|-----|
| #436 Header layout shift | Wrap controls in fixed-width container, use `btn-small` for Start |
| #437 Issue colors lost on tab switch | Merge `sprint:issues` with existing runtime status instead of replacing |
| #438 Activity scroll resets on tab switch | Add mount-time `scrollIntoView` (instant, not smooth) |
| #439 Session stop button too large | Replace `btn btn-danger btn-tiny` with compact 18×18px ■ icon button |

Closes #436, #437, #438, #439