### PR TITLE
fix: retry gh commands on EAGAIN

### DIFF
--- a/src/github/issues.ts
+++ b/src/github/issues.ts
@@ -19,6 +19,7 @@ function isRetryable(error: unknown): boolean {
   if (
     message.includes("ETIMEDOUT") ||
     message.includes("ECONNRESET") ||
+    message.includes("EAGAIN") ||
     message.includes("rate limit") ||
     message.includes("502") ||
     message.includes("503") ||
@@ -26,6 +27,8 @@ function isRetryable(error: unknown): boolean {
   ) {
     return true;
   }
+  // EAGAIN errno code (resource temporarily unavailable)
+  if (errnoCode === "EAGAIN") return true;
   return false;
 }
 


### PR DESCRIPTION
EAGAIN (resource temporarily unavailable) crashes sprint when OS resources are exhausted from concurrent ACP sessions + gh CLI calls. Added EAGAIN to retryable errors list.