### PR TITLE
fix: handle empty sprint plan gracefully

### DIFF
--- a/src/ceremonies/planning.ts
+++ b/src/ceremonies/planning.ts
@@ -90,6 +90,16 @@ export async function runSprintPlanning(
       throw lastError;
     }
 
+    // Handle empty plan — planner found no actionable issues
+    if (plan.sprint_issues.length === 0) {
+      log.info("Planner returned 0 issues — no actionable backlog items for this sprint");
+      eventBus?.emitTyped("log", {
+        level: "info",
+        message: "No actionable backlog issues found — sprint will be skipped",
+      });
+      return plan;
+    }
+
     // Enforce max_issues — LLM may return more than requested
     if (plan.sprint_issues.length > config.maxIssuesPerSprint) {
       log.warn(

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -229,6 +229,12 @@ function registerFullCycle(program: Command): void {
             `  Planned ${plan.sprint_issues.length} issues (${plan.estimated_points} points)`,
           );
 
+          // Handle empty plan — no actionable issues
+          if (plan.sprint_issues.length === 0) {
+            console.log("\n⏭️  No actionable issues found — skipping sprint.");
+            return;
+          }
+
           // Step 2: Execute all issues (with parallel dispatch, merge, pre-merge verification)
           console.log("\n🔄 Phase 2/4: Execution...");
           const sprintResult = await runParallelExecution(client, sprintConfig, plan);

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -22,7 +22,7 @@ export const SprintPlanSchema = z.object({
           .transform((v) => v ?? 0),
       }),
     )
-    .min(1),
+    .min(0),
   execution_groups: z.array(z.array(z.coerce.number())).optional(),
   estimated_points: z
     .number()

--- a/tests/types/schemas.test.ts
+++ b/tests/types/schemas.test.ts
@@ -6,6 +6,7 @@ import {
   AcceptanceCriteriaSchema,
   RetroResultSchema,
   ReviewResultSchema,
+  SprintPlanSchema,
   normalizeRetroFields,
 } from "../../src/types/schemas.js";
 
@@ -190,5 +191,27 @@ describe("ReviewResultSchema", () => {
     expect(result.summary).toBe("No summary provided");
     expect(result.demoItems).toEqual([]);
     expect(result.openItems).toEqual([]);
+  });
+});
+
+describe("SprintPlanSchema", () => {
+  it("accepts an empty sprint_issues array", () => {
+    const result = SprintPlanSchema.parse({
+      sprintNumber: 2,
+      sprint_issues: [],
+      rationale: "No actionable issues in backlog",
+    });
+    expect(result.sprint_issues).toEqual([]);
+    expect(result.sprintNumber).toBe(2);
+  });
+
+  it("accepts a plan with issues", () => {
+    const result = SprintPlanSchema.parse({
+      sprintNumber: 1,
+      sprint_issues: [{ number: 42, title: "Test", ice_score: 5, points: 2 }],
+      rationale: "test",
+    });
+    expect(result.sprint_issues).toHaveLength(1);
+    expect(result.sprint_issues[0]!.number).toBe(42);
   });
 });


### PR DESCRIPTION
Planner may return 0 issues when no actionable backlog items exist. Previously crashed with ZodError. Now returns early with clear message.