### PR TITLE
fix: treat zero-change as completed when planner reports 0 steps

### DIFF
--- a/src/ceremonies/execution.ts
+++ b/src/ceremonies/execution.ts
@@ -50,13 +50,19 @@ interface ExecutionContext {
 // Sub-phase: Plan
 // ---------------------------------------------------------------------------
 
+interface PlanResult {
+  plan: string;
+  stepCount: number;
+}
+
 /** Create ACP session in Plan mode, generate implementation plan, tear down session. */
-async function planPhase(ctx: ExecutionContext): Promise<string> {
+async function planPhase(ctx: ExecutionContext): Promise<PlanResult> {
   const { client, config, issue, eventBus, log, worktreePath, progress } = ctx;
   const plannerConfig = await resolveSessionConfig(config, "planner");
   const promptVars = buildPromptVars(ctx);
 
   let implementationPlan = "";
+  let stepCount = -1; // -1 means unknown (JSON extraction failed)
 
   const { sessionId } = await client.createSession({
     cwd: worktreePath,
@@ -104,6 +110,7 @@ async function planPhase(ctx: ExecutionContext): Promise<string> {
         { summary: planJson.summary, stepCount: planJson.steps?.length ?? 0 },
         "implementation plan created",
       );
+      stepCount = planJson.steps?.length ?? 0;
       // Extract files from the structured plan and merge into expectedFiles.
       // The item planner has read the codebase — its file predictions are more accurate
       // than the sprint planner's guesses.
@@ -142,7 +149,7 @@ async function planPhase(ctx: ExecutionContext): Promise<string> {
     await client.endSession(sessionId);
   }
 
-  return implementationPlan;
+  return { plan: implementationPlan, stepCount };
 }
 
 // ---------------------------------------------------------------------------
@@ -791,7 +798,9 @@ export async function executeIssue(
     log.info({ worktreePath, branch }, "worktree created");
 
     // Step 3: Plan phase (own ACP session as planner)
-    const implementationPlan = await planPhase(ctx);
+    const planResult = await planPhase(ctx);
+    const implementationPlan = planResult.plan;
+    const planStepCount = planResult.stepCount;
 
     // Step 3b: TDD phase (optional — test-engineer writes tests before implementation)
     if (config.enableTdd && implementationPlan) {
@@ -822,20 +831,29 @@ export async function executeIssue(
 
     // Zero-change guard
     if (qualityResult.passed && filesChanged.length === 0) {
-      log.warn({ issue: issue.number }, "Worker produced 0 file changes — treating as failure");
-      status = "failed";
-      qualityResult = {
-        passed: false,
-        checks: [
-          ...qualityResult.checks,
-          {
-            name: "files-changed",
-            passed: false,
-            detail: "Worker produced 0 file changes",
-            category: "other" as const,
-          },
-        ],
-      };
+      if (planStepCount === 0) {
+        // Planner determined work is already done — this is a valid completion
+        log.info(
+          { issue: issue.number },
+          "Planner reported 0 steps — already implemented, marking completed",
+        );
+        status = "completed";
+      } else {
+        log.warn({ issue: issue.number }, "Worker produced 0 file changes — treating as failure");
+        status = "failed";
+        qualityResult = {
+          passed: false,
+          checks: [
+            ...qualityResult.checks,
+            {
+              name: "files-changed",
+              passed: false,
+              detail: "Worker produced 0 file changes",
+              category: "other" as const,
+            },
+          ],
+        };
+      }
     } else {
       status = qualityResult.passed ? "completed" : "failed";
     }

--- a/tests/ceremonies/execution.test.ts
+++ b/tests/ceremonies/execution.test.ts
@@ -384,6 +384,34 @@ describe("executeIssue", () => {
     );
   });
 
+  it("marks as completed when planner reports 0 steps and no file changes", async () => {
+    const mockClient = makeMockClient();
+    vi.mocked(runQualityGate).mockResolvedValue(passingQuality);
+    const { getChangedFiles } = await import("../../src/git/diff-analysis.js");
+    vi.mocked(getChangedFiles).mockResolvedValue([]);
+
+    // Planner returns structured JSON with 0 steps (already implemented)
+    const originalSendPrompt = mockClient.sendPrompt.getMockImplementation()!;
+    let planCallDone = false;
+    mockClient.sendPrompt.mockImplementation((_sid: string, prompt: string) => {
+      if (!planCallDone) {
+        planCallDone = true;
+        return Promise.resolve({
+          response: JSON.stringify({
+            summary: "Already fully implemented",
+            steps: [],
+          }),
+          stopReason: "end_turn",
+        });
+      }
+      return originalSendPrompt(_sid, prompt);
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await executeIssue(mockClient as any, makeConfig(), makeIssue());
+    expect(result.status).toBe("completed");
+  });
+
   it("captures zero-change diagnostic with task-not-applicable outcome when no error", async () => {
     const mockClient = makeMockClient();
     vi.mocked(runQualityGate).mockResolvedValue(passingQuality);


### PR DESCRIPTION
## Problem

When the planner determines an issue is already implemented (e.g., after rebase where changes are already on main), it reports `stepCount: 0`. The developer session runs but produces no changes. The zero-change guard then marks the issue as **failed** even though it's actually **completed**.

This was observed in sprint runs where:
- Issue #1007: Planner said "Graceful shutdown is already fully implemented" → 0 changes → incorrectly failed
- Issue #1009: After rebase conflict + re-execution, changes already on main → 0 changes → incorrectly failed

## Solution

- `planPhase()` now returns `PlanResult { plan, stepCount }` instead of just a string
- Zero-change guard checks `planStepCount`:
  - `stepCount === 0` (planner says already done) + quality passed + 0 changes → **completed**
  - `stepCount === -1` (unknown/parse failure) → preserves existing **failed** behavior
  - `stepCount > 0` (expected changes) → preserves existing **failed** behavior
- Added test for already-implemented completion path

## Testing

- 16 execution tests pass (including new test)
- 613 total tests pass
- Type check clean
- Lint clean