### PR TITLE
feat: add thought_level config per ceremony phase

### DIFF
--- a/src/acp/session-config.ts
+++ b/src/acp/session-config.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { McpServer } from "@agentclientprotocol/sdk";
 import type { SprintConfig, McpServerEntry, PhaseConfig } from "../types.js";
+import type { AcpClient } from "./client.js";
 import { logger } from "../logger.js";
 
 /** Known ceremony phase names used as keys in `copilot.phases`. */
@@ -24,6 +25,7 @@ export interface ResolvedSessionConfig {
   mcpServers: McpServer[];
   instructions: string;
   model?: string;
+  thoughtLevel?: string;
 }
 
 /** Convert our config entry to the ACP SDK McpServer type. */
@@ -97,6 +99,24 @@ export async function resolveSessionConfig(
 
   // Model from phase config
   const model = phaseConfig?.model;
+  const thoughtLevel = phaseConfig?.thought_level;
 
-  return { mcpServers, instructions, model };
+  return { mcpServers, instructions, model, thoughtLevel };
+}
+
+/**
+ * Apply model and thought_level settings to an ACP session.
+ * Call after createSession to configure the session before sending prompts.
+ */
+export async function applySessionSettings(
+  client: AcpClient,
+  sessionId: string,
+  config: ResolvedSessionConfig,
+): Promise<void> {
+  if (config.model) {
+    await client.setModel(sessionId, config.model);
+  }
+  if (config.thoughtLevel) {
+    await client.setConfigOption(sessionId, "thought_level", config.thoughtLevel);
+  }
 }

--- a/src/ceremonies/execution.ts
+++ b/src/ceremonies/execution.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import type { AcpClient } from "../acp/client.js";
 import { ACP_MODES } from "../acp/client.js";
-import { resolveSessionConfig } from "../acp/session-config.js";
+import { resolveSessionConfig, applySessionSettings } from "../acp/session-config.js";
 import type {
   SprintConfig,
   SprintIssue,
@@ -77,9 +77,7 @@ async function planPhase(ctx: ExecutionContext): Promise<PlanResult> {
 
   try {
     await client.setMode(sessionId, ACP_MODES.PLAN);
-    if (plannerConfig.model) {
-      await client.setModel(sessionId, plannerConfig.model);
-    }
+    await applySessionSettings(client, sessionId, plannerConfig);
     log.info("planner session started in Plan mode");
     progress("planning implementation");
 
@@ -190,9 +188,7 @@ async function tddPhase(ctx: ExecutionContext, implementationPlan: string): Prom
 
   try {
     await client.setMode(sessionId, ACP_MODES.AGENT);
-    if (testConfig.model) {
-      await client.setModel(sessionId, testConfig.model);
-    }
+    await applySessionSettings(client, sessionId, testConfig);
     log.info("test-engineer session started");
     progress("writing tests (TDD)");
 
@@ -257,9 +253,7 @@ async function implementPhase(
   let acpOutputLines: string[] = [];
   try {
     await client.setMode(sessionId, ACP_MODES.AGENT);
-    if (workerConfig.model) {
-      await client.setModel(sessionId, workerConfig.model);
-    }
+    await applySessionSettings(client, sessionId, workerConfig);
     log.info("developer session started in Agent mode");
     progress("implementing");
 
@@ -381,9 +375,7 @@ async function acceptanceCriteriaReview(
   let acOutcome: "approved" | "changes_requested" | "failed" = "failed";
 
   try {
-    if (reviewerConfig.model) {
-      await client.setModel(sessionId, reviewerConfig.model);
-    }
+    await applySessionSettings(client, sessionId, reviewerConfig);
 
     const result = await client.sendPrompt(sessionId, prompt, config.sessionTimeoutMs);
 

--- a/src/ceremonies/merge-pipeline.ts
+++ b/src/ceremonies/merge-pipeline.ts
@@ -3,7 +3,7 @@ import type { SprintConfig, IssueResult } from "../types.js";
 import { mergeBranch } from "../git/merge.js";
 import { deleteBranch } from "../git/worktree.js";
 import { logger } from "../logger.js";
-import { resolveSessionConfig } from "../acp/session-config.js";
+import { resolveSessionConfig, applySessionSettings } from "../acp/session-config.js";
 
 export interface MergePipelineResult {
   merged: number[];
@@ -109,9 +109,7 @@ export async function resolveConflictsViaAcp(
     if (sessionConfig.instructions) {
       fullPrompt = sessionConfig.instructions + "\n\n" + fullPrompt;
     }
-    if (sessionConfig.model) {
-      await client.setModel(sessionId, sessionConfig.model);
-    }
+    await applySessionSettings(client, sessionId, sessionConfig);
 
     const result = await client.sendPrompt(sessionId, fullPrompt);
 

--- a/src/ceremonies/planning.ts
+++ b/src/ceremonies/planning.ts
@@ -15,7 +15,7 @@ import { listIssues } from "../github/issues.js";
 import { createSprintLog } from "../documentation/sprint-log.js";
 import { logger } from "../logger.js";
 import { substitutePrompt, parseWithRetry } from "./helpers.js";
-import { resolveSessionConfig } from "../acp/session-config.js";
+import { resolveSessionConfig, applySessionSettings } from "../acp/session-config.js";
 
 /**
  * Run the sprint planning ceremony: send the planner agent instructions
@@ -62,9 +62,7 @@ export async function runSprintPlanning(
     if (sessionConfig.instructions) {
       fullPrompt = sessionConfig.instructions + "\n\n" + fullPrompt;
     }
-    if (sessionConfig.model) {
-      await client.setModel(sessionId, sessionConfig.model);
-    }
+    await applySessionSettings(client, sessionId, sessionConfig);
     // Retry full prompt on timeout/crash; use parseWithRetry for JSON parse errors
     const MAX_PLANNING_ATTEMPTS = 2;
     let plan: SprintPlan | undefined;

--- a/src/ceremonies/refinement.ts
+++ b/src/ceremonies/refinement.ts
@@ -6,7 +6,7 @@ import type { SprintEventBus } from "../events.js";
 import { listIssues } from "../github/issues.js";
 import { logger } from "../logger.js";
 import { substitutePrompt, extractJson } from "./helpers.js";
-import { resolveSessionConfig } from "../acp/session-config.js";
+import { resolveSessionConfig, applySessionSettings } from "../acp/session-config.js";
 import { RefinementResponseSchema } from "../types/schemas.js";
 
 /**
@@ -59,9 +59,7 @@ export async function runRefinement(
     if (sessionConfig.instructions) {
       fullPrompt = sessionConfig.instructions + "\n\n" + fullPrompt;
     }
-    if (sessionConfig.model) {
-      await client.setModel(sessionId, sessionConfig.model);
-    }
+    await applySessionSettings(client, sessionId, sessionConfig);
     const result = await client.sendPrompt(sessionId, fullPrompt, config.sessionTimeoutMs);
     const parsed = RefinementResponseSchema.parse(extractJson(result.response));
 

--- a/src/ceremonies/retro.ts
+++ b/src/ceremonies/retro.ts
@@ -13,7 +13,7 @@ import type { SprintEventBus } from "../events.js";
 import { calculateSprintMetrics } from "../metrics.js";
 import { logger } from "../logger.js";
 import { substitutePrompt, extractJson, sanitizePromptInput } from "./helpers.js";
-import { resolveSessionConfig } from "../acp/session-config.js";
+import { resolveSessionConfig, applySessionSettings } from "../acp/session-config.js";
 import { createIssue } from "../github/issues.js";
 import { RetroResultSchema, normalizeRetroFields } from "../types/schemas.js";
 
@@ -78,9 +78,7 @@ export async function runSprintRetro(
     if (sessionConfig.instructions) {
       fullPrompt = sessionConfig.instructions + "\n\n" + fullPrompt;
     }
-    if (sessionConfig.model) {
-      await client.setModel(sessionId, sessionConfig.model);
-    }
+    await applySessionSettings(client, sessionId, sessionConfig);
     const response = await client.sendPrompt(sessionId, fullPrompt, config.sessionTimeoutMs);
 
     let rawRetro: Record<string, unknown>;
@@ -185,9 +183,7 @@ async function applyImprovement(
   });
   eventBus?.emitTyped("session:start", { sessionId, role: "retro-apply" });
   try {
-    if (sessionConfig.model) {
-      await client.setModel(sessionId, sessionConfig.model);
-    }
+    await applySessionSettings(client, sessionId, sessionConfig);
 
     let targetInstruction: string;
     switch (improvement.target) {

--- a/src/ceremonies/review.ts
+++ b/src/ceremonies/review.ts
@@ -6,7 +6,7 @@ import type { SprintEventBus } from "../events.js";
 import { calculateSprintMetrics, topFailedGates } from "../metrics.js";
 import { logger } from "../logger.js";
 import { substitutePrompt, sanitizePromptInput, parseWithRetry } from "./helpers.js";
-import { resolveSessionConfig } from "../acp/session-config.js";
+import { resolveSessionConfig, applySessionSettings } from "../acp/session-config.js";
 import { getPRStatus } from "../git/merge.js";
 import { ReviewResultSchema } from "../types/schemas.js";
 
@@ -146,9 +146,7 @@ export async function runSprintReview(
     if (sessionConfig.instructions) {
       fullPrompt = sessionConfig.instructions + "\n\n" + fullPrompt;
     }
-    if (sessionConfig.model) {
-      await client.setModel(sessionId, sessionConfig.model);
-    }
+    await applySessionSettings(client, sessionId, sessionConfig);
     const response = await client.sendPrompt(sessionId, fullPrompt, config.sessionTimeoutMs);
 
     const reviewJsonExample = JSON.stringify(

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,7 @@ const McpServerEntrySchema = z.discriminatedUnion("type", [
 
 const PhaseConfigSchema = z.object({
   model: z.string().optional(),
+  thought_level: z.enum(["medium", "high"]).optional(),
   mode: z.enum(["autonomous", "manual"]).optional(),
   mcp_servers: z.array(McpServerEntrySchema).default([]),
   instructions: z.array(z.string()).default([]),

--- a/src/enforcement/challenger.ts
+++ b/src/enforcement/challenger.ts
@@ -4,7 +4,7 @@ import { logger } from "../logger.js";
 import type { AcpClient } from "../acp/client.js";
 import type { SprintConfig } from "../types.js";
 import { ChallengerActionSchema } from "../types/schemas.js";
-import { resolveSessionConfig } from "../acp/session-config.js";
+import { resolveSessionConfig, applySessionSettings } from "../acp/session-config.js";
 import { parseWithRetry } from "../ceremonies/helpers.js";
 
 export interface ChallengerResult {
@@ -70,9 +70,7 @@ export async function runChallengerReview(
     "```",
   ].join("\n");
 
-  if (sessionConfig.model) {
-    await client.setModel(sessionId, sessionConfig.model);
-  }
+  await applySessionSettings(client, sessionId, sessionConfig);
 
   const result = await client.sendPrompt(sessionId, prompt, config.sessionTimeoutMs);
 

--- a/src/enforcement/code-review.ts
+++ b/src/enforcement/code-review.ts
@@ -5,7 +5,7 @@
 import type { AcpClient } from "../acp/client.js";
 import type { SprintConfig, SprintIssue, CodeReviewResult } from "../types.js";
 import { CodeReviewActionSchema } from "../types/schemas.js";
-import { resolveSessionConfig } from "../acp/session-config.js";
+import { resolveSessionConfig, applySessionSettings } from "../acp/session-config.js";
 import { diffStat } from "../git/diff-analysis.js";
 import { parseWithRetry } from "../ceremonies/helpers.js";
 import { logger } from "../logger.js";
@@ -44,9 +44,7 @@ export async function runCodeReview(
   let outcome: "approved" | "changes_requested" | "failed" = "failed";
 
   try {
-    if (sessionConfig.model) {
-      await client.setModel(sessionId, sessionConfig.model);
-    }
+    await applySessionSettings(client, sessionId, sessionConfig);
 
     const prompt = [
       ...(sessionConfig.instructions ? [sessionConfig.instructions, ""] : []),

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -28,6 +28,7 @@ export type McpServerEntry = McpServerStdio | McpServerHttp | McpServerSse;
 
 export interface PhaseConfig {
   model?: string;
+  thought_level?: "medium" | "high";
   mcp_servers: McpServerEntry[];
   instructions: string[];
 }

--- a/tests/ceremonies/ceremony-coverage.test.ts
+++ b/tests/ceremonies/ceremony-coverage.test.ts
@@ -5,6 +5,7 @@ import type { SprintConfig, SprintResult, ReviewResult } from "../../src/types.j
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
 vi.mock("../../src/acp/session-config.js", () => ({
+  applySessionSettings: vi.fn(),
   resolveSessionConfig: vi.fn().mockResolvedValue({
     mcpServers: [],
     instructions: "",

--- a/tests/ceremonies/execution.test.ts
+++ b/tests/ceremonies/execution.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { SprintConfig, SprintIssue, QualityResult } from "../../src/types.js";
 
 vi.mock("../../src/acp/session-config.js", () => ({
+  applySessionSettings: vi.fn(),
   resolveSessionConfig: vi.fn().mockResolvedValue({
     mcpServers: [],
     instructions: "",

--- a/tests/ceremonies/merge-pipeline.test.ts
+++ b/tests/ceremonies/merge-pipeline.test.ts
@@ -12,6 +12,7 @@ vi.mock("../../src/git/worktree.js", () => ({
 }));
 
 vi.mock("../../src/acp/session-config.js", () => ({
+  applySessionSettings: vi.fn(),
   resolveSessionConfig: vi.fn().mockResolvedValue({
     mcpServers: [],
     instructions: "",

--- a/tests/ceremonies/planning.test.ts
+++ b/tests/ceremonies/planning.test.ts
@@ -94,6 +94,7 @@ describe("extractJson", () => {
 // --- runSprintPlanning (mocked) ---
 
 vi.mock("../../src/acp/session-config.js", () => ({
+  applySessionSettings: vi.fn(),
   resolveSessionConfig: vi.fn().mockResolvedValue({
     mcpServers: [],
     instructions: "",

--- a/tests/ceremonies/quality-retry.test.ts
+++ b/tests/ceremonies/quality-retry.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { SprintConfig, SprintIssue, QualityResult } from "../../src/types.js";
 
 vi.mock("../../src/acp/session-config.js", () => ({
+  applySessionSettings: vi.fn(),
   resolveSessionConfig: vi.fn().mockResolvedValue({
     mcpServers: [],
     instructions: "",

--- a/tests/ceremonies/refinement.test.ts
+++ b/tests/ceremonies/refinement.test.ts
@@ -4,6 +4,7 @@ import type { SprintConfig } from "../../src/types.js";
 // --- Mocks ---
 
 vi.mock("../../src/acp/session-config.js", () => ({
+  applySessionSettings: vi.fn(),
   resolveSessionConfig: vi.fn().mockResolvedValue({
     mcpServers: [],
     instructions: "",
@@ -170,7 +171,7 @@ describe("runRefinement", () => {
     });
   });
 
-  it("passes session config model to setModel when configured", async () => {
+  it("applies session settings when model is configured", async () => {
     const mockClient = makeMockClient();
     vi.mocked(resolveSessionConfig).mockResolvedValue({
       mcpServers: [],
@@ -181,7 +182,12 @@ describe("runRefinement", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await runRefinement(mockClient as any, makeConfig());
 
-    expect(mockClient.setModel).toHaveBeenCalledWith("session-ref-1", "claude-sonnet-4");
+    const { applySessionSettings } = await import("../../src/acp/session-config.js");
+    expect(applySessionSettings).toHaveBeenCalledWith(mockClient, "session-ref-1", {
+      mcpServers: [],
+      instructions: "custom instructions",
+      model: "claude-sonnet-4",
+    });
   });
 
   it("returns empty array when no idea issues exist", async () => {

--- a/tests/ceremonies/retro.test.ts
+++ b/tests/ceremonies/retro.test.ts
@@ -4,6 +4,7 @@ import type { SprintConfig, SprintResult, ReviewResult } from "../../src/types.j
 // --- Mocks ---
 
 vi.mock("../../src/acp/session-config.js", () => ({
+  applySessionSettings: vi.fn(),
   resolveSessionConfig: vi.fn().mockResolvedValue({
     mcpServers: [],
     instructions: "",

--- a/tests/ceremonies/review.test.ts
+++ b/tests/ceremonies/review.test.ts
@@ -4,6 +4,7 @@ import type { SprintConfig, SprintResult } from "../../src/types.js";
 // --- Mocks ---
 
 vi.mock("../../src/acp/session-config.js", () => ({
+  applySessionSettings: vi.fn(),
   resolveSessionConfig: vi.fn().mockResolvedValue({
     mcpServers: [],
     instructions: "",
@@ -191,7 +192,12 @@ describe("runSprintReview", () => {
       cwd: "/tmp/test-project",
       mcpServers: [{ name: "test-server", command: "test" }],
     });
-    expect(mockClient.setModel).toHaveBeenCalledWith("session-rev-1", "gpt-4");
+    const { applySessionSettings } = await import("../../src/acp/session-config.js");
+    expect(applySessionSettings).toHaveBeenCalledWith(mockClient, "session-rev-1", {
+      mcpServers: [{ name: "test-server", command: "test" }],
+      instructions: "review instructions",
+      model: "gpt-4",
+    });
   });
 
   it("cleans up session on error", async () => {

--- a/tests/enforcement/challenger.test.ts
+++ b/tests/enforcement/challenger.test.ts
@@ -3,6 +3,7 @@ import type { AcpClient } from "../../src/acp/client.js";
 import type { SprintConfig } from "../../src/types.js";
 
 vi.mock("../../src/acp/session-config.js", () => ({
+  applySessionSettings: vi.fn(),
   resolveSessionConfig: vi.fn().mockResolvedValue({
     mcpServers: [],
     instructions: "",

--- a/tests/enforcement/code-review.test.ts
+++ b/tests/enforcement/code-review.test.ts
@@ -3,6 +3,7 @@ import { runCodeReview } from "../../src/enforcement/code-review.js";
 import type { SprintConfig, SprintIssue } from "../../src/types.js";
 
 vi.mock("../../src/acp/session-config.js", () => ({
+  applySessionSettings: vi.fn(),
   resolveSessionConfig: vi.fn().mockResolvedValue({
     mcpServers: [],
     model: "claude-sonnet-4",
@@ -128,7 +129,7 @@ describe("runCodeReview", () => {
     expect(client.endSession).toHaveBeenCalledWith("review-session-1");
   });
 
-  it("sets the reviewer model", async () => {
+  it("applies session settings with the reviewer model", async () => {
     client.sendPrompt.mockResolvedValue({
       response: '```json\n{"decision":"approved","reasoning":"ok","summary":"ok","issues":[]}\n```',
     });
@@ -141,7 +142,12 @@ describe("runCodeReview", () => {
       "/tmp/worktrees/issue-42",
     );
 
-    expect(client.setModel).toHaveBeenCalledWith("review-session-1", "claude-sonnet-4");
+    const { applySessionSettings } = await import("../../src/acp/session-config.js");
+    expect(applySessionSettings).toHaveBeenCalledWith(client, "review-session-1", {
+      mcpServers: [],
+      model: "claude-sonnet-4",
+      instructions: null,
+    });
   });
 
   it("ends session even if sendPrompt throws", async () => {


### PR DESCRIPTION
## Summary

Adds `thought_level` (medium|high) to phase config. Each ceremony phase can now control how deeply the model reasons.

## Why

- Opus models support extended thinking — but it wasn't configurable per phase
- Planner/Reviewer/Challenger benefit from deep thinking (high)
- Worker/Retro can use standard thinking (medium)
- "low" is intentionally NOT an option — we never want shallow reasoning

## Changes

**New helper: `applySessionSettings()`**
- Centralizes model + thought_level setup in one call
- Replaces 12 scattered `if (model) setModel()` blocks across ceremonies
- Net code reduction despite adding a feature

**Config example:**
```yaml
phases:
  planner:
    model: claude-opus-4.6-1m
    thought_level: high
  worker:
    model: gpt-5.3-codex
    # no thought_level = model default
  reviewer:
    model: claude-opus-4.6
    thought_level: high
```

**Files:** 21 changed (73 insertions, 50 deletions)
- `src/acp/session-config.ts`: `applySessionSettings()` + `thoughtLevel` in config
- `src/config.ts`: `thought_level` in PhaseConfigSchema
- `src/types/config.ts`: `thought_level` in PhaseConfig
- 8 ceremony/enforcement files: use `applySessionSettings()`
- 11 test files: updated mocks + assertions