### PR TITLE
fix: sequential execute-and-merge to prevent merge conflicts

### DIFF
--- a/src/ceremonies/execution.ts
+++ b/src/ceremonies/execution.ts
@@ -793,8 +793,17 @@ export async function executeIssue(
   let devSessionId: string | undefined;
 
   try {
-    // Step 2: Create worktree
-    await createWorktree({ path: worktreePath, branch, base: config.baseBranch });
+    // Step 2: Fetch latest base branch and create worktree from remote HEAD
+    // This ensures each issue branches from the most recent main (important when
+    // sequential execute-and-merge updates remote main between issues).
+    await execFile("git", ["fetch", "origin", config.baseBranch], {
+      cwd: config.projectPath,
+    });
+    await createWorktree({
+      path: worktreePath,
+      branch,
+      base: `origin/${config.baseBranch}`,
+    });
     log.info({ worktreePath, branch }, "worktree created");
 
     // Step 3: Plan phase (own ACP session as planner)

--- a/src/ceremonies/parallel-dispatcher.ts
+++ b/src/ceremonies/parallel-dispatcher.ts
@@ -120,291 +120,450 @@ export async function runParallelExecution(
   const issueMap = new Map(plan.sprint_issues.map((i) => [i.number, i]));
 
   for (const group of groups) {
-    const concurrency = config.sequentialExecution ? 1 : config.maxParallelSessions;
-    const limit = pLimit(concurrency);
-    log.info({ group: group.group, issues: group.issues, concurrency }, "executing group");
+    log.info({ group: group.group, issues: group.issues }, "executing group");
 
-    const settled = await Promise.allSettled(
-      group.issues.map((issueNumber) =>
-        limit(async () => {
-          const issue = issueMap.get(issueNumber);
-          if (!issue) {
-            throw new Error(`Issue #${issueNumber} not found in sprint plan`);
-          }
-          return executeIssue(client, config, issue, eventBus);
-        }),
-      ),
-    );
+    if (config.sequentialExecution && config.autoMerge) {
+      // Sequential execute-and-merge: each issue merges before the next executes,
+      // so each subsequent issue branches from the latest main (no merge conflicts).
+      let haltMerges = false;
 
-    for (let i = 0; i < settled.length; i++) {
-      const outcome = settled[i];
-      if (outcome.status === "fulfilled") {
-        const result = outcome.value;
+      for (const issueNumber of group.issues) {
+        const issue = issueMap.get(issueNumber);
+        if (!issue) {
+          log.error({ issueNumber }, "issue not found in sprint plan");
+          allResults.push({
+            issueNumber,
+            status: "failed",
+            qualityGatePassed: false,
+            qualityDetails: { passed: false, checks: [] },
+            branch: config.branchPattern
+              .replace("{prefix}", config.sprintSlug)
+              .replace("{sprint}", String(config.sprintNumber))
+              .replace("{issue}", String(issueNumber)),
+            duration_ms: 0,
+            filesChanged: [],
+            retryCount: 0,
+            points: 0,
+          });
+          continue;
+        }
+
+        let result: IssueResult;
+        try {
+          result = await executeIssue(client, config, issue, eventBus);
+        } catch (err: unknown) {
+          log.error({ issueNumber, err }, "issue execution rejected");
+          allResults.push({
+            issueNumber,
+            status: "failed",
+            qualityGatePassed: false,
+            qualityDetails: { passed: false, checks: [] },
+            branch: config.branchPattern
+              .replace("{prefix}", config.sprintSlug)
+              .replace("{sprint}", String(config.sprintNumber))
+              .replace("{issue}", String(issueNumber)),
+            duration_ms: 0,
+            filesChanged: [],
+            retryCount: 0,
+            points: issue.points,
+          });
+          continue;
+        }
+
         allResults.push(result);
 
-        // Merge successful branches back to base via GitHub PR
-        if (config.autoMerge && result.status === "completed") {
-          // Rebase branch on latest main before pre-merge (main may have changed from earlier merges)
-          // Use a temporary worktree to avoid "unstaged changes" errors in the main repo
-          let rebaseSucceeded = true;
-          const rebaseTmpDir = path.join(
-            os.tmpdir(),
-            `rebase-${result.branch.replace(/\//g, "-")}-${Date.now()}`,
-          );
-          try {
-            await execFile("git", ["fetch", "origin", config.baseBranch], {
-              cwd: config.projectPath,
-            });
-            await createWorktree({
-              path: rebaseTmpDir,
-              branch: `rebase-tmp-${Date.now()}`,
-              base: result.branch,
-            });
-            await execFile("git", ["rebase", `origin/${config.baseBranch}`], { cwd: rebaseTmpDir });
-            await execFile(
-              "git",
-              ["push", "origin", `HEAD:${result.branch}`, "--force-with-lease"],
-              { cwd: rebaseTmpDir },
-            );
-          } catch (rebaseErr) {
-            rebaseSucceeded = false;
-            // Rebase failed (conflicts) — abort and let pre-merge catch it
-            try {
-              await execFile("git", ["rebase", "--abort"], { cwd: rebaseTmpDir });
-            } catch {
-              /* ignore */
-            }
-            appendErrorLog("warn", `rebase on latest main failed — issue #${result.issueNumber}`, {
-              issue: result.issueNumber,
-              err: String(rebaseErr),
-            });
-            log.warn(
-              { issue: result.issueNumber, err: String(rebaseErr) },
-              "rebase on latest main failed — proceeding to pre-merge",
-            );
-          } finally {
-            try {
-              await removeWorktree(rebaseTmpDir);
-            } catch {
-              /* ignore */
-            }
-          }
+        if (result.status !== "completed" || haltMerges) {
+          continue;
+        }
 
-          // Pre-merge verification: test feature branch with main merged in
-          const premerge = await runPreMergeVerification(result.branch, config);
-          if (!premerge.passed) {
-            // On rebase conflict, re-execute issue from latest main (counts as retry)
-            if (!rebaseSucceeded && config.maxRetries > 0) {
-              const issue = issueMap.get(result.issueNumber);
-              if (issue) {
-                log.info(
-                  { issue: result.issueNumber },
-                  "rebase conflict — re-executing issue from latest main",
-                );
-                await addComment(
-                  result.issueNumber,
-                  "⚠️ Merge conflict detected. Re-executing from latest main...",
-                ).catch(() => {});
-                try {
-                  await execFile("git", ["push", "origin", "--delete", result.branch], {
-                    cwd: config.projectPath,
-                  });
-                } catch {
-                  /* may not exist */
-                }
-                try {
-                  await execFile("git", ["branch", "-D", result.branch], {
-                    cwd: config.projectPath,
-                  });
-                } catch {
-                  /* ignore */
-                }
-                const retryResult = await executeIssue(client, config, issue, eventBus);
-                allResults[allResults.length - 1] = retryResult;
-                if (retryResult.status === "completed") {
-                  const retryPremerge = await runPreMergeVerification(retryResult.branch, config);
-                  if (retryPremerge.passed) {
-                    try {
-                      const retryMerge = await mergeIssuePR(retryResult.branch, {
-                        squash: config.squashMerge,
-                        deleteBranch: config.deleteBranchAfterMerge,
-                      });
-                      if (retryMerge.success) {
-                        log.info(
-                          { issue: retryResult.issueNumber, pr: retryMerge.prNumber },
-                          "PR merged after conflict retry",
-                        );
-                        try {
-                          const gateConfig = buildQualityGateConfig(config);
-                          const verifyResult = await verifyMainBranch(
-                            config.projectPath,
-                            gateConfig,
-                          );
-                          if (!verifyResult.passed) {
-                            const failedChecks = verifyResult.checks
-                              .filter((c) => !c.passed)
-                              .map((c) => c.name)
-                              .join(", ");
-                            log.error(
-                              { issue: retryResult.issueNumber, failedChecks },
-                              "post-merge verification FAILED on main",
-                            );
-                            await escalateToStakeholder(
-                              {
-                                level: "must",
-                                reason: `Post-merge verification failed after merging #${retryResult.issueNumber}`,
-                                detail: `Failed checks: ${failedChecks}. Main branch may be broken.`,
-                                context: {
-                                  issueNumber: retryResult.issueNumber,
-                                  branch: retryResult.branch,
-                                },
-                                timestamp: new Date(),
-                              },
-                              {
-                                ntfyEnabled: !!config.ntfy?.enabled,
-                                ntfyTopic: config.ntfy?.topic,
-                              },
-                              eventBus,
-                            );
-                          }
-                        } catch (verifyErr: unknown) {
-                          appendErrorLog(
-                            "error",
-                            `post-merge verification failed (retry) — issue #${retryResult.issueNumber}`,
-                            { issue: retryResult.issueNumber, err: String(verifyErr) },
-                          );
-                          log.error(
-                            { err: verifyErr, issue: retryResult.issueNumber },
-                            "post-merge verification could not run",
-                          );
-                        }
-                        continue;
-                      }
-                    } catch {
-                      /* fall through to mark failed */
-                    }
-                  }
-                }
-                // Retry didn't resolve the conflict
-                retryResult.status = "failed";
-                retryResult.qualityGatePassed = false;
-                await setStatusLabel(retryResult.issueNumber, "status:blocked");
-                await addComment(
-                  retryResult.issueNumber,
-                  "**Block reason:** Pre-merge verification failed after conflict retry",
-                ).catch(() => {});
-                continue;
-              }
-            }
+        // No rebase needed — branch is already based on latest main
+        const premerge = await runPreMergeVerification(result.branch, config);
+        if (!premerge.passed) {
+          log.warn(
+            { issue: result.issueNumber, reason: premerge.reason },
+            "pre-merge verification failed",
+          );
+          result.status = "failed";
+          result.qualityGatePassed = false;
+          await setStatusLabel(result.issueNumber, "status:blocked");
+          await addComment(
+            result.issueNumber,
+            `**Block reason:** Pre-merge verification failed — ${premerge.reason ?? "unknown"}`,
+          ).catch((err) => log.warn({ err: String(err) }, "failed to post block comment"));
+          continue;
+        }
+
+        try {
+          const mergeResult = await mergeIssuePR(result.branch, {
+            squash: config.squashMerge,
+            deleteBranch: config.deleteBranchAfterMerge,
+          });
+
+          if (!mergeResult.success) {
+            mergeConflicts++;
             log.warn(
-              { issue: result.issueNumber, reason: premerge.reason },
-              "pre-merge verification failed",
+              { issue: result.issueNumber, branch: result.branch, reason: mergeResult.reason },
+              "PR merge failed — marking as failed",
             );
             result.status = "failed";
             result.qualityGatePassed = false;
             await setStatusLabel(result.issueNumber, "status:blocked");
             await addComment(
               result.issueNumber,
-              `**Block reason:** Pre-merge verification failed — ${premerge.reason ?? "unknown"}`,
-            ).catch((err) => log.warn({ err: String(err) }, "failed to post block comment"));
-            continue;
-          }
-          try {
-            const mergeResult = await mergeIssuePR(result.branch, {
-              squash: config.squashMerge,
-              deleteBranch: config.deleteBranchAfterMerge,
-            });
-
-            if (!mergeResult.success) {
-              mergeConflicts++;
+              `**Block reason:** PR merge failed — ${mergeResult.reason ?? "unknown"}`,
+            ).catch((err) =>
               log.warn(
-                { issue: result.issueNumber, branch: result.branch, reason: mergeResult.reason },
-                "PR merge failed — marking as failed",
+                { err: String(err), issue: result.issueNumber },
+                "failed to post block reason comment",
+              ),
+            );
+          } else {
+            log.info(
+              { issue: result.issueNumber, branch: result.branch, pr: mergeResult.prNumber },
+              "PR merged",
+            );
+
+            // Post-merge verification
+            try {
+              const gateConfig = buildQualityGateConfig(config);
+              const verifyResult = await verifyMainBranch(config.projectPath, gateConfig);
+              if (!verifyResult.passed) {
+                const failedChecks = verifyResult.checks
+                  .filter((c) => !c.passed)
+                  .map((c) => c.name)
+                  .join(", ");
+                log.error(
+                  { issue: result.issueNumber, failedChecks },
+                  "post-merge verification FAILED on main",
+                );
+                await escalateToStakeholder(
+                  {
+                    level: "must",
+                    reason: `Post-merge verification failed after merging #${result.issueNumber}`,
+                    detail: `Failed checks: ${failedChecks}. Main branch may be broken.`,
+                    context: { issueNumber: result.issueNumber, branch: result.branch },
+                    timestamp: new Date(),
+                  },
+                  { ntfyEnabled: !!config.ntfy?.enabled, ntfyTopic: config.ntfy?.topic },
+                  eventBus,
+                );
+              }
+            } catch (verifyErr: unknown) {
+              appendErrorLog(
+                "error",
+                `post-merge verification FAILED — issue #${result.issueNumber}, halting merges`,
+                { issue: result.issueNumber, err: String(verifyErr) },
+              );
+              log.error(
+                { err: verifyErr, issue: result.issueNumber },
+                "post-merge verification could not run — halting further merges",
+              );
+              haltMerges = true;
+            }
+          }
+        } catch (err: unknown) {
+          mergeConflicts++;
+          appendErrorLog("error", `merge error — issue #${result.issueNumber}`, {
+            issue: result.issueNumber,
+            err: String(err),
+          });
+          log.error({ issue: result.issueNumber, err }, "merge error");
+          result.status = "failed";
+          result.qualityGatePassed = false;
+        }
+      }
+    } else {
+      // Parallel execution: run all issues concurrently, then merge sequentially
+      const concurrency = config.maxParallelSessions;
+      const limit = pLimit(concurrency);
+
+      const settled = await Promise.allSettled(
+        group.issues.map((issueNumber) =>
+          limit(async () => {
+            const issue = issueMap.get(issueNumber);
+            if (!issue) {
+              throw new Error(`Issue #${issueNumber} not found in sprint plan`);
+            }
+            return executeIssue(client, config, issue, eventBus);
+          }),
+        ),
+      );
+
+      for (let i = 0; i < settled.length; i++) {
+        const outcome = settled[i];
+        if (outcome.status === "fulfilled") {
+          const result = outcome.value;
+          allResults.push(result);
+
+          // Merge successful branches back to base via GitHub PR
+          if (config.autoMerge && result.status === "completed") {
+            // Rebase branch on latest main before pre-merge (main may have changed from earlier merges)
+            let rebaseSucceeded = true;
+            const rebaseTmpDir = path.join(
+              os.tmpdir(),
+              `rebase-${result.branch.replace(/\//g, "-")}-${Date.now()}`,
+            );
+            try {
+              await execFile("git", ["fetch", "origin", config.baseBranch], {
+                cwd: config.projectPath,
+              });
+              await createWorktree({
+                path: rebaseTmpDir,
+                branch: `rebase-tmp-${Date.now()}`,
+                base: result.branch,
+              });
+              await execFile("git", ["rebase", `origin/${config.baseBranch}`], {
+                cwd: rebaseTmpDir,
+              });
+              await execFile(
+                "git",
+                ["push", "origin", `HEAD:${result.branch}`, "--force-with-lease"],
+                { cwd: rebaseTmpDir },
+              );
+            } catch (rebaseErr) {
+              rebaseSucceeded = false;
+              try {
+                await execFile("git", ["rebase", "--abort"], { cwd: rebaseTmpDir });
+              } catch {
+                /* ignore */
+              }
+              appendErrorLog(
+                "warn",
+                `rebase on latest main failed — issue #${result.issueNumber}`,
+                { issue: result.issueNumber, err: String(rebaseErr) },
+              );
+              log.warn(
+                { issue: result.issueNumber, err: String(rebaseErr) },
+                "rebase on latest main failed — proceeding to pre-merge",
+              );
+            } finally {
+              try {
+                await removeWorktree(rebaseTmpDir);
+              } catch {
+                /* ignore */
+              }
+            }
+
+            // Pre-merge verification: test feature branch with main merged in
+            const premerge = await runPreMergeVerification(result.branch, config);
+            if (!premerge.passed) {
+              // On rebase conflict, re-execute issue from latest main (counts as retry)
+              if (!rebaseSucceeded && config.maxRetries > 0) {
+                const issue = issueMap.get(result.issueNumber);
+                if (issue) {
+                  log.info(
+                    { issue: result.issueNumber },
+                    "rebase conflict — re-executing issue from latest main",
+                  );
+                  await addComment(
+                    result.issueNumber,
+                    "⚠️ Merge conflict detected. Re-executing from latest main...",
+                  ).catch(() => {});
+                  try {
+                    await execFile("git", ["push", "origin", "--delete", result.branch], {
+                      cwd: config.projectPath,
+                    });
+                  } catch {
+                    /* may not exist */
+                  }
+                  try {
+                    await execFile("git", ["branch", "-D", result.branch], {
+                      cwd: config.projectPath,
+                    });
+                  } catch {
+                    /* ignore */
+                  }
+                  const retryResult = await executeIssue(client, config, issue, eventBus);
+                  allResults[allResults.length - 1] = retryResult;
+                  if (retryResult.status === "completed") {
+                    const retryPremerge = await runPreMergeVerification(retryResult.branch, config);
+                    if (retryPremerge.passed) {
+                      try {
+                        const retryMerge = await mergeIssuePR(retryResult.branch, {
+                          squash: config.squashMerge,
+                          deleteBranch: config.deleteBranchAfterMerge,
+                        });
+                        if (retryMerge.success) {
+                          log.info(
+                            { issue: retryResult.issueNumber, pr: retryMerge.prNumber },
+                            "PR merged after conflict retry",
+                          );
+                          try {
+                            const gateConfig = buildQualityGateConfig(config);
+                            const verifyResult = await verifyMainBranch(
+                              config.projectPath,
+                              gateConfig,
+                            );
+                            if (!verifyResult.passed) {
+                              const failedChecks = verifyResult.checks
+                                .filter((c) => !c.passed)
+                                .map((c) => c.name)
+                                .join(", ");
+                              log.error(
+                                { issue: retryResult.issueNumber, failedChecks },
+                                "post-merge verification FAILED on main",
+                              );
+                              await escalateToStakeholder(
+                                {
+                                  level: "must",
+                                  reason: `Post-merge verification failed after merging #${retryResult.issueNumber}`,
+                                  detail: `Failed checks: ${failedChecks}. Main branch may be broken.`,
+                                  context: {
+                                    issueNumber: retryResult.issueNumber,
+                                    branch: retryResult.branch,
+                                  },
+                                  timestamp: new Date(),
+                                },
+                                {
+                                  ntfyEnabled: !!config.ntfy?.enabled,
+                                  ntfyTopic: config.ntfy?.topic,
+                                },
+                                eventBus,
+                              );
+                            }
+                          } catch (verifyErr: unknown) {
+                            appendErrorLog(
+                              "error",
+                              `post-merge verification failed (retry) — issue #${retryResult.issueNumber}`,
+                              { issue: retryResult.issueNumber, err: String(verifyErr) },
+                            );
+                            log.error(
+                              { err: verifyErr, issue: retryResult.issueNumber },
+                              "post-merge verification could not run",
+                            );
+                          }
+                          continue;
+                        }
+                      } catch {
+                        /* fall through to mark failed */
+                      }
+                    }
+                  }
+                  // Retry didn't resolve the conflict
+                  retryResult.status = "failed";
+                  retryResult.qualityGatePassed = false;
+                  await setStatusLabel(retryResult.issueNumber, "status:blocked");
+                  await addComment(
+                    retryResult.issueNumber,
+                    "**Block reason:** Pre-merge verification failed after conflict retry",
+                  ).catch(() => {});
+                  continue;
+                }
+              }
+              log.warn(
+                { issue: result.issueNumber, reason: premerge.reason },
+                "pre-merge verification failed",
               );
               result.status = "failed";
               result.qualityGatePassed = false;
               await setStatusLabel(result.issueNumber, "status:blocked");
               await addComment(
                 result.issueNumber,
-                `**Block reason:** PR merge failed — ${mergeResult.reason ?? "unknown"}`,
-              ).catch((err) =>
-                log.warn(
-                  { err: String(err), issue: result.issueNumber },
-                  "failed to post block reason comment",
-                ),
-              );
-            } else {
-              log.info(
-                { issue: result.issueNumber, branch: result.branch, pr: mergeResult.prNumber },
-                "PR merged",
-              );
-
-              // Post-merge verification: run tests + types on main to catch combinatorial breakage
-              try {
-                const gateConfig = buildQualityGateConfig(config);
-                const verifyResult = await verifyMainBranch(config.projectPath, gateConfig);
-                if (!verifyResult.passed) {
-                  const failedChecks = verifyResult.checks
-                    .filter((c) => !c.passed)
-                    .map((c) => c.name)
-                    .join(", ");
-                  log.error(
-                    { issue: result.issueNumber, failedChecks },
-                    "post-merge verification FAILED on main",
-                  );
-                  await escalateToStakeholder(
-                    {
-                      level: "must",
-                      reason: `Post-merge verification failed after merging #${result.issueNumber}`,
-                      detail: `Failed checks: ${failedChecks}. Main branch may be broken.`,
-                      context: { issueNumber: result.issueNumber, branch: result.branch },
-                      timestamp: new Date(),
-                    },
-                    { ntfyEnabled: !!config.ntfy?.enabled, ntfyTopic: config.ntfy?.topic },
-                    eventBus,
-                  );
-                }
-              } catch (verifyErr: unknown) {
-                appendErrorLog(
-                  "error",
-                  `post-merge verification FAILED — issue #${result.issueNumber}, halting merges`,
-                  { issue: result.issueNumber, err: String(verifyErr) },
-                );
-                log.error(
-                  { err: verifyErr, issue: result.issueNumber },
-                  "post-merge verification could not run — halting further merges",
-                );
-                break;
-              }
+                `**Block reason:** Pre-merge verification failed — ${premerge.reason ?? "unknown"}`,
+              ).catch((err) => log.warn({ err: String(err) }, "failed to post block comment"));
+              continue;
             }
-          } catch (err: unknown) {
-            mergeConflicts++;
-            appendErrorLog("error", `merge error — issue #${result.issueNumber}`, {
-              issue: result.issueNumber,
-              err: String(err),
-            });
-            log.error({ issue: result.issueNumber, err }, "merge error");
-            result.status = "failed";
-            result.qualityGatePassed = false;
+            try {
+              const mergeResult = await mergeIssuePR(result.branch, {
+                squash: config.squashMerge,
+                deleteBranch: config.deleteBranchAfterMerge,
+              });
+
+              if (!mergeResult.success) {
+                mergeConflicts++;
+                log.warn(
+                  {
+                    issue: result.issueNumber,
+                    branch: result.branch,
+                    reason: mergeResult.reason,
+                  },
+                  "PR merge failed — marking as failed",
+                );
+                result.status = "failed";
+                result.qualityGatePassed = false;
+                await setStatusLabel(result.issueNumber, "status:blocked");
+                await addComment(
+                  result.issueNumber,
+                  `**Block reason:** PR merge failed — ${mergeResult.reason ?? "unknown"}`,
+                ).catch((err) =>
+                  log.warn(
+                    { err: String(err), issue: result.issueNumber },
+                    "failed to post block reason comment",
+                  ),
+                );
+              } else {
+                log.info(
+                  { issue: result.issueNumber, branch: result.branch, pr: mergeResult.prNumber },
+                  "PR merged",
+                );
+
+                // Post-merge verification
+                try {
+                  const gateConfig = buildQualityGateConfig(config);
+                  const verifyResult = await verifyMainBranch(config.projectPath, gateConfig);
+                  if (!verifyResult.passed) {
+                    const failedChecks = verifyResult.checks
+                      .filter((c) => !c.passed)
+                      .map((c) => c.name)
+                      .join(", ");
+                    log.error(
+                      { issue: result.issueNumber, failedChecks },
+                      "post-merge verification FAILED on main",
+                    );
+                    await escalateToStakeholder(
+                      {
+                        level: "must",
+                        reason: `Post-merge verification failed after merging #${result.issueNumber}`,
+                        detail: `Failed checks: ${failedChecks}. Main branch may be broken.`,
+                        context: { issueNumber: result.issueNumber, branch: result.branch },
+                        timestamp: new Date(),
+                      },
+                      { ntfyEnabled: !!config.ntfy?.enabled, ntfyTopic: config.ntfy?.topic },
+                      eventBus,
+                    );
+                  }
+                } catch (verifyErr: unknown) {
+                  appendErrorLog(
+                    "error",
+                    `post-merge verification FAILED — issue #${result.issueNumber}, halting merges`,
+                    { issue: result.issueNumber, err: String(verifyErr) },
+                  );
+                  log.error(
+                    { err: verifyErr, issue: result.issueNumber },
+                    "post-merge verification could not run — halting further merges",
+                  );
+                  break;
+                }
+              }
+            } catch (err: unknown) {
+              mergeConflicts++;
+              appendErrorLog("error", `merge error — issue #${result.issueNumber}`, {
+                issue: result.issueNumber,
+                err: String(err),
+              });
+              log.error({ issue: result.issueNumber, err }, "merge error");
+              result.status = "failed";
+              result.qualityGatePassed = false;
+            }
           }
+        } else {
+          const issueNumber = group.issues[i];
+          log.error({ issueNumber, err: outcome.reason }, "issue execution rejected");
+          allResults.push({
+            issueNumber,
+            status: "failed",
+            qualityGatePassed: false,
+            qualityDetails: { passed: false, checks: [] },
+            branch: config.branchPattern
+              .replace("{prefix}", config.sprintSlug)
+              .replace("{sprint}", String(config.sprintNumber))
+              .replace("{issue}", String(issueNumber)),
+            duration_ms: 0,
+            filesChanged: [],
+            retryCount: 0,
+            points: issueMap.get(issueNumber)?.points ?? 0,
+          });
         }
-      } else {
-        const issueNumber = group.issues[i];
-        log.error({ issueNumber, err: outcome.reason }, "issue execution rejected");
-        allResults.push({
-          issueNumber,
-          status: "failed",
-          qualityGatePassed: false,
-          qualityDetails: { passed: false, checks: [] },
-          branch: config.branchPattern
-            .replace("{prefix}", config.sprintSlug)
-            .replace("{sprint}", String(config.sprintNumber))
-            .replace("{issue}", String(issueNumber)),
-          duration_ms: 0,
-          filesChanged: [],
-          retryCount: 0,
-          points: issueMap.get(issueNumber)?.points ?? 0,
-        });
       }
     }
 

--- a/tests/ceremonies/execution.test.ts
+++ b/tests/ceremonies/execution.test.ts
@@ -238,7 +238,7 @@ describe("executeIssue", () => {
     expect(createWorktree).toHaveBeenCalledWith({
       path: "/tmp/worktrees/issue-42",
       branch: "sprint/3/issue-42",
-      base: "main",
+      base: "origin/main",
     });
 
     // ACP session created in worktree directory

--- a/tests/ceremonies/parallel-dispatcher.test.ts
+++ b/tests/ceremonies/parallel-dispatcher.test.ts
@@ -136,6 +136,7 @@ function makeConfig(overrides: Partial<SprintConfig> = {}): SprintConfig {
     maxDriftIncidents: 2,
     maxRetries: 1,
     enableChallenger: false,
+    sequentialExecution: false,
     autoRevertDrift: false,
     backlogLabels: [],
     autoMerge: true,
@@ -495,6 +496,77 @@ describe("runParallelExecution", () => {
     expect(removeWorktree).toHaveBeenCalled();
     const issue1 = result.results.find((r) => r.issueNumber === 1)!;
     expect(issue1.status).toBe("completed");
+  });
+
+  // --- Sequential execute-and-merge tests ---
+
+  it("merges each issue before executing the next in sequential mode", async () => {
+    const issues = [makeIssue(1), makeIssue(2)];
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1, 2] }]);
+
+    const executionOrder: string[] = [];
+    vi.mocked(executeIssue).mockImplementation(async (_c, _cfg, issue) => {
+      executionOrder.push(`execute-${issue.number}`);
+      return makeResult(issue.number);
+    });
+    vi.mocked(mergeIssuePR).mockImplementation(async () => {
+      executionOrder.push("merge");
+      return { success: true };
+    });
+
+    await runParallelExecution(
+      mockClient,
+      makeConfig({ sequentialExecution: true, autoMerge: true }),
+      makePlan(issues),
+    );
+
+    // In sequential mode: execute #1 → merge → execute #2 → merge
+    expect(executionOrder).toEqual(["execute-1", "merge", "execute-2", "merge"]);
+    expect(executeIssue).toHaveBeenCalledTimes(2);
+    expect(mergeIssuePR).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips rebase in sequential mode (no worktree for rebase)", async () => {
+    const issues = [makeIssue(1)];
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1] }]);
+    vi.mocked(executeIssue).mockResolvedValueOnce(makeResult(1));
+    vi.mocked(mergeIssuePR).mockResolvedValue({ success: true });
+
+    const worktreeCallsBefore = vi.mocked(createWorktree).mock.calls.length;
+
+    await runParallelExecution(
+      mockClient,
+      makeConfig({ sequentialExecution: true, autoMerge: true }),
+      makePlan(issues),
+    );
+
+    // In sequential mode, createWorktree is called for pre-merge verification only (no rebase worktree)
+    const worktreeCallsAfter = vi.mocked(createWorktree).mock.calls.length;
+    const newCalls = worktreeCallsAfter - worktreeCallsBefore;
+    // Pre-merge verification creates 1 worktree; rebase would add another
+    expect(newCalls).toBe(1);
+    expect(mergeIssuePR).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles execution failure in sequential mode", async () => {
+    const issues = [makeIssue(1), makeIssue(2)];
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1, 2] }]);
+    vi.mocked(executeIssue)
+      .mockRejectedValueOnce(new Error("session crashed"))
+      .mockResolvedValueOnce(makeResult(2));
+    vi.mocked(mergeIssuePR).mockResolvedValue({ success: true });
+
+    const result = await runParallelExecution(
+      mockClient,
+      makeConfig({ sequentialExecution: true, autoMerge: true }),
+      makePlan(issues),
+    );
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]!.status).toBe("failed");
+    expect(result.results[1]!.status).toBe("completed");
+    // Issue 2 should still execute and merge even though issue 1 failed
+    expect(mergeIssuePR).toHaveBeenCalledTimes(1);
   });
 
   it("cleans up worktree even when pre-merge verification fails", async () => {


### PR DESCRIPTION
## Problem

When `sequentialExecution` is true (the default), all issues in a sprint group executed BEFORE any merging started. This caused recurring merge conflicts:

1. Issue #1 executes (from main at commit A)
2. Issue #2 executes (also from main at A — no merge happened yet)
3. Merge loop: #1 merges → main becomes B
4. Merge loop: #2 tries to merge → **conflict** because it branched from stale A

## Solution

Two changes:

### 1. Sequential execute-and-merge (parallel-dispatcher.ts)

When `sequentialExecution && autoMerge`, each issue now executes and merges before the next one starts:

```
Execute #1 → pre-merge verify → merge PR → (main updated)
Execute #2 → pre-merge verify → merge PR → (main updated)  
```

No rebase step needed since each issue branches from the latest main. The parallel path (non-default) retains the existing rebase + conflict retry flow unchanged.

### 2. Fetch remote HEAD before worktree creation (execution.ts)

`executeIssue` now fetches `origin/baseBranch` and uses `origin/main` as the worktree base. This ensures each issue starts from the remote HEAD, not a potentially stale local ref.

## Tests

- 3 new tests for sequential execute-and-merge behavior
- 17 existing dispatcher tests pass (all use parallel path)
- 617 total tests pass
- Type check clean, lint clean