### PR TITLE
fix: improve JSON parsing retry with schema examples

### DIFF
--- a/src/ceremonies/execution.ts
+++ b/src/ceremonies/execution.ts
@@ -372,6 +372,24 @@ async function acceptanceCriteriaReview(
     }
 
     const result = await client.sendPrompt(sessionId, prompt, config.sessionTimeoutMs);
+
+    const acJsonExample = JSON.stringify(
+      {
+        approved: true,
+        reasoning: "All acceptance criteria met",
+        summary: "Implementation matches requirements",
+        criteria: [
+          {
+            criterion: "Feature works as specified",
+            passed: true,
+            evidence: "Verified in tests",
+          },
+        ],
+      },
+      null,
+      2,
+    );
+
     const acResult = await parseWithRetry(
       AcceptanceCriteriaSchema,
       result.response,
@@ -379,6 +397,7 @@ async function acceptanceCriteriaReview(
         const retry = await client.sendPrompt(sessionId, hint, config.sessionTimeoutMs);
         return retry.response;
       },
+      acJsonExample,
     );
 
     // Post results as issue comment

--- a/src/ceremonies/helpers.ts
+++ b/src/ceremonies/helpers.ts
@@ -91,11 +91,16 @@ export function extractJson<T = unknown>(text: string): T {
  * Parse an agent response against a Zod schema, retrying once on validation failure.
  * On first failure, calls `retryFn` with a format hint derived from the schema error.
  * Logs the first failure as a warning. Throws on second failure.
+ *
+ * @param jsonExample - Optional JSON example string to include in the retry hint.
+ *   Providing this dramatically improves retry success by showing the LLM the exact
+ *   structure expected.
  */
 export async function parseWithRetry<S extends z.ZodTypeAny>(
   schema: S,
   rawResponse: string,
   retryFn: (formatHint: string) => Promise<string>,
+  jsonExample?: string,
 ): Promise<z.output<S>> {
   const log = logger.child({ module: "parseWithRetry" });
 
@@ -105,16 +110,27 @@ export async function parseWithRetry<S extends z.ZodTypeAny>(
     const errMsg = firstError instanceof Error ? firstError.message : String(firstError);
     log.warn({ error: errMsg }, "schema validation failed — retrying with format hint");
 
-    const formatHint = [
-      "Your previous response could not be parsed.",
+    const hintLines = [
+      "Your previous response could not be parsed as JSON.",
       `Error: ${errMsg}`,
       "",
-      "Please respond with your analysis as readable text, then include a JSON block at the end.",
-      "The JSON must be wrapped in a ```json fenced code block.",
-      "Do NOT change your analysis — only fix the JSON format.",
-    ].join("\n");
+      "IMPORTANT: You MUST include a JSON block in your response.",
+      "Write your analysis as readable text first, then end with a ```json fenced code block.",
+    ];
 
-    const retryResponse = await retryFn(formatHint);
+    if (jsonExample) {
+      hintLines.push(
+        "",
+        "The JSON must match this exact structure:",
+        "```json",
+        jsonExample,
+        "```",
+      );
+    }
+
+    hintLines.push("", "Do NOT change your analysis — only add the JSON block at the end.");
+
+    const retryResponse = await retryFn(hintLines.join("\n"));
     return schema.parse(extractJson(retryResponse));
   }
 }

--- a/src/ceremonies/planning.ts
+++ b/src/ceremonies/planning.ts
@@ -72,15 +72,41 @@ export async function runSprintPlanning(
     for (let attempt = 1; attempt <= MAX_PLANNING_ATTEMPTS; attempt++) {
       try {
         const result = await client.sendPrompt(sessionId, fullPrompt, config.sessionTimeoutMs);
-        plan = (await parseWithRetry(SprintPlanSchema, result.response, async (formatHint) => {
-          log.warn("Planning parse failed — retrying with format hint");
-          eventBus?.emitTyped("log", {
-            level: "warn",
-            message: "Planning parse failed, retrying with format hint…",
-          });
-          const retry = await client.sendPrompt(sessionId, formatHint, config.sessionTimeoutMs);
-          return retry.response;
-        })) as SprintPlan;
+        const planJsonExample = JSON.stringify(
+          {
+            sprintNumber: config.sprintNumber,
+            sprint_issues: [
+              {
+                number: 1,
+                title: "Example issue",
+                ice_score: 8,
+                depends_on: [],
+                acceptanceCriteria: "Feature works as expected",
+                expectedFiles: ["src/example.ts"],
+                points: 1,
+              },
+            ],
+            execution_groups: [[1]],
+            estimated_points: 1,
+            rationale: "Selected based on priority and dependencies",
+          },
+          null,
+          2,
+        );
+        plan = (await parseWithRetry(
+          SprintPlanSchema,
+          result.response,
+          async (formatHint) => {
+            log.warn("Planning parse failed — retrying with format hint");
+            eventBus?.emitTyped("log", {
+              level: "warn",
+              message: "Planning parse failed, retrying with format hint…",
+            });
+            const retry = await client.sendPrompt(sessionId, formatHint, config.sessionTimeoutMs);
+            return retry.response;
+          },
+          planJsonExample,
+        )) as SprintPlan;
         break;
       } catch (err: unknown) {
         lastError = err;

--- a/src/enforcement/challenger.ts
+++ b/src/enforcement/challenger.ts
@@ -76,10 +76,21 @@ export async function runChallengerReview(
 
   const result = await client.sendPrompt(sessionId, prompt, config.sessionTimeoutMs);
 
-  const action = await parseWithRetry(ChallengerActionSchema, result.response, async (hint) => {
-    const retry = await client.sendPrompt(sessionId, hint, config.sessionTimeoutMs);
-    return retry.response;
-  });
+  const challengerJsonExample = JSON.stringify(
+    { decision: "approved", reasoning: "No blocking issues found", feedback: "LGTM" },
+    null,
+    2,
+  );
+
+  const action = await parseWithRetry(
+    ChallengerActionSchema,
+    result.response,
+    async (hint) => {
+      const retry = await client.sendPrompt(sessionId, hint, config.sessionTimeoutMs);
+      return retry.response;
+    },
+    challengerJsonExample,
+  );
 
   await client.endSession(sessionId);
 

--- a/src/enforcement/code-review.ts
+++ b/src/enforcement/code-review.ts
@@ -89,10 +89,26 @@ export async function runCodeReview(
 
     const result = await client.sendPrompt(sessionId, prompt, config.sessionTimeoutMs);
 
-    const action = await parseWithRetry(CodeReviewActionSchema, result.response, async (hint) => {
-      const retry = await client.sendPrompt(sessionId, hint, config.sessionTimeoutMs);
-      return retry.response;
-    });
+    const codeReviewJsonExample = JSON.stringify(
+      {
+        decision: "approved",
+        reasoning: "No blocking issues found",
+        summary: "Changes look correct",
+        issues: [],
+      },
+      null,
+      2,
+    );
+
+    const action = await parseWithRetry(
+      CodeReviewActionSchema,
+      result.response,
+      async (hint) => {
+        const retry = await client.sendPrompt(sessionId, hint, config.sessionTimeoutMs);
+        return retry.response;
+      },
+      codeReviewJsonExample,
+    );
 
     const approved = action.decision === "approved";
 


### PR DESCRIPTION
## Problem

Code review JSON parsing fails 100% of the time during autonomous sprint runs. The reviewer LLM returns markdown instead of JSON, and the retry hint doesn't include the expected JSON structure, so the retry also fails.

## Changes

- **`parseWithRetry`**: New optional `jsonExample` parameter. When provided, the retry hint includes the exact JSON structure expected, making retries dramatically more likely to succeed.
- **All 4 callers updated**: code-review, acceptance criteria, challenger, and planning now pass concrete JSON examples.
- **Stronger retry hint wording**: Changed from 'please respond' to 'IMPORTANT: You MUST include a JSON block'.

## Files Modified

- `src/ceremonies/helpers.ts`: Updated `parseWithRetry` signature and hint generation
- `src/enforcement/code-review.ts`: Pass CodeReviewActionSchema example
- `src/ceremonies/execution.ts`: Pass AcceptanceCriteriaSchema example
- `src/enforcement/challenger.ts`: Pass ChallengerActionSchema example
- `src/ceremonies/planning.ts`: Pass SprintPlanSchema example

## Testing

- 621 tests pass
- Type check clean
- Lint clean