### PR TITLE
fix: add JSON retry to sprint review and retro ceremonies

### DIFF
--- a/src/ceremonies/retro.ts
+++ b/src/ceremonies/retro.ts
@@ -82,7 +82,22 @@ export async function runSprintRetro(
       await client.setModel(sessionId, sessionConfig.model);
     }
     const response = await client.sendPrompt(sessionId, fullPrompt, config.sessionTimeoutMs);
-    const rawRetro = extractJson<Record<string, unknown>>(response.response);
+
+    let rawRetro: Record<string, unknown>;
+    try {
+      rawRetro = extractJson<Record<string, unknown>>(response.response);
+    } catch {
+      log.warn("retro JSON extraction failed — retrying with format hint");
+      const retryHint = [
+        "Your response could not be parsed as JSON.",
+        "IMPORTANT: Respond with ONLY a JSON block — no markdown, no explanation.",
+        "```json",
+        '{ "wentWell": ["..."], "wentBadly": ["..."], "improvements": [{ "title": "...", "description": "...", "autoApplicable": false, "target": "process" }] }',
+        "```",
+      ].join("\n");
+      const retryResponse = await client.sendPrompt(sessionId, retryHint, config.sessionTimeoutMs);
+      rawRetro = extractJson<Record<string, unknown>>(retryResponse.response);
+    }
 
     // Normalize LLM field name variations, then validate via Zod schema
     const normalized = normalizeRetroFields(rawRetro);

--- a/src/ceremonies/review.ts
+++ b/src/ceremonies/review.ts
@@ -5,7 +5,7 @@ import type { SprintConfig, SprintResult, ReviewResult, IssueResult } from "../t
 import type { SprintEventBus } from "../events.js";
 import { calculateSprintMetrics, topFailedGates } from "../metrics.js";
 import { logger } from "../logger.js";
-import { substitutePrompt, extractJson, sanitizePromptInput } from "./helpers.js";
+import { substitutePrompt, sanitizePromptInput, parseWithRetry } from "./helpers.js";
 import { resolveSessionConfig } from "../acp/session-config.js";
 import { getPRStatus } from "../git/merge.js";
 import { ReviewResultSchema } from "../types/schemas.js";
@@ -150,7 +150,27 @@ export async function runSprintReview(
       await client.setModel(sessionId, sessionConfig.model);
     }
     const response = await client.sendPrompt(sessionId, fullPrompt, config.sessionTimeoutMs);
-    const review = ReviewResultSchema.parse(extractJson(response.response));
+
+    const reviewJsonExample = JSON.stringify(
+      {
+        summary: "Sprint N completed with X/Y issues done",
+        demoItems: ["#1 - feature description"],
+        velocityUpdate: "Velocity: N points",
+        openItems: [],
+      },
+      null,
+      2,
+    );
+
+    const review = await parseWithRetry(
+      ReviewResultSchema,
+      response.response,
+      async (hint) => {
+        const retry = await client.sendPrompt(sessionId, hint, config.sessionTimeoutMs);
+        return retry.response;
+      },
+      reviewJsonExample,
+    );
 
     log.info(
       {


### PR DESCRIPTION
Sprint test loop found that review.ts crashes when the LLM returns markdown instead of JSON. Same risk in retro.ts. Both now use retry with format hints.