### PR TITLE
fix: sprint run issues — label cleanup, schema, config guard, zero-change recovery

### DIFF
--- a/src/ceremonies/execution.ts
+++ b/src/ceremonies/execution.ts
@@ -20,7 +20,7 @@ import { formatHuddleComment, formatSprintLogEntry } from "../documentation/hudd
 import type { ZeroChangeDiagnostic, HuddleEntryWithDiag } from "../documentation/huddle.js";
 import { appendToSprintLog } from "../documentation/sprint-log.js";
 import { addComment } from "../github/issues.js";
-import { setLabel } from "../github/labels.js";
+import { setStatusLabel } from "../github/labels.js";
 import { getChangedFiles } from "../git/diff-analysis.js";
 import { getPRStats } from "../git/merge.js";
 import { substitutePrompt, extractJson, sanitizePromptInput, parseWithRetry } from "./helpers.js";
@@ -622,6 +622,24 @@ async function cleanupPhase(ctx: ExecutionContext, input: CleanupInput): Promise
           "PR has files — overriding local diff",
         );
         input.filesChanged = [`(${stats.changedFiles} files via PR #${stats.prNumber})`];
+
+        // If the only failure reason was zero file changes, recover the status
+        const zeroChangeOnly =
+          input.status === "failed" &&
+          input.qualityResult.checks.some((c) => c.name === "files-changed" && !c.passed) &&
+          input.qualityResult.checks.filter((c) => !c.passed).length === 1;
+        if (zeroChangeOnly) {
+          log.info({ issue: issue.number }, "Recovering status — PR has actual file changes");
+          input.status = "completed";
+          input.qualityResult = {
+            passed: true,
+            checks: input.qualityResult.checks.map((c) =>
+              c.name === "files-changed"
+                ? { ...c, passed: true, detail: `${stats.changedFiles} files via PR` }
+                : c,
+            ),
+          };
+        }
       }
     }
   } catch {
@@ -676,7 +694,7 @@ async function cleanupPhase(ctx: ExecutionContext, input: CleanupInput): Promise
   // Set final label
   const finalLabel = input.status === "completed" ? "status:done" : "status:blocked";
   try {
-    await setLabel(issue.number, finalLabel);
+    await setStatusLabel(issue.number, finalLabel);
     if (finalLabel === "status:blocked") {
       const blockReason =
         input.errorMessage ??
@@ -753,7 +771,7 @@ export async function executeIssue(
   };
 
   // Step 1: Set in-progress label
-  await setLabel(issue.number, "status:in-progress");
+  await setStatusLabel(issue.number, "status:in-progress");
   log.info("issue marked in-progress");
   progress("creating worktree");
 

--- a/src/ceremonies/parallel-dispatcher.ts
+++ b/src/ceremonies/parallel-dispatcher.ts
@@ -13,7 +13,7 @@ import { createWorktree, removeWorktree } from "../git/worktree.js";
 import { verifyMainBranch } from "../enforcement/quality-gate.js";
 import { buildQualityGateConfig } from "./quality-retry.js";
 import { escalateToStakeholder } from "../enforcement/escalation.js";
-import { setLabel } from "../github/labels.js";
+import { setStatusLabel } from "../github/labels.js";
 import { addComment } from "../github/issues.js";
 import { logger, appendErrorLog } from "../logger.js";
 
@@ -288,7 +288,7 @@ export async function runParallelExecution(
                 // Retry didn't resolve the conflict
                 retryResult.status = "failed";
                 retryResult.qualityGatePassed = false;
-                await setLabel(retryResult.issueNumber, "status:blocked");
+                await setStatusLabel(retryResult.issueNumber, "status:blocked");
                 await addComment(
                   retryResult.issueNumber,
                   "**Block reason:** Pre-merge verification failed after conflict retry",
@@ -302,7 +302,7 @@ export async function runParallelExecution(
             );
             result.status = "failed";
             result.qualityGatePassed = false;
-            await setLabel(result.issueNumber, "status:blocked");
+            await setStatusLabel(result.issueNumber, "status:blocked");
             await addComment(
               result.issueNumber,
               `**Block reason:** Pre-merge verification failed — ${premerge.reason ?? "unknown"}`,
@@ -323,7 +323,7 @@ export async function runParallelExecution(
               );
               result.status = "failed";
               result.qualityGatePassed = false;
-              await setLabel(result.issueNumber, "status:blocked");
+              await setStatusLabel(result.issueNumber, "status:blocked");
               await addComment(
                 result.issueNumber,
                 `**Block reason:** PR merge failed — ${mergeResult.reason ?? "unknown"}`,

--- a/src/ceremonies/planning.ts
+++ b/src/ceremonies/planning.ts
@@ -4,7 +4,7 @@ import type { AcpClient } from "../acp/client.js";
 import type { SprintConfig, SprintPlan } from "../types.js";
 import { SprintPlanSchema } from "../types.js";
 import type { SprintEventBus } from "../events.js";
-import { setLabel, removeLabel } from "../github/labels.js";
+import { setStatusLabel, removeLabel } from "../github/labels.js";
 import {
   setMilestone,
   getMilestone,
@@ -121,7 +121,7 @@ export async function runSprintPlanning(
     // Set labels and milestone on each selected issue
     const plannedNumbers = new Set(plan.sprint_issues.map((i) => i.number));
     for (const issue of plan.sprint_issues) {
-      await setLabel(issue.number, "status:planned");
+      await setStatusLabel(issue.number, "status:planned");
       await setMilestone(issue.number, milestoneTitle);
       log.debug({ issue: issue.number }, "Labeled and milestoned issue");
     }

--- a/src/dashboard/frontend/src/components/ActivityFeed.tsx
+++ b/src/dashboard/frontend/src/components/ActivityFeed.tsx
@@ -6,9 +6,14 @@ export function ActivityFeed() {
   const activities = useDashboardStore((s) => s.activities);
   const bottomRef = useRef<HTMLLIElement>(null);
 
+  // Scroll to bottom on new entries and on initial mount (tab switch)
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [activities]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "auto" });
+  }, []);
 
   return (
     <div id="activity-panel" className="activity-container">

--- a/src/dashboard/frontend/src/components/Header.css
+++ b/src/dashboard/frontend/src/components/Header.css
@@ -111,3 +111,10 @@
   background: rgba(46, 160, 67, 0.15);
   border-color: #3fb950;
 }
+
+.header-controls {
+  display: flex;
+  gap: 4px;
+  min-width: 120px;
+  justify-content: flex-end;
+}

--- a/src/dashboard/frontend/src/components/Header.tsx
+++ b/src/dashboard/frontend/src/components/Header.tsx
@@ -152,11 +152,13 @@ export function Header() {
           <option value="10">10 Sprints</option>
         </select>
 
-        {idle && <button className="btn btn-primary" onClick={() => send({ type: "sprint:start" })}>▶ Start</button>}
-        {running && isViewingActive && <button className="btn btn-small" onClick={() => send({ type: "sprint:pause" })}>⏸ Pause</button>}
-        {paused && isViewingActive && <button className="btn btn-small" onClick={() => send({ type: "sprint:resume" })}>▶ Resume</button>}
-        {(running || paused) && isViewingActive && <button className="btn btn-danger btn-small" onClick={() => { if (confirm("Stop sprint?")) send({ type: "sprint:stop" }); }}>⏹ Stop</button>}
-        {(running || paused) && isViewingActive && <button className="btn btn-danger btn-small" onClick={() => { if (confirm("Cancel sprint and return items to backlog?")) send({ type: "sprint:cancel" }); }}>✕ Cancel</button>}
+        <div className="header-controls">
+          {idle && <button className="btn btn-primary btn-small" onClick={() => send({ type: "sprint:start" })}>▶ Start</button>}
+          {running && isViewingActive && <button className="btn btn-small" onClick={() => send({ type: "sprint:pause" })}>⏸ Pause</button>}
+          {paused && isViewingActive && <button className="btn btn-small" onClick={() => send({ type: "sprint:resume" })}>▶ Resume</button>}
+          {(running || paused) && isViewingActive && <button className="btn btn-danger btn-small" onClick={() => { if (confirm("Stop sprint?")) send({ type: "sprint:stop" }); }}>⏹ Stop</button>}
+          {(running || paused) && isViewingActive && <button className="btn btn-danger btn-small" onClick={() => { if (confirm("Cancel sprint and return items to backlog?")) send({ type: "sprint:cancel" }); }}>✕ Cancel</button>}
+        </div>
       </div>
 
       <div className="phase-stepper">

--- a/src/dashboard/frontend/src/components/SessionPanel.css
+++ b/src/dashboard/frontend/src/components/SessionPanel.css
@@ -63,11 +63,24 @@
   border-radius: 3px;
   margin-left: auto;
 }
-.btn-tiny {
-  padding: 2px 6px;
-  font-size: 10px;
-  line-height: 1.2;
+
+.session-stop-btn {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: 3px;
+  background: var(--red);
+  color: #fff;
+  font-size: 8px;
+  line-height: 18px;
+  text-align: center;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.15s;
 }
+.session-stop-btn:hover { opacity: 1; }
 
 /* Session viewer */
 .session-viewer {

--- a/src/dashboard/frontend/src/components/SessionPanel.tsx
+++ b/src/dashboard/frontend/src/components/SessionPanel.tsx
@@ -66,15 +66,16 @@ export function SessionPanel() {
                 {isViewing && <span className="session-viewing-badge">viewing</span>}
                 {isActive && isViewing && (
                   <button
-                    className="btn btn-danger btn-tiny"
+                    className="session-stop-btn"
                     onClick={(e) => {
                       e.stopPropagation();
                       if (confirm("Stop this session?")) {
                         send({ type: "session:stop", sessionId: s.sessionId });
                       }
                     }}
+                    title="Stop session"
                   >
-                    Stop
+                    ■
                   </button>
                 )}
               </div>

--- a/src/dashboard/frontend/src/store.ts
+++ b/src/dashboard/frontend/src/store.ts
@@ -206,9 +206,21 @@ function handleMessage(msg: ServerMessage, set: SetFn, get: GetFn): void {
       break;
     }
 
-    case "sprint:issues":
-      set({ issues: (msg.payload as SprintIssue[]) || [] });
+    case "sprint:issues": {
+      const incoming = (msg.payload as SprintIssue[]) || [];
+      const current = get().issues;
+      // Preserve runtime status/step/failReason from existing issues
+      const statusMap = new Map(current.map((i) => [i.number, i]));
+      const merged = incoming.map((i) => {
+        const prev = statusMap.get(i.number);
+        if (prev && prev.status !== "planned" && prev.status !== i.status) {
+          return { ...i, status: prev.status, step: prev.step, failReason: prev.failReason };
+        }
+        return i;
+      });
+      set({ issues: merged });
       break;
+    }
 
     case "sprint:switched": {
       const p = msg.payload as { activeSprintNumber?: number } | undefined;

--- a/src/dashboard/ws-server.ts
+++ b/src/dashboard/ws-server.ts
@@ -904,6 +904,10 @@ export class DashboardWebServer {
     value: string,
     ws: WebSocket,
   ): Promise<void> {
+    if (!optionId || typeof optionId !== "string") {
+      log.warn({ sessionId, optionId }, "Ignoring chat config — invalid optionId");
+      return;
+    }
     try {
       log.info({ sessionId, optionId, value }, "Setting chat config option");
       await this.getChatManager().setConfig(sessionId, optionId, value);
@@ -1693,9 +1697,9 @@ export class DashboardWebServer {
   /** Approve a decision: remove human-decision-needed label, add status:refined. */
   private async handleDecisionApprove(issueNumber: number, _ws: WebSocket): Promise<void> {
     try {
-      const { removeLabel, setLabel } = await import("../github/labels.js");
+      const { removeLabel, setStatusLabel } = await import("../github/labels.js");
       await removeLabel(issueNumber, "human-decision-needed");
-      await setLabel(issueNumber, "status:refined");
+      await setStatusLabel(issueNumber, "status:refined");
       this.broadcast({
         type: "sprint:event",
         eventName: "decisions:approved",
@@ -1750,7 +1754,7 @@ export class DashboardWebServer {
     const prefix = this.options.sprintPrefix ?? "Sprint";
     const milestoneTitle = `${prefix} ${sprintNum}`;
     try {
-      const { setLabel, removeLabel } = await import("../github/labels.js");
+      const { setStatusLabel, removeLabel } = await import("../github/labels.js");
       const { setMilestone, createMilestone, getMilestone } =
         await import("../github/milestones.js");
       // Ensure milestone exists
@@ -1759,7 +1763,7 @@ export class DashboardWebServer {
         await createMilestone(milestoneTitle);
       }
       await setMilestone(issueNumber, milestoneTitle);
-      await setLabel(issueNumber, "status:planned");
+      await setStatusLabel(issueNumber, "status:planned");
       try {
         await removeLabel(issueNumber, "status:refined");
       } catch {
@@ -1783,10 +1787,10 @@ export class DashboardWebServer {
   /** Remove an issue from the sprint (remove milestone + planned label). */
   private async handleRemoveFromSprint(issueNumber: number, ws: WebSocket): Promise<void> {
     try {
-      const { setLabel, removeLabel } = await import("../github/labels.js");
+      const { setStatusLabel, removeLabel } = await import("../github/labels.js");
       const { removeMilestone } = await import("../github/milestones.js");
       await removeLabel(issueNumber, "status:planned");
-      await setLabel(issueNumber, "status:refined");
+      await setStatusLabel(issueNumber, "status:refined");
       await removeMilestone(issueNumber);
       log.info({ issueNumber }, "Issue removed from sprint");
       this.sendTo(ws, { type: "backlog:removed", payload: { issueNumber } } as ServerMessage);

--- a/src/github/labels.ts
+++ b/src/github/labels.ts
@@ -7,6 +7,8 @@ export const STATUS_LABELS = [
   "status:in-progress",
   "status:done",
   "status:blocked",
+  "status:refined",
+  "status:ready",
 ] as const;
 
 export type StatusLabel = (typeof STATUS_LABELS)[number];
@@ -15,6 +17,29 @@ export type StatusLabel = (typeof STATUS_LABELS)[number];
 export async function setLabel(issueNumber: number, label: string): Promise<void> {
   logger.debug({ issueNumber, label }, "Adding label");
   await execGh(["issue", "edit", String(issueNumber), "--add-label", label]);
+}
+
+/**
+ * Set a status label, removing any other status:* labels first.
+ * Prevents duplicate status labels from accumulating on issues.
+ */
+export async function setStatusLabel(issueNumber: number, label: StatusLabel): Promise<void> {
+  try {
+    const current = await getLabels(issueNumber);
+    const staleStatuses = current
+      .filter((l) => l.name.startsWith("status:") && l.name !== label)
+      .map((l) => l.name);
+
+    for (const old of staleStatuses) {
+      await removeLabel(issueNumber, old).catch((err) =>
+        logger.debug({ err, issueNumber, label: old }, "failed to remove stale status label"),
+      );
+    }
+  } catch (err) {
+    logger.debug({ err, issueNumber }, "failed to read current labels — adding anyway");
+  }
+
+  await setLabel(issueNumber, label);
 }
 
 /** Remove a label from an issue. */

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -167,8 +167,8 @@ export const AcceptanceCriteriaSchema = z.object({
       z.object({
         criterion: z.string(),
         passed: z.boolean(),
-        evidence: z.string().optional(),
-        concern: z.string().optional(),
+        evidence: z.string().nullish(),
+        concern: z.string().nullish(),
       }),
     )
     .default([]),

--- a/tests/ceremonies/execution.test.ts
+++ b/tests/ceremonies/execution.test.ts
@@ -34,6 +34,9 @@ vi.mock("../../src/github/issues.js", () => ({
 
 vi.mock("../../src/github/labels.js", () => ({
   setLabel: vi.fn().mockResolvedValue(undefined),
+  setStatusLabel: vi.fn().mockResolvedValue(undefined),
+  getLabels: vi.fn().mockResolvedValue([]),
+  removeLabel: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../../src/git/diff-analysis.js", () => ({
@@ -115,7 +118,7 @@ const { formatHuddleComment, formatSprintLogEntry } =
   await import("../../src/documentation/huddle.js");
 const { appendToSprintLog } = await import("../../src/documentation/sprint-log.js");
 const { addComment } = await import("../../src/github/issues.js");
-const { setLabel } = await import("../../src/github/labels.js");
+const { setStatusLabel } = await import("../../src/github/labels.js");
 await import("../../src/git/diff-analysis.js");
 
 const { executeIssue } = await import("../../src/ceremonies/execution.js");
@@ -229,7 +232,7 @@ describe("executeIssue", () => {
     const result = await executeIssue(mockClient as any, makeConfig(), makeIssue());
 
     // Label set to in-progress first
-    expect(setLabel).toHaveBeenCalledWith(42, "status:in-progress");
+    expect(setStatusLabel).toHaveBeenCalledWith(42, "status:in-progress");
 
     // Worktree created
     expect(createWorktree).toHaveBeenCalledWith({
@@ -260,7 +263,7 @@ describe("executeIssue", () => {
     expect(appendToSprintLog).toHaveBeenCalledWith(3, "log entry", undefined, "sprint");
 
     // Final label
-    expect(setLabel).toHaveBeenCalledWith(42, "status:done");
+    expect(setStatusLabel).toHaveBeenCalledWith(42, "status:done");
 
     // Worktree removed
     expect(removeWorktree).toHaveBeenCalledWith("/tmp/worktrees/issue-42");
@@ -287,7 +290,7 @@ describe("executeIssue", () => {
     expect(result.qualityGatePassed).toBe(false);
 
     // Final label should be blocked
-    expect(setLabel).toHaveBeenCalledWith(42, "status:blocked");
+    expect(setStatusLabel).toHaveBeenCalledWith(42, "status:blocked");
   });
 
   it("sends QG retry feedback to same developer session instead of creating new one", async () => {

--- a/tests/ceremonies/parallel-dispatcher.test.ts
+++ b/tests/ceremonies/parallel-dispatcher.test.ts
@@ -53,6 +53,9 @@ vi.mock("node:util", async () => {
 
 vi.mock("../../src/github/labels.js", () => ({
   setLabel: vi.fn().mockResolvedValue(undefined),
+  setStatusLabel: vi.fn().mockResolvedValue(undefined),
+  getLabels: vi.fn().mockResolvedValue([]),
+  removeLabel: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../../src/github/issues.js", () => ({
@@ -87,7 +90,7 @@ import { buildExecutionGroups } from "../../src/ceremonies/dep-graph.js";
 import { executeIssue } from "../../src/ceremonies/execution.js";
 import { hasConflicts, mergeIssuePR } from "../../src/git/merge.js";
 import { createWorktree, removeWorktree } from "../../src/git/worktree.js";
-import { setLabel } from "../../src/github/labels.js";
+import { setStatusLabel } from "../../src/github/labels.js";
 import { addComment } from "../../src/github/issues.js";
 import { escalateToStakeholder } from "../../src/enforcement/escalation.js";
 
@@ -234,7 +237,7 @@ describe("runParallelExecution", () => {
     const failedResult = result.results.find((r) => r.issueNumber === 2);
     expect(failedResult?.status).toBe("failed");
     expect(failedResult?.qualityGatePassed).toBe(false);
-    expect(setLabel).toHaveBeenCalledWith(2, "status:blocked");
+    expect(setStatusLabel).toHaveBeenCalledWith(2, "status:blocked");
   });
 
   it("skips merging when autoMerge is disabled", async () => {
@@ -429,7 +432,7 @@ describe("runParallelExecution", () => {
     const issue1 = result.results.find((r) => r.issueNumber === 1)!;
     expect(issue1.status).toBe("failed");
     expect(issue1.qualityGatePassed).toBe(false);
-    expect(setLabel).toHaveBeenCalledWith(1, "status:blocked");
+    expect(setStatusLabel).toHaveBeenCalledWith(1, "status:blocked");
     expect(addComment).toHaveBeenCalledWith(1, expect.stringContaining("Merge conflicts"));
   });
 
@@ -452,7 +455,7 @@ describe("runParallelExecution", () => {
     const issue1 = result.results.find((r) => r.issueNumber === 1)!;
     expect(issue1.status).toBe("failed");
     expect(issue1.qualityGatePassed).toBe(false);
-    expect(setLabel).toHaveBeenCalledWith(1, "status:blocked");
+    expect(setStatusLabel).toHaveBeenCalledWith(1, "status:blocked");
     expect(addComment).toHaveBeenCalledWith(1, expect.stringContaining("Tests failed"));
   });
 

--- a/tests/ceremonies/planning.test.ts
+++ b/tests/ceremonies/planning.test.ts
@@ -107,6 +107,9 @@ vi.mock("../../src/github/issues.js", () => ({
 }));
 vi.mock("../../src/github/labels.js", () => ({
   setLabel: vi.fn(),
+  setStatusLabel: vi.fn(),
+  getLabels: vi.fn().mockResolvedValue([]),
+  removeLabel: vi.fn(),
 }));
 vi.mock("../../src/github/milestones.js", () => ({
   getMilestone: vi.fn(),
@@ -137,7 +140,7 @@ vi.mock("node:fs/promises", () => ({
 }));
 
 const { listIssues } = await import("../../src/github/issues.js");
-const { setLabel } = await import("../../src/github/labels.js");
+const { setStatusLabel } = await import("../../src/github/labels.js");
 const { getMilestone, createMilestone, setMilestone } =
   await import("../../src/github/milestones.js");
 const { createSprintLog } = await import("../../src/documentation/sprint-log.js");
@@ -232,7 +235,7 @@ describe("runSprintPlanning", () => {
       description: "",
       state: "open",
     });
-    vi.mocked(setLabel).mockResolvedValue(undefined);
+    vi.mocked(setStatusLabel).mockResolvedValue(undefined);
     vi.mocked(setMilestone).mockResolvedValue(undefined);
     vi.mocked(createSprintLog).mockReturnValue("/tmp/log.md");
 
@@ -251,9 +254,9 @@ describe("runSprintPlanning", () => {
     expect(plan.estimated_points).toBe(5);
 
     // Each issue gets label + milestone
-    expect(setLabel).toHaveBeenCalledTimes(2);
-    expect(setLabel).toHaveBeenCalledWith(10, "status:planned");
-    expect(setLabel).toHaveBeenCalledWith(12, "status:planned");
+    expect(setStatusLabel).toHaveBeenCalledTimes(2);
+    expect(setStatusLabel).toHaveBeenCalledWith(10, "status:planned");
+    expect(setStatusLabel).toHaveBeenCalledWith(12, "status:planned");
     expect(setMilestone).toHaveBeenCalledTimes(2);
 
     // Milestone created since it didn't exist
@@ -279,7 +282,7 @@ describe("runSprintPlanning", () => {
       description: "",
       state: "open",
     });
-    vi.mocked(setLabel).mockResolvedValue(undefined);
+    vi.mocked(setStatusLabel).mockResolvedValue(undefined);
     vi.mocked(setMilestone).mockResolvedValue(undefined);
     vi.mocked(createSprintLog).mockReturnValue("/tmp/log.md");
 
@@ -317,7 +320,7 @@ describe("runSprintPlanning", () => {
       description: "",
       state: "open",
     });
-    vi.mocked(setLabel).mockResolvedValue(undefined);
+    vi.mocked(setStatusLabel).mockResolvedValue(undefined);
     vi.mocked(setMilestone).mockResolvedValue(undefined);
     vi.mocked(createSprintLog).mockReturnValue("/tmp/log.md");
 

--- a/tests/github/labels.test.ts
+++ b/tests/github/labels.test.ts
@@ -8,7 +8,13 @@ vi.mock("../../src/logger.js", () => ({
 }));
 
 import { execGh } from "../../src/github/issues.js";
-import { setLabel, removeLabel, getLabels, ensureLabelExists } from "../../src/github/labels.js";
+import {
+  setLabel,
+  removeLabel,
+  getLabels,
+  ensureLabelExists,
+  setStatusLabel,
+} from "../../src/github/labels.js";
 
 const mockExecGh = vi.mocked(execGh);
 
@@ -59,6 +65,50 @@ describe("labels", () => {
       "--description",
       "A label",
       "--force",
+    ]);
+  });
+
+  it("setStatusLabel removes stale status labels before adding new one", async () => {
+    mockExecGh
+      .mockResolvedValueOnce('{"labels": [{"name": "status:planned"}, {"name": "bug"}]}') // getLabels
+      .mockResolvedValueOnce("") // removeLabel status:planned
+      .mockResolvedValueOnce(""); // setLabel status:in-progress
+    await setStatusLabel(42, "status:in-progress");
+    expect(mockExecGh).toHaveBeenCalledWith([
+      "issue",
+      "edit",
+      "42",
+      "--remove-label",
+      "status:planned",
+    ]);
+    expect(mockExecGh).toHaveBeenCalledWith([
+      "issue",
+      "edit",
+      "42",
+      "--add-label",
+      "status:in-progress",
+    ]);
+  });
+
+  it("setStatusLabel does not remove the target label itself", async () => {
+    mockExecGh
+      .mockResolvedValueOnce('{"labels": [{"name": "status:done"}]}') // getLabels
+      .mockResolvedValueOnce(""); // setLabel
+    await setStatusLabel(42, "status:done");
+    expect(mockExecGh).toHaveBeenCalledTimes(2); // getLabels + setLabel only
+  });
+
+  it("setStatusLabel works even when getLabels fails", async () => {
+    mockExecGh
+      .mockRejectedValueOnce(new Error("gh failed")) // getLabels
+      .mockResolvedValueOnce(""); // setLabel
+    await setStatusLabel(42, "status:blocked");
+    expect(mockExecGh).toHaveBeenCalledWith([
+      "issue",
+      "edit",
+      "42",
+      "--add-label",
+      "status:blocked",
     ]);
   });
 });

--- a/tests/types/schemas.test.ts
+++ b/tests/types/schemas.test.ts
@@ -115,6 +115,15 @@ describe("AcceptanceCriteriaSchema", () => {
   it("rejects missing approved", () => {
     expect(() => AcceptanceCriteriaSchema.parse({})).toThrow();
   });
+
+  it("accepts null concern and evidence fields", () => {
+    const result = AcceptanceCriteriaSchema.parse({
+      approved: false,
+      criteria: [{ criterion: "test", passed: false, concern: null, evidence: null }],
+    });
+    expect(result.criteria[0].concern).toBeNull();
+    expect(result.criteria[0].evidence).toBeNull();
+  });
 });
 
 describe("normalizeRetroFields", () => {


### PR DESCRIPTION
Fixes 4 issues discovered from analyzing the test repo sprint run logs:

## Changes

### 1. Duplicate status labels (`setStatusLabel`)
Issues were accumulating multiple `status:*` labels (e.g., planned + in-progress + done + blocked all at once). New `setStatusLabel()` function removes stale status labels before adding the new one. Applied across all label-setting code paths:
- `src/ceremonies/execution.ts` — in-progress + done/blocked
- `src/ceremonies/planning.ts` — planned
- `src/ceremonies/parallel-dispatcher.ts` — blocked
- `src/dashboard/ws-server.ts` — refined/planned (dashboard actions)

### 2. Schema null fields (`.nullish()`)
LLMs return `null` for optional fields, but Zod's `.optional()` only accepts `undefined`. Changed `concern` and `evidence` in `AcceptanceCriteriaSchema` to `.nullish()` to accept both. Eliminates schema validation retries.

### 3. Chat config guard
Added null/invalid `optionId` guard in `handleChatSetConfig`. Prevents 15+ errors per sprint run.

### 4. Zero-change status recovery
When the worker reports 0 local file changes but the PR has actual files (committed directly by the agent), the status is now recovered to `completed` — but only if zero-change was the **sole** failure reason.

## Also fixed in test project (separate commit)
- Installed `@types/node` in `ai-scrum-test-project` — root cause of all 14 post-merge type check failures.

## Tests
- 612 tests pass (4 new: 3 for setStatusLabel, 1 for null concern)
- Type check clean
- Lint clean