### PR TITLE
feat: add example config tests + link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,12 @@ aiscrum status                          # Active worker status
 
 ## Configuration
 
-Everything is config-driven. One YAML file controls the entire sprint engine.
+Everything is config-driven. One YAML file controls the entire sprint engine. Ready-to-use examples for **[TypeScript](examples/typescript/)**, **[Python](examples/python/)**, **[React](examples/react/)**, and **[Go](examples/go/)** — just copy and go:
+
+```bash
+cp -r examples/python/.aiscrum .aiscrum    # Pick your stack
+$EDITOR .aiscrum/config.yaml               # Set project name
+```
 
 ```yaml
 # .aiscrum/config.yaml — Zod-validated at startup
@@ -257,6 +262,7 @@ Git hooks are installed automatically on `npm install`:
 | [Process Constitution](docs/constitution/PROCESS.md) | Full development process — ceremonies, DoD, ICE scoring, labels |
 | [Philosophy](docs/constitution/PHILOSOPHY.md) | Values and principles |
 | [ADRs](docs/architecture/ADR.md) | Architectural Decision Records |
+| [Examples](examples/) | Ready-to-copy `.aiscrum/` configs for TypeScript, Python, React, Go |
 | [Changelog](CHANGELOG.md) | Version history |
 
 ## License

--- a/docs/index.html
+++ b/docs/index.html
@@ -1295,17 +1295,18 @@
           <span class="terminal__title">~/my-project</span>
         </div>
         <div class="terminal__body">
-          <div><span class="comment"># Clone and install</span></div>
-          <div><span class="prompt">$ </span><span class="cmd">git clone https://github.com/trsdn/aiscrum-pro && cd aiscrum-pro</span></div>
-          <div><span class="prompt">$ </span><span class="cmd">npm install</span></div>
+          <div><span class="comment"># Pick a starter config for your stack</span></div>
+          <div><span class="prompt">$ </span><span class="cmd">cp -r examples/python/.aiscrum .aiscrum</span></div>
           <div style="height: 0.5rem;"></div>
-          <div><span class="comment"># Launch the dashboard</span></div>
-          <div><span class="prompt">$ </span><span class="cmd">npx tsx src/index.ts web</span></div>
+          <div><span class="comment"># Install and launch</span></div>
+          <div><span class="prompt">$ </span><span class="cmd">npm install && npx tsx src/index.ts web</span></div>
           <div><span class="output">🏃 AiScrum Pro dashboard → http://localhost:9100</span></div>
           <div style="height: 0.5rem;"></div>
           <div><span class="comment"># Or run a full sprint cycle</span></div>
           <div><span class="prompt">$ </span><span class="cmd">npx tsx src/index.ts full-cycle --sprint 1</span></div>
           <div><span class="output">🔍 Refining ideas... → 📋 Planning sprint... → ⚡ Executing...</span></div>
+          <div style="height: 0.75rem;"></div>
+          <div><span class="comment"># Starter configs: typescript · python · react · go</span></div>
         </div>
       </div>
     </div>

--- a/tests/examples/example-configs.test.ts
+++ b/tests/examples/example-configs.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { loadConfig } from "../../src/config.js";
+
+const EXAMPLES_DIR = path.resolve(__dirname, "../../examples");
+
+const STACKS = ["typescript", "python", "react", "go"] as const;
+const REQUIRED_ROLES = [
+  "general",
+  "planner",
+  "refiner",
+  "reviewer",
+  "test-engineer",
+  "retro",
+] as const;
+
+function withNtfyTopic<T>(fn: () => T): T {
+  const orig = process.env.NTFY_TOPIC;
+  process.env.NTFY_TOPIC = "test-topic";
+  try {
+    return fn();
+  } finally {
+    if (orig === undefined) {
+      delete process.env.NTFY_TOPIC;
+    } else {
+      process.env.NTFY_TOPIC = orig;
+    }
+  }
+}
+
+function readRole(stack: string, role: string): string {
+  return fs.readFileSync(
+    path.join(EXAMPLES_DIR, stack, ".aiscrum", "roles", role, "copilot-instructions.md"),
+    "utf-8",
+  );
+}
+
+describe("example configs", () => {
+  for (const stack of STACKS) {
+    const configPath = path.join(EXAMPLES_DIR, stack, ".aiscrum", "config.yaml");
+
+    describe(stack, () => {
+      it("config.yaml exists", () => {
+        expect(fs.existsSync(configPath)).toBe(true);
+      });
+
+      it("passes Zod schema validation", () => {
+        const config = withNtfyTopic(() => loadConfig(configPath));
+        expect(config.project.name).toBeTruthy();
+        expect(config.sprint.prefix).toBe("Sprint");
+        expect(config.quality_gates).toBeDefined();
+        expect(config.git.branch_pattern).toContain("{issue}");
+      });
+
+      it("has all required role directories with copilot-instructions.md", () => {
+        for (const role of REQUIRED_ROLES) {
+          const instrFile = path.join(
+            EXAMPLES_DIR,
+            stack,
+            ".aiscrum",
+            "roles",
+            role,
+            "copilot-instructions.md",
+          );
+          expect(
+            fs.existsSync(instrFile),
+            `missing ${stack}/roles/${role}/copilot-instructions.md`,
+          ).toBe(true);
+        }
+      });
+
+      it("has quality gate commands defined", () => {
+        const config = withNtfyTopic(() => loadConfig(configPath));
+        expect(config.quality_gates.test_command).toBeDefined();
+        expect(config.quality_gates.lint_command).toBeDefined();
+      });
+    });
+  }
+});
+
+describe("role instructions structure", () => {
+  for (const stack of STACKS) {
+    describe(stack, () => {
+      for (const role of REQUIRED_ROLES) {
+        describe(role, () => {
+          it("starts with a markdown heading", () => {
+            const content = readRole(stack, role);
+            expect(content.trimStart()).toMatch(/^# .+/);
+          });
+
+          it("has a ## Role or ## Workflow section", () => {
+            const content = readRole(stack, role);
+            expect(content).toMatch(/## (Role|Workflow)/);
+          });
+
+          it("has a ## Rules section", () => {
+            const content = readRole(stack, role);
+            expect(content).toMatch(/## Rules/);
+          });
+
+          it("is non-trivial (>200 chars)", () => {
+            const content = readRole(stack, role);
+            expect(content.length).toBeGreaterThan(200);
+          });
+        });
+      }
+    });
+  }
+});
+
+describe("role instructions content", () => {
+  describe("shared roles are consistent across stacks", () => {
+    const sharedRoles = ["general", "planner", "refiner", "reviewer", "retro"] as const;
+
+    for (const role of sharedRoles) {
+      it(`${role} is identical across all stacks`, () => {
+        const contents = STACKS.map((stack) => readRole(stack, role));
+        for (let i = 1; i < contents.length; i++) {
+          expect(contents[i], `${role} differs between ${STACKS[0]} and ${STACKS[i]}`).toBe(
+            contents[0],
+          );
+        }
+      });
+    }
+  });
+
+  describe("test-engineer is stack-specific", () => {
+    it("typescript mentions Vitest", () => {
+      expect(readRole("typescript", "test-engineer")).toMatch(/vitest/i);
+    });
+
+    it("python mentions pytest", () => {
+      expect(readRole("python", "test-engineer")).toMatch(/pytest/i);
+    });
+
+    it("react mentions React Testing Library", () => {
+      expect(readRole("react", "test-engineer")).toMatch(/testing.library/i);
+    });
+
+    it("go mentions Go testing stdlib", () => {
+      expect(readRole("go", "test-engineer")).toMatch(/testing|t\.Run/);
+    });
+
+    it("each stack has a unique test-engineer", () => {
+      const contents = STACKS.map((stack) => readRole(stack, "test-engineer"));
+      const unique = new Set(contents);
+      expect(unique.size).toBe(STACKS.length);
+    });
+  });
+});
+
+describe("stack-specific quality gates", () => {
+  it("typescript uses vitest and eslint", () => {
+    const config = withNtfyTopic(() =>
+      loadConfig(path.join(EXAMPLES_DIR, "typescript", ".aiscrum", "config.yaml")),
+    );
+    expect(config.quality_gates.test_command).toContain("vitest");
+    expect(config.quality_gates.lint_command).toContain("eslint");
+    expect(config.quality_gates.require_types).toBe(true);
+    expect(config.quality_gates.require_build).toBe(true);
+  });
+
+  it("python uses pytest and ruff, no build", () => {
+    const config = withNtfyTopic(() =>
+      loadConfig(path.join(EXAMPLES_DIR, "python", ".aiscrum", "config.yaml")),
+    );
+    expect(config.quality_gates.test_command).toContain("pytest");
+    expect(config.quality_gates.lint_command).toContain("ruff");
+    expect(config.quality_gates.typecheck_command).toContain("mypy");
+    expect(config.quality_gates.require_build).toBe(false);
+  });
+
+  it("react uses vitest and vite build with TDD enabled", () => {
+    const config = withNtfyTopic(() =>
+      loadConfig(path.join(EXAMPLES_DIR, "react", ".aiscrum", "config.yaml")),
+    );
+    expect(config.quality_gates.test_command).toContain("vitest");
+    expect(config.quality_gates.build_command).toContain("vite");
+    expect(config.sprint.enable_tdd).toBe(true);
+  });
+
+  it("go uses go test and golangci-lint with TDD enabled", () => {
+    const config = withNtfyTopic(() =>
+      loadConfig(path.join(EXAMPLES_DIR, "go", ".aiscrum", "config.yaml")),
+    );
+    expect(config.quality_gates.test_command).toContain("go");
+    expect(config.quality_gates.lint_command).toContain("golangci-lint");
+    expect(config.quality_gates.typecheck_command).toContain("vet");
+    expect(config.sprint.enable_tdd).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

126 tests validating all 4 example configs against the real Zod schema, plus documentation links.

## Tests cover

- **Config validation**: Each example's `config.yaml` loads through `loadConfig()` without errors
- **Role structure**: All 6 roles exist with `copilot-instructions.md` containing required sections (`# Heading`, `## Role/Workflow`, `## Rules`, >200 chars)
- **Shared role consistency**: general/planner/refiner/reviewer/retro are identical across all 4 stacks
- **Test-engineer uniqueness**: Each stack has a unique test-engineer with stack-specific content (Vitest/pytest/RTL/Go testing)
- **Quality gate commands**: Stack-appropriate tools verified (vitest+eslint, pytest+ruff, vite build, golangci-lint, etc.)

## Docs

- README: Added examples link in Configuration section + Documentation table
- GitHub Pages: Updated Quick Start terminal to show `cp -r examples/` workflow