### PR TITLE
fix: coerce file-path retro targets to valid enum values

### DIFF
--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -78,12 +78,6 @@ export function normalizeRetroFields(raw: Record<string, unknown>): Record<strin
 
 function normalizeRetroImprovements(raw: unknown): unknown[] {
   if (!Array.isArray(raw)) return [];
-  const categoryMap: Record<string, string> = {
-    config: "config",
-    agent: "agent",
-    skill: "skill",
-    process: "process",
-  };
   return raw.map((item: Record<string, unknown>) => ({
     title: (item.title as string) || (item.action as string) || (item.problem as string) || "",
     description:
@@ -93,9 +87,21 @@ function normalizeRetroImprovements(raw: unknown): unknown[] {
         .join(" — ") ||
       "",
     autoApplicable: item.autoApplicable !== undefined ? Boolean(item.autoApplicable) : true,
-    target:
-      (item.target as string) || categoryMap[(item.category as string)?.toLowerCase()] || "process",
+    target: coerceRetroTarget((item.target as string) || (item.category as string) || "process"),
   }));
+}
+
+const VALID_RETRO_TARGETS = new Set(["config", "agent", "skill", "process"]);
+
+function coerceRetroTarget(value: string): string {
+  const lower = value.toLowerCase();
+  if (VALID_RETRO_TARGETS.has(lower)) return lower;
+  // LLMs sometimes return file paths — infer category from path
+  if (lower.includes("config") || lower.endsWith(".yaml") || lower.endsWith(".json"))
+    return "config";
+  if (lower.includes("agent") || lower.includes("roles/")) return "agent";
+  if (lower.includes("skill")) return "skill";
+  return "process";
 }
 
 // --- Action Schemas (#421 + #425) ---

--- a/tests/types/schemas.test.ts
+++ b/tests/types/schemas.test.ts
@@ -148,6 +148,23 @@ describe("normalizeRetroFields", () => {
     expect(improvements[0].target).toBe("config");
   });
 
+  it("coerces file-path targets to valid enum values", () => {
+    const result = normalizeRetroFields({
+      improvements: [
+        { title: "Update planner", description: "d", target: ".aiscrum/roles/planner/" },
+        { title: "Fix ceremonies", description: "d", target: "src/ceremonies/" },
+        { title: "Update config", description: "d", target: ".aiscrum/config.yaml" },
+      ],
+    });
+    const improvements = result.improvements as Array<Record<string, unknown>>;
+    expect(improvements[0].target).toBe("agent");
+    expect(improvements[1].target).toBe("process");
+    expect(improvements[2].target).toBe("config");
+    // Verify they pass schema validation
+    const parsed = RetroResultSchema.parse(result);
+    expect(parsed.improvements).toHaveLength(3);
+  });
+
   it("passes through RetroResultSchema", () => {
     const normalized = normalizeRetroFields({
       went_well: ["fast delivery"],


### PR DESCRIPTION
## Problem

The retro ceremony crashes when the LLM returns file paths (e.g. `.aiscrum/roles/planner/`, `src/ceremonies/`, `.aiscrum/config.yaml`) as improvement `target` values instead of the expected enum (`config`/`agent`/`skill`/`process`). This kills the entire sprint after execution completes.

## Solution

Added `coerceRetroTarget()` in the normalizer that infers the correct enum value from file-path patterns before Zod validation:
- `.yaml`/`.json`/`config` paths → `config`
- `roles/` paths → `agent`
- `skill` paths → `skill`
- Everything else → `process`

## Testing
- 614 tests pass, including new test for file-path coercion
- Type check + lint clean