### PR TITLE
fix: skip merge for zero-change completed issues

### DIFF
--- a/src/ceremonies/parallel-dispatcher.ts
+++ b/src/ceremonies/parallel-dispatcher.ts
@@ -176,6 +176,15 @@ export async function runParallelExecution(
           continue;
         }
 
+        // Skip merge for zero-change issues (already implemented — no PR to merge)
+        if (result.filesChanged.length === 0) {
+          log.info(
+            { issue: result.issueNumber },
+            "zero-change issue — skipping merge (already implemented)",
+          );
+          continue;
+        }
+
         // No rebase needed — branch is already based on latest main
         const premerge = await runPreMergeVerification(result.branch, config);
         if (!premerge.passed) {
@@ -297,6 +306,14 @@ export async function runParallelExecution(
 
           // Merge successful branches back to base via GitHub PR
           if (config.autoMerge && result.status === "completed") {
+            // Skip merge for zero-change issues (already implemented — no PR to merge)
+            if (result.filesChanged.length === 0) {
+              log.info(
+                { issue: result.issueNumber },
+                "zero-change issue — skipping merge (already implemented)",
+              );
+              continue;
+            }
             // Rebase branch on latest main before pre-merge (main may have changed from earlier merges)
             let rebaseSucceeded = true;
             const rebaseTmpDir = path.join(

--- a/tests/ceremonies/parallel-dispatcher.test.ts
+++ b/tests/ceremonies/parallel-dispatcher.test.ts
@@ -569,6 +569,42 @@ describe("runParallelExecution", () => {
     expect(mergeIssuePR).toHaveBeenCalledTimes(1);
   });
 
+  it("skips merge for zero-change completed issues", async () => {
+    const issues = [makeIssue(1)];
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1] }]);
+    vi.mocked(executeIssue).mockResolvedValueOnce({
+      ...makeResult(1),
+      filesChanged: [], // zero changes — already implemented
+    });
+
+    const result = await runParallelExecution(mockClient, makeConfig(), makePlan(issues));
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]!.status).toBe("completed");
+    // Should NOT attempt merge for zero-change issues
+    expect(mergeIssuePR).not.toHaveBeenCalled();
+    expect(hasConflicts).not.toHaveBeenCalled();
+  });
+
+  it("skips merge for zero-change issues in sequential mode", async () => {
+    const issues = [makeIssue(1), makeIssue(2)];
+    vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1, 2] }]);
+    vi.mocked(executeIssue)
+      .mockResolvedValueOnce({ ...makeResult(1), filesChanged: [] }) // zero changes
+      .mockResolvedValueOnce(makeResult(2)); // has changes
+    vi.mocked(mergeIssuePR).mockResolvedValue({ success: true });
+
+    const result = await runParallelExecution(
+      mockClient,
+      makeConfig({ sequentialExecution: true, autoMerge: true }),
+      makePlan(issues),
+    );
+
+    expect(result.results).toHaveLength(2);
+    // Only issue 2 should be merged (issue 1 has zero changes)
+    expect(mergeIssuePR).toHaveBeenCalledTimes(1);
+  });
+
   it("cleans up worktree even when pre-merge verification fails", async () => {
     const issues = [makeIssue(1)];
     vi.mocked(buildExecutionGroups).mockReturnValue([{ group: 0, issues: [1] }]);


### PR DESCRIPTION
When issues are already implemented (QG passed, 0 file changes), no PR exists. Skip the merge step instead of failing with 'No open PR found'.