### PR TITLE
feat: add prompts and skills to example configs

### DIFF
--- a/examples/go/.aiscrum/roles/general/prompts/worker.md
+++ b/examples/go/.aiscrum/roles/general/prompts/worker.md
@@ -1,0 +1,29 @@
+Implement issue #{{ISSUE_NUMBER}}: "{{ISSUE_TITLE}}"
+
+## Issue Body
+
+{{ISSUE_BODY}}
+
+## Instructions
+
+1. **Parse** the issue title and body — understand exactly what is requested
+2. **Plan** — list files to modify/create before writing code
+3. **Write tests** — at least 3 tests per feature, regression test for bugs
+4. **Implement** — keep diff under {{MAX_DIFF_LINES}} lines (aim for ~150)
+5. **Verify** — run all quality gates:
+   - Tests pass
+   - Lint clean
+   - Types clean
+   - Build passes
+   - Diff within size limit
+6. **Commit** — use conventional commit format: `feat|fix|refactor(scope): description`
+7. **Push** — push to branch `{{BRANCH_NAME}}`
+8. **PR** — create PR linking to issue #{{ISSUE_NUMBER}}
+
+## Rules
+
+- Work in worktree: `{{WORKTREE_PATH}}`
+- Base branch: `{{BASE_BRANCH}}`
+- Follow existing code conventions and patterns
+- No completion claims without fresh verification evidence
+- If blocked, escalate — do not guess or assume

--- a/examples/go/.aiscrum/roles/planner/prompts/item-planner.md
+++ b/examples/go/.aiscrum/roles/planner/prompts/item-planner.md
@@ -1,0 +1,23 @@
+Create an implementation plan for issue #{{ISSUE_NUMBER}}: "{{ISSUE_TITLE}}"
+
+## Issue Body
+
+{{ISSUE_BODY}}
+
+## Instructions
+
+Analyze the codebase and produce a detailed plan. Do NOT make any changes.
+
+1. Identify files to modify/create
+2. Understand current code state and dependencies
+3. Plan test strategy
+4. Estimate diff size
+
+## Output
+
+JSON with:
+- summary: one-line description
+- steps: array of { action: "create"|"modify"|"test", file, details }
+- test_strategy: what to test and how
+- risks: potential issues
+- estimated_diff_lines: number (must be under {{MAX_DIFF_LINES}})

--- a/examples/go/.aiscrum/roles/planner/prompts/planning.md
+++ b/examples/go/.aiscrum/roles/planner/prompts/planning.md
@@ -1,0 +1,29 @@
+Plan Sprint {{SPRINT_NUMBER}} for {{PROJECT_NAME}}.
+
+## Backlog
+
+Select issues from the backlog for this sprint.
+
+## Process
+
+1. **Review eligible issues** — labeled `status:refined` but NOT `status:planned` or `status:in-progress`
+2. **Apply priority rules**:
+   - Stakeholder-flagged issues first
+   - Bugs before features
+   - ICE score (Impact × Confidence × Ease, each 1-10)
+   - Dependency order
+3. **Calculate capacity** — use 3-sprint velocity average with ~20% buffer
+4. **Analyze dependencies** — identify blocking chains and parallelizable work
+5. **Structure execution groups** — group parallel work, sequence dependent work
+6. **Apply labels** — `status:planned` + milestone "Sprint {{SPRINT_NUMBER}}"
+
+## Constraints
+
+- Minimum issues: {{MIN_ISSUES}}
+- Maximum issues: {{MAX_ISSUES}}
+- Never exceed max — quality over quantity
+- Escalate if insufficient capacity for critical issues
+
+## Output
+
+JSON with: selected_issues, execution_groups, effort_estimation, rationale

--- a/examples/go/.aiscrum/roles/planner/skills/sprint-planning/SKILL.md
+++ b/examples/go/.aiscrum/roles/planner/skills/sprint-planning/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: sprint-planning
+description: Sprint planning workflow with ICE scoring and velocity-based sizing.
+---
+
+## When to Use
+
+- Starting a new sprint
+- Re-evaluating sprint scope
+- Triaging newly refined issues
+
+## Steps
+
+1. Fetch backlog: issues labeled `status:refined`
+2. Check velocity history from previous sprints
+3. ICE score each issue: Impact (1-10) × Confidence (1-10) × Ease (1-10)
+4. Build dependency graph — identify blocking chains
+5. Select scope within velocity budget (~20% buffer)
+6. Assign milestone and `status:planned` label
+
+## Sizing Guide
+
+| Effort | Diff Lines | Description |
+|--------|-----------|-------------|
+| 1      | <50       | Small — single file, straightforward |
+| 2      | ~150      | Medium — multiple files, some complexity |
+| 3      | ~300      | Large — architectural change, many files |
+
+## Constraints
+
+- Never exceed `max_issues` from config
+- Respect dependency order
+- Escalate if >2 unplanned issues appear mid-sprint

--- a/examples/go/.aiscrum/roles/refiner/prompts/refinement.md
+++ b/examples/go/.aiscrum/roles/refiner/prompts/refinement.md
@@ -1,0 +1,25 @@
+Refine all `type:idea` issues into concrete, implementable work items for {{PROJECT_NAME}}.
+
+## Process
+
+1. **Discover** all `type:idea` issues
+2. **Research** — check codebase, ADRs, dependencies, existing tests
+3. **Break down** each idea into concrete issues with:
+   - Clear title
+   - Problem statement
+   - ≥3 testable acceptance criteria
+   - Effort estimate (1=small <50 lines, 2=medium ~150 lines, 3=large ~300 lines)
+   - Labels: type (feature/bug/chore), priority, component
+4. **ICE score** each refined issue
+5. **Create issues** via GitHub
+
+## Constraints
+
+- Do NOT implement code — refinement only
+- Never descope ideas without stakeholder approval
+- Do NOT modify ADRs
+- Do NOT assign to sprints — that is the planner's job
+
+## Output
+
+JSON with: refined_issues array, skipped_ideas with reasons, totals

--- a/examples/go/.aiscrum/roles/refiner/skills/codebase-research/SKILL.md
+++ b/examples/go/.aiscrum/roles/refiner/skills/codebase-research/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: codebase-research
+description: Research codebase to inform refinement and planning decisions.
+---
+
+## When to Use
+
+- Before writing acceptance criteria
+- When an idea references existing functionality
+- When estimating implementation effort
+
+## Steps
+
+1. Search for related code (grep, file search, symbol lookup)
+2. Check architecture decisions and documentation
+3. Review dependencies and package configuration
+4. Find existing tests for related functionality
+
+## Output
+
+Provide evidence-based findings with file references to inform refinement.

--- a/examples/go/.aiscrum/roles/refiner/skills/issue-editing/SKILL.md
+++ b/examples/go/.aiscrum/roles/refiner/skills/issue-editing/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: issue-editing
+description: Create and edit GitHub issues via gh CLI.
+---
+
+## When to Use
+
+- Updating issue body after refinement
+- Managing labels during status transitions
+- Adding documentation comments to issues
+
+## Commands
+
+- `gh issue view <number> --json title,body,labels` — read issue
+- `gh issue edit <number> --body "<body>"` — update body
+- `gh issue edit <number> --add-label "label"` — add label
+- `gh issue edit <number> --remove-label "label"` — remove label
+- `gh issue comment <number> --body "<comment>"` — add comment
+- `gh issue create --title "..." --body "..." --label "..."` — create new issue
+
+## Rules
+
+- Always read the full issue before editing
+- Show proposed body to user before saving
+- Never remove labels without stating why

--- a/examples/go/.aiscrum/roles/retro/prompts/retro.md
+++ b/examples/go/.aiscrum/roles/retro/prompts/retro.md
@@ -1,0 +1,27 @@
+Run retrospective for Sprint {{SPRINT_NUMBER}} of {{PROJECT_NAME}}.
+
+## Process
+
+1. **Review previous retro** — check if improvements were adopted
+2. **What went well** — backed by data (metrics, completed issues)
+3. **What went poorly** — backed by data (failures, delays, drift)
+4. **Analyze metrics** — velocity, completion rate, CI failures, drift, estimation accuracy
+5. **Root cause analysis** — for each problem, identify the underlying cause
+6. **Propose improvements** — concrete, actionable changes:
+   - Config changes (models, gates, limits)
+   - Agent instruction updates
+   - New skills
+   - Process changes
+   - Tooling improvements
+7. **Evaluate agents** — which roles performed well/poorly and why
+
+## Constraints
+
+- Data-driven only — no speculation
+- Do NOT create GitHub issues (system handles that)
+- Do NOT modify ADRs without stakeholder confirmation
+- Stakeholder authority is absolute
+
+## Output
+
+JSON with: went_well, went_poorly, improvements array (problem, root_cause, action, expected_outcome, category), metrics

--- a/examples/go/.aiscrum/roles/retro/skills/copilot-authoring/SKILL.md
+++ b/examples/go/.aiscrum/roles/retro/skills/copilot-authoring/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: copilot-authoring
+description: Guide for modifying agent configurations (copilot-instructions.md and SKILL.md).
+---
+
+## When to Use
+
+- Applying retro improvements to agent instructions
+- Creating new skills based on sprint learnings
+- Fixing recurring agent errors by updating guidance
+
+## Agent Structure
+
+```
+.aiscrum/roles/<role>/
+├── copilot-instructions.md    # Core role definition
+├── prompts/                   # Task-specific prompt templates
+│   └── <task>.md
+└── skills/                    # Reusable capability definitions
+    └── <skill-name>/
+        └── SKILL.md
+```
+
+## Modification Rules
+
+- Make surgical changes — edit specific sections, not full rewrites
+- Preserve existing structure and formatting
+- Add guidance, don't remove working instructions
+- Keep CLI commands accurate
+- Preserve stakeholder authority rules
+- One improvement per change
+
+## Safety
+
+- Never modify log directories
+- Propose changes before applying
+- Preserve existing behavior
+- Test that modified files are valid markdown

--- a/examples/go/.aiscrum/roles/reviewer/prompts/review.md
+++ b/examples/go/.aiscrum/roles/reviewer/prompts/review.md
@@ -1,0 +1,26 @@
+Create Sprint {{SPRINT_NUMBER}} review for {{PROJECT_NAME}}.
+
+## Process
+
+1. **Gather results** — check each sprint issue: closed/open status, PR diffs
+2. **Change summary** — git diff stats per issue
+3. **Calculate metrics**:
+   - Issues planned vs completed
+   - Completion rate
+   - Velocity (story points or issue count)
+   - Trend vs previous sprints
+   - Drift incidents
+4. **Update velocity** — append to velocity tracking document
+5. **Identify carryover** — unfinished items with reasons
+6. **Notify stakeholder** — summary of deliverables
+
+## Drift Check
+
+- All PRs correspond to planned issues
+- No direct pushes to {{BASE_BRANCH}}
+- Unplanned work stayed in backlog
+- Changed files relate to assigned issues
+
+## Output
+
+JSON with: metrics, deliverables array, carryover array, notification_status

--- a/examples/go/.aiscrum/roles/reviewer/skills/code-review/SKILL.md
+++ b/examples/go/.aiscrum/roles/reviewer/skills/code-review/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: code-review
+description: Review pull requests for correctness, security, and logic errors.
+---
+
+## When to Use
+
+- Reviewing a PR before merge
+- Auditing staged changes
+- Checking Definition of Done compliance
+
+## Steps
+
+1. Read the diff: `gh pr diff <number>`
+2. Check DoD: tests added/updated, lint clean, docs updated if needed
+3. Run tests to verify they pass
+4. Check scope: changes match issue scope — flag unrelated additions
+5. Provide structured feedback with blocking vs. non-blocking findings
+
+## Rules
+
+- Do NOT modify code — only report findings
+- Focus on correctness, security, and logic (ignore style/formatting)
+- Flag missing tests as blocking
+- Verify CI status before approving

--- a/examples/go/.aiscrum/roles/reviewer/skills/tdd-workflow/SKILL.md
+++ b/examples/go/.aiscrum/roles/reviewer/skills/tdd-workflow/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: tdd-workflow
+description: Test-Driven Development cycle for writing tests before implementation.
+---
+
+## When to Use
+
+- Writing tests before implementation code
+- Verifying a bug fix with regression test (red → green)
+- Checking test coverage
+
+## Steps
+
+1. Write test first — based on acceptance criteria
+2. Run tests — verify they FAIL (red phase)
+3. Implement — write minimal code to make tests pass (green phase)
+4. Refactor — clean up while keeping tests green
+5. Check coverage — ensure new code is covered
+
+## Verify
+
+- Tests should fail before implementation exists
+- Tests should pass after implementation
+- Coverage should not decrease

--- a/examples/go/.aiscrum/roles/test-engineer/prompts/tdd.md
+++ b/examples/go/.aiscrum/roles/test-engineer/prompts/tdd.md
@@ -1,0 +1,20 @@
+Write tests for issue #{{ISSUE_NUMBER}}: "{{ISSUE_TITLE}}"
+
+## Acceptance Criteria
+
+{{ISSUE_BODY}}
+
+## Implementation Plan
+
+{{IMPLEMENTATION_PLAN}}
+
+## Instructions
+
+Write tests BEFORE implementation based on the acceptance criteria and plan.
+
+1. Analyze each acceptance criterion
+2. Create test files verifying expected behavior
+3. Cover all criteria plus edge cases and error paths
+4. Tests should FAIL initially — the developer implements code to make them pass
+
+Use the project's existing test framework and conventions. Write specific, meaningful tests — not vague assertions.

--- a/examples/python/.aiscrum/roles/general/prompts/worker.md
+++ b/examples/python/.aiscrum/roles/general/prompts/worker.md
@@ -1,0 +1,29 @@
+Implement issue #{{ISSUE_NUMBER}}: "{{ISSUE_TITLE}}"
+
+## Issue Body
+
+{{ISSUE_BODY}}
+
+## Instructions
+
+1. **Parse** the issue title and body — understand exactly what is requested
+2. **Plan** — list files to modify/create before writing code
+3. **Write tests** — at least 3 tests per feature, regression test for bugs
+4. **Implement** — keep diff under {{MAX_DIFF_LINES}} lines (aim for ~150)
+5. **Verify** — run all quality gates:
+   - Tests pass
+   - Lint clean
+   - Types clean
+   - Build passes
+   - Diff within size limit
+6. **Commit** — use conventional commit format: `feat|fix|refactor(scope): description`
+7. **Push** — push to branch `{{BRANCH_NAME}}`
+8. **PR** — create PR linking to issue #{{ISSUE_NUMBER}}
+
+## Rules
+
+- Work in worktree: `{{WORKTREE_PATH}}`
+- Base branch: `{{BASE_BRANCH}}`
+- Follow existing code conventions and patterns
+- No completion claims without fresh verification evidence
+- If blocked, escalate — do not guess or assume

--- a/examples/python/.aiscrum/roles/planner/prompts/item-planner.md
+++ b/examples/python/.aiscrum/roles/planner/prompts/item-planner.md
@@ -1,0 +1,23 @@
+Create an implementation plan for issue #{{ISSUE_NUMBER}}: "{{ISSUE_TITLE}}"
+
+## Issue Body
+
+{{ISSUE_BODY}}
+
+## Instructions
+
+Analyze the codebase and produce a detailed plan. Do NOT make any changes.
+
+1. Identify files to modify/create
+2. Understand current code state and dependencies
+3. Plan test strategy
+4. Estimate diff size
+
+## Output
+
+JSON with:
+- summary: one-line description
+- steps: array of { action: "create"|"modify"|"test", file, details }
+- test_strategy: what to test and how
+- risks: potential issues
+- estimated_diff_lines: number (must be under {{MAX_DIFF_LINES}})

--- a/examples/python/.aiscrum/roles/planner/prompts/planning.md
+++ b/examples/python/.aiscrum/roles/planner/prompts/planning.md
@@ -1,0 +1,29 @@
+Plan Sprint {{SPRINT_NUMBER}} for {{PROJECT_NAME}}.
+
+## Backlog
+
+Select issues from the backlog for this sprint.
+
+## Process
+
+1. **Review eligible issues** — labeled `status:refined` but NOT `status:planned` or `status:in-progress`
+2. **Apply priority rules**:
+   - Stakeholder-flagged issues first
+   - Bugs before features
+   - ICE score (Impact × Confidence × Ease, each 1-10)
+   - Dependency order
+3. **Calculate capacity** — use 3-sprint velocity average with ~20% buffer
+4. **Analyze dependencies** — identify blocking chains and parallelizable work
+5. **Structure execution groups** — group parallel work, sequence dependent work
+6. **Apply labels** — `status:planned` + milestone "Sprint {{SPRINT_NUMBER}}"
+
+## Constraints
+
+- Minimum issues: {{MIN_ISSUES}}
+- Maximum issues: {{MAX_ISSUES}}
+- Never exceed max — quality over quantity
+- Escalate if insufficient capacity for critical issues
+
+## Output
+
+JSON with: selected_issues, execution_groups, effort_estimation, rationale

--- a/examples/python/.aiscrum/roles/planner/skills/sprint-planning/SKILL.md
+++ b/examples/python/.aiscrum/roles/planner/skills/sprint-planning/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: sprint-planning
+description: Sprint planning workflow with ICE scoring and velocity-based sizing.
+---
+
+## When to Use
+
+- Starting a new sprint
+- Re-evaluating sprint scope
+- Triaging newly refined issues
+
+## Steps
+
+1. Fetch backlog: issues labeled `status:refined`
+2. Check velocity history from previous sprints
+3. ICE score each issue: Impact (1-10) × Confidence (1-10) × Ease (1-10)
+4. Build dependency graph — identify blocking chains
+5. Select scope within velocity budget (~20% buffer)
+6. Assign milestone and `status:planned` label
+
+## Sizing Guide
+
+| Effort | Diff Lines | Description |
+|--------|-----------|-------------|
+| 1      | <50       | Small — single file, straightforward |
+| 2      | ~150      | Medium — multiple files, some complexity |
+| 3      | ~300      | Large — architectural change, many files |
+
+## Constraints
+
+- Never exceed `max_issues` from config
+- Respect dependency order
+- Escalate if >2 unplanned issues appear mid-sprint

--- a/examples/python/.aiscrum/roles/refiner/prompts/refinement.md
+++ b/examples/python/.aiscrum/roles/refiner/prompts/refinement.md
@@ -1,0 +1,25 @@
+Refine all `type:idea` issues into concrete, implementable work items for {{PROJECT_NAME}}.
+
+## Process
+
+1. **Discover** all `type:idea` issues
+2. **Research** — check codebase, ADRs, dependencies, existing tests
+3. **Break down** each idea into concrete issues with:
+   - Clear title
+   - Problem statement
+   - ≥3 testable acceptance criteria
+   - Effort estimate (1=small <50 lines, 2=medium ~150 lines, 3=large ~300 lines)
+   - Labels: type (feature/bug/chore), priority, component
+4. **ICE score** each refined issue
+5. **Create issues** via GitHub
+
+## Constraints
+
+- Do NOT implement code — refinement only
+- Never descope ideas without stakeholder approval
+- Do NOT modify ADRs
+- Do NOT assign to sprints — that is the planner's job
+
+## Output
+
+JSON with: refined_issues array, skipped_ideas with reasons, totals

--- a/examples/python/.aiscrum/roles/refiner/skills/codebase-research/SKILL.md
+++ b/examples/python/.aiscrum/roles/refiner/skills/codebase-research/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: codebase-research
+description: Research codebase to inform refinement and planning decisions.
+---
+
+## When to Use
+
+- Before writing acceptance criteria
+- When an idea references existing functionality
+- When estimating implementation effort
+
+## Steps
+
+1. Search for related code (grep, file search, symbol lookup)
+2. Check architecture decisions and documentation
+3. Review dependencies and package configuration
+4. Find existing tests for related functionality
+
+## Output
+
+Provide evidence-based findings with file references to inform refinement.

--- a/examples/python/.aiscrum/roles/refiner/skills/issue-editing/SKILL.md
+++ b/examples/python/.aiscrum/roles/refiner/skills/issue-editing/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: issue-editing
+description: Create and edit GitHub issues via gh CLI.
+---
+
+## When to Use
+
+- Updating issue body after refinement
+- Managing labels during status transitions
+- Adding documentation comments to issues
+
+## Commands
+
+- `gh issue view <number> --json title,body,labels` — read issue
+- `gh issue edit <number> --body "<body>"` — update body
+- `gh issue edit <number> --add-label "label"` — add label
+- `gh issue edit <number> --remove-label "label"` — remove label
+- `gh issue comment <number> --body "<comment>"` — add comment
+- `gh issue create --title "..." --body "..." --label "..."` — create new issue
+
+## Rules
+
+- Always read the full issue before editing
+- Show proposed body to user before saving
+- Never remove labels without stating why

--- a/examples/python/.aiscrum/roles/retro/prompts/retro.md
+++ b/examples/python/.aiscrum/roles/retro/prompts/retro.md
@@ -1,0 +1,27 @@
+Run retrospective for Sprint {{SPRINT_NUMBER}} of {{PROJECT_NAME}}.
+
+## Process
+
+1. **Review previous retro** — check if improvements were adopted
+2. **What went well** — backed by data (metrics, completed issues)
+3. **What went poorly** — backed by data (failures, delays, drift)
+4. **Analyze metrics** — velocity, completion rate, CI failures, drift, estimation accuracy
+5. **Root cause analysis** — for each problem, identify the underlying cause
+6. **Propose improvements** — concrete, actionable changes:
+   - Config changes (models, gates, limits)
+   - Agent instruction updates
+   - New skills
+   - Process changes
+   - Tooling improvements
+7. **Evaluate agents** — which roles performed well/poorly and why
+
+## Constraints
+
+- Data-driven only — no speculation
+- Do NOT create GitHub issues (system handles that)
+- Do NOT modify ADRs without stakeholder confirmation
+- Stakeholder authority is absolute
+
+## Output
+
+JSON with: went_well, went_poorly, improvements array (problem, root_cause, action, expected_outcome, category), metrics

--- a/examples/python/.aiscrum/roles/retro/skills/copilot-authoring/SKILL.md
+++ b/examples/python/.aiscrum/roles/retro/skills/copilot-authoring/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: copilot-authoring
+description: Guide for modifying agent configurations (copilot-instructions.md and SKILL.md).
+---
+
+## When to Use
+
+- Applying retro improvements to agent instructions
+- Creating new skills based on sprint learnings
+- Fixing recurring agent errors by updating guidance
+
+## Agent Structure
+
+```
+.aiscrum/roles/<role>/
+├── copilot-instructions.md    # Core role definition
+├── prompts/                   # Task-specific prompt templates
+│   └── <task>.md
+└── skills/                    # Reusable capability definitions
+    └── <skill-name>/
+        └── SKILL.md
+```
+
+## Modification Rules
+
+- Make surgical changes — edit specific sections, not full rewrites
+- Preserve existing structure and formatting
+- Add guidance, don't remove working instructions
+- Keep CLI commands accurate
+- Preserve stakeholder authority rules
+- One improvement per change
+
+## Safety
+
+- Never modify log directories
+- Propose changes before applying
+- Preserve existing behavior
+- Test that modified files are valid markdown

--- a/examples/python/.aiscrum/roles/reviewer/prompts/review.md
+++ b/examples/python/.aiscrum/roles/reviewer/prompts/review.md
@@ -1,0 +1,26 @@
+Create Sprint {{SPRINT_NUMBER}} review for {{PROJECT_NAME}}.
+
+## Process
+
+1. **Gather results** — check each sprint issue: closed/open status, PR diffs
+2. **Change summary** — git diff stats per issue
+3. **Calculate metrics**:
+   - Issues planned vs completed
+   - Completion rate
+   - Velocity (story points or issue count)
+   - Trend vs previous sprints
+   - Drift incidents
+4. **Update velocity** — append to velocity tracking document
+5. **Identify carryover** — unfinished items with reasons
+6. **Notify stakeholder** — summary of deliverables
+
+## Drift Check
+
+- All PRs correspond to planned issues
+- No direct pushes to {{BASE_BRANCH}}
+- Unplanned work stayed in backlog
+- Changed files relate to assigned issues
+
+## Output
+
+JSON with: metrics, deliverables array, carryover array, notification_status

--- a/examples/python/.aiscrum/roles/reviewer/skills/code-review/SKILL.md
+++ b/examples/python/.aiscrum/roles/reviewer/skills/code-review/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: code-review
+description: Review pull requests for correctness, security, and logic errors.
+---
+
+## When to Use
+
+- Reviewing a PR before merge
+- Auditing staged changes
+- Checking Definition of Done compliance
+
+## Steps
+
+1. Read the diff: `gh pr diff <number>`
+2. Check DoD: tests added/updated, lint clean, docs updated if needed
+3. Run tests to verify they pass
+4. Check scope: changes match issue scope — flag unrelated additions
+5. Provide structured feedback with blocking vs. non-blocking findings
+
+## Rules
+
+- Do NOT modify code — only report findings
+- Focus on correctness, security, and logic (ignore style/formatting)
+- Flag missing tests as blocking
+- Verify CI status before approving

--- a/examples/python/.aiscrum/roles/reviewer/skills/tdd-workflow/SKILL.md
+++ b/examples/python/.aiscrum/roles/reviewer/skills/tdd-workflow/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: tdd-workflow
+description: Test-Driven Development cycle for writing tests before implementation.
+---
+
+## When to Use
+
+- Writing tests before implementation code
+- Verifying a bug fix with regression test (red → green)
+- Checking test coverage
+
+## Steps
+
+1. Write test first — based on acceptance criteria
+2. Run tests — verify they FAIL (red phase)
+3. Implement — write minimal code to make tests pass (green phase)
+4. Refactor — clean up while keeping tests green
+5. Check coverage — ensure new code is covered
+
+## Verify
+
+- Tests should fail before implementation exists
+- Tests should pass after implementation
+- Coverage should not decrease

--- a/examples/python/.aiscrum/roles/test-engineer/prompts/tdd.md
+++ b/examples/python/.aiscrum/roles/test-engineer/prompts/tdd.md
@@ -1,0 +1,20 @@
+Write tests for issue #{{ISSUE_NUMBER}}: "{{ISSUE_TITLE}}"
+
+## Acceptance Criteria
+
+{{ISSUE_BODY}}
+
+## Implementation Plan
+
+{{IMPLEMENTATION_PLAN}}
+
+## Instructions
+
+Write tests BEFORE implementation based on the acceptance criteria and plan.
+
+1. Analyze each acceptance criterion
+2. Create test files verifying expected behavior
+3. Cover all criteria plus edge cases and error paths
+4. Tests should FAIL initially — the developer implements code to make them pass
+
+Use the project's existing test framework and conventions. Write specific, meaningful tests — not vague assertions.

--- a/examples/react/.aiscrum/roles/general/prompts/worker.md
+++ b/examples/react/.aiscrum/roles/general/prompts/worker.md
@@ -1,0 +1,29 @@
+Implement issue #{{ISSUE_NUMBER}}: "{{ISSUE_TITLE}}"
+
+## Issue Body
+
+{{ISSUE_BODY}}
+
+## Instructions
+
+1. **Parse** the issue title and body — understand exactly what is requested
+2. **Plan** — list files to modify/create before writing code
+3. **Write tests** — at least 3 tests per feature, regression test for bugs
+4. **Implement** — keep diff under {{MAX_DIFF_LINES}} lines (aim for ~150)
+5. **Verify** — run all quality gates:
+   - Tests pass
+   - Lint clean
+   - Types clean
+   - Build passes
+   - Diff within size limit
+6. **Commit** — use conventional commit format: `feat|fix|refactor(scope): description`
+7. **Push** — push to branch `{{BRANCH_NAME}}`
+8. **PR** — create PR linking to issue #{{ISSUE_NUMBER}}
+
+## Rules
+
+- Work in worktree: `{{WORKTREE_PATH}}`
+- Base branch: `{{BASE_BRANCH}}`
+- Follow existing code conventions and patterns
+- No completion claims without fresh verification evidence
+- If blocked, escalate — do not guess or assume

--- a/examples/react/.aiscrum/roles/planner/prompts/item-planner.md
+++ b/examples/react/.aiscrum/roles/planner/prompts/item-planner.md
@@ -1,0 +1,23 @@
+Create an implementation plan for issue #{{ISSUE_NUMBER}}: "{{ISSUE_TITLE}}"
+
+## Issue Body
+
+{{ISSUE_BODY}}
+
+## Instructions
+
+Analyze the codebase and produce a detailed plan. Do NOT make any changes.
+
+1. Identify files to modify/create
+2. Understand current code state and dependencies
+3. Plan test strategy
+4. Estimate diff size
+
+## Output
+
+JSON with:
+- summary: one-line description
+- steps: array of { action: "create"|"modify"|"test", file, details }
+- test_strategy: what to test and how
+- risks: potential issues
+- estimated_diff_lines: number (must be under {{MAX_DIFF_LINES}})

--- a/examples/react/.aiscrum/roles/planner/prompts/planning.md
+++ b/examples/react/.aiscrum/roles/planner/prompts/planning.md
@@ -1,0 +1,29 @@
+Plan Sprint {{SPRINT_NUMBER}} for {{PROJECT_NAME}}.
+
+## Backlog
+
+Select issues from the backlog for this sprint.
+
+## Process
+
+1. **Review eligible issues** — labeled `status:refined` but NOT `status:planned` or `status:in-progress`
+2. **Apply priority rules**:
+   - Stakeholder-flagged issues first
+   - Bugs before features
+   - ICE score (Impact × Confidence × Ease, each 1-10)
+   - Dependency order
+3. **Calculate capacity** — use 3-sprint velocity average with ~20% buffer
+4. **Analyze dependencies** — identify blocking chains and parallelizable work
+5. **Structure execution groups** — group parallel work, sequence dependent work
+6. **Apply labels** — `status:planned` + milestone "Sprint {{SPRINT_NUMBER}}"
+
+## Constraints
+
+- Minimum issues: {{MIN_ISSUES}}
+- Maximum issues: {{MAX_ISSUES}}
+- Never exceed max — quality over quantity
+- Escalate if insufficient capacity for critical issues
+
+## Output
+
+JSON with: selected_issues, execution_groups, effort_estimation, rationale

--- a/examples/react/.aiscrum/roles/planner/skills/sprint-planning/SKILL.md
+++ b/examples/react/.aiscrum/roles/planner/skills/sprint-planning/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: sprint-planning
+description: Sprint planning workflow with ICE scoring and velocity-based sizing.
+---
+
+## When to Use
+
+- Starting a new sprint
+- Re-evaluating sprint scope
+- Triaging newly refined issues
+
+## Steps
+
+1. Fetch backlog: issues labeled `status:refined`
+2. Check velocity history from previous sprints
+3. ICE score each issue: Impact (1-10) × Confidence (1-10) × Ease (1-10)
+4. Build dependency graph — identify blocking chains
+5. Select scope within velocity budget (~20% buffer)
+6. Assign milestone and `status:planned` label
+
+## Sizing Guide
+
+| Effort | Diff Lines | Description |
+|--------|-----------|-------------|
+| 1      | <50       | Small — single file, straightforward |
+| 2      | ~150      | Medium — multiple files, some complexity |
+| 3      | ~300      | Large — architectural change, many files |
+
+## Constraints
+
+- Never exceed `max_issues` from config
+- Respect dependency order
+- Escalate if >2 unplanned issues appear mid-sprint

--- a/examples/react/.aiscrum/roles/refiner/prompts/refinement.md
+++ b/examples/react/.aiscrum/roles/refiner/prompts/refinement.md
@@ -1,0 +1,25 @@
+Refine all `type:idea` issues into concrete, implementable work items for {{PROJECT_NAME}}.
+
+## Process
+
+1. **Discover** all `type:idea` issues
+2. **Research** — check codebase, ADRs, dependencies, existing tests
+3. **Break down** each idea into concrete issues with:
+   - Clear title
+   - Problem statement
+   - ≥3 testable acceptance criteria
+   - Effort estimate (1=small <50 lines, 2=medium ~150 lines, 3=large ~300 lines)
+   - Labels: type (feature/bug/chore), priority, component
+4. **ICE score** each refined issue
+5. **Create issues** via GitHub
+
+## Constraints
+
+- Do NOT implement code — refinement only
+- Never descope ideas without stakeholder approval
+- Do NOT modify ADRs
+- Do NOT assign to sprints — that is the planner's job
+
+## Output
+
+JSON with: refined_issues array, skipped_ideas with reasons, totals

--- a/examples/react/.aiscrum/roles/refiner/skills/codebase-research/SKILL.md
+++ b/examples/react/.aiscrum/roles/refiner/skills/codebase-research/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: codebase-research
+description: Research codebase to inform refinement and planning decisions.
+---
+
+## When to Use
+
+- Before writing acceptance criteria
+- When an idea references existing functionality
+- When estimating implementation effort
+
+## Steps
+
+1. Search for related code (grep, file search, symbol lookup)
+2. Check architecture decisions and documentation
+3. Review dependencies and package configuration
+4. Find existing tests for related functionality
+
+## Output
+
+Provide evidence-based findings with file references to inform refinement.

--- a/examples/react/.aiscrum/roles/refiner/skills/issue-editing/SKILL.md
+++ b/examples/react/.aiscrum/roles/refiner/skills/issue-editing/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: issue-editing
+description: Create and edit GitHub issues via gh CLI.
+---
+
+## When to Use
+
+- Updating issue body after refinement
+- Managing labels during status transitions
+- Adding documentation comments to issues
+
+## Commands
+
+- `gh issue view <number> --json title,body,labels` — read issue
+- `gh issue edit <number> --body "<body>"` — update body
+- `gh issue edit <number> --add-label "label"` — add label
+- `gh issue edit <number> --remove-label "label"` — remove label
+- `gh issue comment <number> --body "<comment>"` — add comment
+- `gh issue create --title "..." --body "..." --label "..."` — create new issue
+
+## Rules
+
+- Always read the full issue before editing
+- Show proposed body to user before saving
+- Never remove labels without stating why

--- a/examples/react/.aiscrum/roles/retro/prompts/retro.md
+++ b/examples/react/.aiscrum/roles/retro/prompts/retro.md
@@ -1,0 +1,27 @@
+Run retrospective for Sprint {{SPRINT_NUMBER}} of {{PROJECT_NAME}}.
+
+## Process
+
+1. **Review previous retro** — check if improvements were adopted
+2. **What went well** — backed by data (metrics, completed issues)
+3. **What went poorly** — backed by data (failures, delays, drift)
+4. **Analyze metrics** — velocity, completion rate, CI failures, drift, estimation accuracy
+5. **Root cause analysis** — for each problem, identify the underlying cause
+6. **Propose improvements** — concrete, actionable changes:
+   - Config changes (models, gates, limits)
+   - Agent instruction updates
+   - New skills
+   - Process changes
+   - Tooling improvements
+7. **Evaluate agents** — which roles performed well/poorly and why
+
+## Constraints
+
+- Data-driven only — no speculation
+- Do NOT create GitHub issues (system handles that)
+- Do NOT modify ADRs without stakeholder confirmation
+- Stakeholder authority is absolute
+
+## Output
+
+JSON with: went_well, went_poorly, improvements array (problem, root_cause, action, expected_outcome, category), metrics

--- a/examples/react/.aiscrum/roles/retro/skills/copilot-authoring/SKILL.md
+++ b/examples/react/.aiscrum/roles/retro/skills/copilot-authoring/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: copilot-authoring
+description: Guide for modifying agent configurations (copilot-instructions.md and SKILL.md).
+---
+
+## When to Use
+
+- Applying retro improvements to agent instructions
+- Creating new skills based on sprint learnings
+- Fixing recurring agent errors by updating guidance
+
+## Agent Structure
+
+```
+.aiscrum/roles/<role>/
+├── copilot-instructions.md    # Core role definition
+├── prompts/                   # Task-specific prompt templates
+│   └── <task>.md
+└── skills/                    # Reusable capability definitions
+    └── <skill-name>/
+        └── SKILL.md
+```
+
+## Modification Rules
+
+- Make surgical changes — edit specific sections, not full rewrites
+- Preserve existing structure and formatting
+- Add guidance, don't remove working instructions
+- Keep CLI commands accurate
+- Preserve stakeholder authority rules
+- One improvement per change
+
+## Safety
+
+- Never modify log directories
+- Propose changes before applying
+- Preserve existing behavior
+- Test that modified files are valid markdown

--- a/examples/react/.aiscrum/roles/reviewer/prompts/review.md
+++ b/examples/react/.aiscrum/roles/reviewer/prompts/review.md
@@ -1,0 +1,26 @@
+Create Sprint {{SPRINT_NUMBER}} review for {{PROJECT_NAME}}.
+
+## Process
+
+1. **Gather results** — check each sprint issue: closed/open status, PR diffs
+2. **Change summary** — git diff stats per issue
+3. **Calculate metrics**:
+   - Issues planned vs completed
+   - Completion rate
+   - Velocity (story points or issue count)
+   - Trend vs previous sprints
+   - Drift incidents
+4. **Update velocity** — append to velocity tracking document
+5. **Identify carryover** — unfinished items with reasons
+6. **Notify stakeholder** — summary of deliverables
+
+## Drift Check
+
+- All PRs correspond to planned issues
+- No direct pushes to {{BASE_BRANCH}}
+- Unplanned work stayed in backlog
+- Changed files relate to assigned issues
+
+## Output
+
+JSON with: metrics, deliverables array, carryover array, notification_status

--- a/examples/react/.aiscrum/roles/reviewer/skills/code-review/SKILL.md
+++ b/examples/react/.aiscrum/roles/reviewer/skills/code-review/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: code-review
+description: Review pull requests for correctness, security, and logic errors.
+---
+
+## When to Use
+
+- Reviewing a PR before merge
+- Auditing staged changes
+- Checking Definition of Done compliance
+
+## Steps
+
+1. Read the diff: `gh pr diff <number>`
+2. Check DoD: tests added/updated, lint clean, docs updated if needed
+3. Run tests to verify they pass
+4. Check scope: changes match issue scope — flag unrelated additions
+5. Provide structured feedback with blocking vs. non-blocking findings
+
+## Rules
+
+- Do NOT modify code — only report findings
+- Focus on correctness, security, and logic (ignore style/formatting)
+- Flag missing tests as blocking
+- Verify CI status before approving

--- a/examples/react/.aiscrum/roles/reviewer/skills/tdd-workflow/SKILL.md
+++ b/examples/react/.aiscrum/roles/reviewer/skills/tdd-workflow/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: tdd-workflow
+description: Test-Driven Development cycle for writing tests before implementation.
+---
+
+## When to Use
+
+- Writing tests before implementation code
+- Verifying a bug fix with regression test (red → green)
+- Checking test coverage
+
+## Steps
+
+1. Write test first — based on acceptance criteria
+2. Run tests — verify they FAIL (red phase)
+3. Implement — write minimal code to make tests pass (green phase)
+4. Refactor — clean up while keeping tests green
+5. Check coverage — ensure new code is covered
+
+## Verify
+
+- Tests should fail before implementation exists
+- Tests should pass after implementation
+- Coverage should not decrease

--- a/examples/react/.aiscrum/roles/test-engineer/prompts/tdd.md
+++ b/examples/react/.aiscrum/roles/test-engineer/prompts/tdd.md
@@ -1,0 +1,20 @@
+Write tests for issue #{{ISSUE_NUMBER}}: "{{ISSUE_TITLE}}"
+
+## Acceptance Criteria
+
+{{ISSUE_BODY}}
+
+## Implementation Plan
+
+{{IMPLEMENTATION_PLAN}}
+
+## Instructions
+
+Write tests BEFORE implementation based on the acceptance criteria and plan.
+
+1. Analyze each acceptance criterion
+2. Create test files verifying expected behavior
+3. Cover all criteria plus edge cases and error paths
+4. Tests should FAIL initially — the developer implements code to make them pass
+
+Use the project's existing test framework and conventions. Write specific, meaningful tests — not vague assertions.

--- a/examples/typescript/.aiscrum/roles/general/prompts/worker.md
+++ b/examples/typescript/.aiscrum/roles/general/prompts/worker.md
@@ -1,0 +1,29 @@
+Implement issue #{{ISSUE_NUMBER}}: "{{ISSUE_TITLE}}"
+
+## Issue Body
+
+{{ISSUE_BODY}}
+
+## Instructions
+
+1. **Parse** the issue title and body — understand exactly what is requested
+2. **Plan** — list files to modify/create before writing code
+3. **Write tests** — at least 3 tests per feature, regression test for bugs
+4. **Implement** — keep diff under {{MAX_DIFF_LINES}} lines (aim for ~150)
+5. **Verify** — run all quality gates:
+   - Tests pass
+   - Lint clean
+   - Types clean
+   - Build passes
+   - Diff within size limit
+6. **Commit** — use conventional commit format: `feat|fix|refactor(scope): description`
+7. **Push** — push to branch `{{BRANCH_NAME}}`
+8. **PR** — create PR linking to issue #{{ISSUE_NUMBER}}
+
+## Rules
+
+- Work in worktree: `{{WORKTREE_PATH}}`
+- Base branch: `{{BASE_BRANCH}}`
+- Follow existing code conventions and patterns
+- No completion claims without fresh verification evidence
+- If blocked, escalate — do not guess or assume

--- a/examples/typescript/.aiscrum/roles/planner/prompts/item-planner.md
+++ b/examples/typescript/.aiscrum/roles/planner/prompts/item-planner.md
@@ -1,0 +1,23 @@
+Create an implementation plan for issue #{{ISSUE_NUMBER}}: "{{ISSUE_TITLE}}"
+
+## Issue Body
+
+{{ISSUE_BODY}}
+
+## Instructions
+
+Analyze the codebase and produce a detailed plan. Do NOT make any changes.
+
+1. Identify files to modify/create
+2. Understand current code state and dependencies
+3. Plan test strategy
+4. Estimate diff size
+
+## Output
+
+JSON with:
+- summary: one-line description
+- steps: array of { action: "create"|"modify"|"test", file, details }
+- test_strategy: what to test and how
+- risks: potential issues
+- estimated_diff_lines: number (must be under {{MAX_DIFF_LINES}})

--- a/examples/typescript/.aiscrum/roles/planner/prompts/planning.md
+++ b/examples/typescript/.aiscrum/roles/planner/prompts/planning.md
@@ -1,0 +1,29 @@
+Plan Sprint {{SPRINT_NUMBER}} for {{PROJECT_NAME}}.
+
+## Backlog
+
+Select issues from the backlog for this sprint.
+
+## Process
+
+1. **Review eligible issues** — labeled `status:refined` but NOT `status:planned` or `status:in-progress`
+2. **Apply priority rules**:
+   - Stakeholder-flagged issues first
+   - Bugs before features
+   - ICE score (Impact × Confidence × Ease, each 1-10)
+   - Dependency order
+3. **Calculate capacity** — use 3-sprint velocity average with ~20% buffer
+4. **Analyze dependencies** — identify blocking chains and parallelizable work
+5. **Structure execution groups** — group parallel work, sequence dependent work
+6. **Apply labels** — `status:planned` + milestone "Sprint {{SPRINT_NUMBER}}"
+
+## Constraints
+
+- Minimum issues: {{MIN_ISSUES}}
+- Maximum issues: {{MAX_ISSUES}}
+- Never exceed max — quality over quantity
+- Escalate if insufficient capacity for critical issues
+
+## Output
+
+JSON with: selected_issues, execution_groups, effort_estimation, rationale

--- a/examples/typescript/.aiscrum/roles/planner/skills/sprint-planning/SKILL.md
+++ b/examples/typescript/.aiscrum/roles/planner/skills/sprint-planning/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: sprint-planning
+description: Sprint planning workflow with ICE scoring and velocity-based sizing.
+---
+
+## When to Use
+
+- Starting a new sprint
+- Re-evaluating sprint scope
+- Triaging newly refined issues
+
+## Steps
+
+1. Fetch backlog: issues labeled `status:refined`
+2. Check velocity history from previous sprints
+3. ICE score each issue: Impact (1-10) × Confidence (1-10) × Ease (1-10)
+4. Build dependency graph — identify blocking chains
+5. Select scope within velocity budget (~20% buffer)
+6. Assign milestone and `status:planned` label
+
+## Sizing Guide
+
+| Effort | Diff Lines | Description |
+|--------|-----------|-------------|
+| 1      | <50       | Small — single file, straightforward |
+| 2      | ~150      | Medium — multiple files, some complexity |
+| 3      | ~300      | Large — architectural change, many files |
+
+## Constraints
+
+- Never exceed `max_issues` from config
+- Respect dependency order
+- Escalate if >2 unplanned issues appear mid-sprint

--- a/examples/typescript/.aiscrum/roles/refiner/prompts/refinement.md
+++ b/examples/typescript/.aiscrum/roles/refiner/prompts/refinement.md
@@ -1,0 +1,25 @@
+Refine all `type:idea` issues into concrete, implementable work items for {{PROJECT_NAME}}.
+
+## Process
+
+1. **Discover** all `type:idea` issues
+2. **Research** — check codebase, ADRs, dependencies, existing tests
+3. **Break down** each idea into concrete issues with:
+   - Clear title
+   - Problem statement
+   - ≥3 testable acceptance criteria
+   - Effort estimate (1=small <50 lines, 2=medium ~150 lines, 3=large ~300 lines)
+   - Labels: type (feature/bug/chore), priority, component
+4. **ICE score** each refined issue
+5. **Create issues** via GitHub
+
+## Constraints
+
+- Do NOT implement code — refinement only
+- Never descope ideas without stakeholder approval
+- Do NOT modify ADRs
+- Do NOT assign to sprints — that is the planner's job
+
+## Output
+
+JSON with: refined_issues array, skipped_ideas with reasons, totals

--- a/examples/typescript/.aiscrum/roles/refiner/skills/codebase-research/SKILL.md
+++ b/examples/typescript/.aiscrum/roles/refiner/skills/codebase-research/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: codebase-research
+description: Research codebase to inform refinement and planning decisions.
+---
+
+## When to Use
+
+- Before writing acceptance criteria
+- When an idea references existing functionality
+- When estimating implementation effort
+
+## Steps
+
+1. Search for related code (grep, file search, symbol lookup)
+2. Check architecture decisions and documentation
+3. Review dependencies and package configuration
+4. Find existing tests for related functionality
+
+## Output
+
+Provide evidence-based findings with file references to inform refinement.

--- a/examples/typescript/.aiscrum/roles/refiner/skills/issue-editing/SKILL.md
+++ b/examples/typescript/.aiscrum/roles/refiner/skills/issue-editing/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: issue-editing
+description: Create and edit GitHub issues via gh CLI.
+---
+
+## When to Use
+
+- Updating issue body after refinement
+- Managing labels during status transitions
+- Adding documentation comments to issues
+
+## Commands
+
+- `gh issue view <number> --json title,body,labels` — read issue
+- `gh issue edit <number> --body "<body>"` — update body
+- `gh issue edit <number> --add-label "label"` — add label
+- `gh issue edit <number> --remove-label "label"` — remove label
+- `gh issue comment <number> --body "<comment>"` — add comment
+- `gh issue create --title "..." --body "..." --label "..."` — create new issue
+
+## Rules
+
+- Always read the full issue before editing
+- Show proposed body to user before saving
+- Never remove labels without stating why

--- a/examples/typescript/.aiscrum/roles/retro/prompts/retro.md
+++ b/examples/typescript/.aiscrum/roles/retro/prompts/retro.md
@@ -1,0 +1,27 @@
+Run retrospective for Sprint {{SPRINT_NUMBER}} of {{PROJECT_NAME}}.
+
+## Process
+
+1. **Review previous retro** — check if improvements were adopted
+2. **What went well** — backed by data (metrics, completed issues)
+3. **What went poorly** — backed by data (failures, delays, drift)
+4. **Analyze metrics** — velocity, completion rate, CI failures, drift, estimation accuracy
+5. **Root cause analysis** — for each problem, identify the underlying cause
+6. **Propose improvements** — concrete, actionable changes:
+   - Config changes (models, gates, limits)
+   - Agent instruction updates
+   - New skills
+   - Process changes
+   - Tooling improvements
+7. **Evaluate agents** — which roles performed well/poorly and why
+
+## Constraints
+
+- Data-driven only — no speculation
+- Do NOT create GitHub issues (system handles that)
+- Do NOT modify ADRs without stakeholder confirmation
+- Stakeholder authority is absolute
+
+## Output
+
+JSON with: went_well, went_poorly, improvements array (problem, root_cause, action, expected_outcome, category), metrics

--- a/examples/typescript/.aiscrum/roles/retro/skills/copilot-authoring/SKILL.md
+++ b/examples/typescript/.aiscrum/roles/retro/skills/copilot-authoring/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: copilot-authoring
+description: Guide for modifying agent configurations (copilot-instructions.md and SKILL.md).
+---
+
+## When to Use
+
+- Applying retro improvements to agent instructions
+- Creating new skills based on sprint learnings
+- Fixing recurring agent errors by updating guidance
+
+## Agent Structure
+
+```
+.aiscrum/roles/<role>/
+├── copilot-instructions.md    # Core role definition
+├── prompts/                   # Task-specific prompt templates
+│   └── <task>.md
+└── skills/                    # Reusable capability definitions
+    └── <skill-name>/
+        └── SKILL.md
+```
+
+## Modification Rules
+
+- Make surgical changes — edit specific sections, not full rewrites
+- Preserve existing structure and formatting
+- Add guidance, don't remove working instructions
+- Keep CLI commands accurate
+- Preserve stakeholder authority rules
+- One improvement per change
+
+## Safety
+
+- Never modify log directories
+- Propose changes before applying
+- Preserve existing behavior
+- Test that modified files are valid markdown

--- a/examples/typescript/.aiscrum/roles/reviewer/prompts/review.md
+++ b/examples/typescript/.aiscrum/roles/reviewer/prompts/review.md
@@ -1,0 +1,26 @@
+Create Sprint {{SPRINT_NUMBER}} review for {{PROJECT_NAME}}.
+
+## Process
+
+1. **Gather results** — check each sprint issue: closed/open status, PR diffs
+2. **Change summary** — git diff stats per issue
+3. **Calculate metrics**:
+   - Issues planned vs completed
+   - Completion rate
+   - Velocity (story points or issue count)
+   - Trend vs previous sprints
+   - Drift incidents
+4. **Update velocity** — append to velocity tracking document
+5. **Identify carryover** — unfinished items with reasons
+6. **Notify stakeholder** — summary of deliverables
+
+## Drift Check
+
+- All PRs correspond to planned issues
+- No direct pushes to {{BASE_BRANCH}}
+- Unplanned work stayed in backlog
+- Changed files relate to assigned issues
+
+## Output
+
+JSON with: metrics, deliverables array, carryover array, notification_status

--- a/examples/typescript/.aiscrum/roles/reviewer/skills/code-review/SKILL.md
+++ b/examples/typescript/.aiscrum/roles/reviewer/skills/code-review/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: code-review
+description: Review pull requests for correctness, security, and logic errors.
+---
+
+## When to Use
+
+- Reviewing a PR before merge
+- Auditing staged changes
+- Checking Definition of Done compliance
+
+## Steps
+
+1. Read the diff: `gh pr diff <number>`
+2. Check DoD: tests added/updated, lint clean, docs updated if needed
+3. Run tests to verify they pass
+4. Check scope: changes match issue scope — flag unrelated additions
+5. Provide structured feedback with blocking vs. non-blocking findings
+
+## Rules
+
+- Do NOT modify code — only report findings
+- Focus on correctness, security, and logic (ignore style/formatting)
+- Flag missing tests as blocking
+- Verify CI status before approving

--- a/examples/typescript/.aiscrum/roles/reviewer/skills/tdd-workflow/SKILL.md
+++ b/examples/typescript/.aiscrum/roles/reviewer/skills/tdd-workflow/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: tdd-workflow
+description: Test-Driven Development cycle for writing tests before implementation.
+---
+
+## When to Use
+
+- Writing tests before implementation code
+- Verifying a bug fix with regression test (red → green)
+- Checking test coverage
+
+## Steps
+
+1. Write test first — based on acceptance criteria
+2. Run tests — verify they FAIL (red phase)
+3. Implement — write minimal code to make tests pass (green phase)
+4. Refactor — clean up while keeping tests green
+5. Check coverage — ensure new code is covered
+
+## Verify
+
+- Tests should fail before implementation exists
+- Tests should pass after implementation
+- Coverage should not decrease

--- a/examples/typescript/.aiscrum/roles/test-engineer/prompts/tdd.md
+++ b/examples/typescript/.aiscrum/roles/test-engineer/prompts/tdd.md
@@ -1,0 +1,20 @@
+Write tests for issue #{{ISSUE_NUMBER}}: "{{ISSUE_TITLE}}"
+
+## Acceptance Criteria
+
+{{ISSUE_BODY}}
+
+## Implementation Plan
+
+{{IMPLEMENTATION_PLAN}}
+
+## Instructions
+
+Write tests BEFORE implementation based on the acceptance criteria and plan.
+
+1. Analyze each acceptance criterion
+2. Create test files verifying expected behavior
+3. Cover all criteria plus edge cases and error paths
+4. Tests should FAIL initially — the developer implements code to make them pass
+
+Use the project's existing test framework and conventions. Write specific, meaningful tests — not vague assertions.

--- a/tests/examples/example-configs.test.ts
+++ b/tests/examples/example-configs.test.ts
@@ -75,6 +75,116 @@ describe("example configs", () => {
         expect(config.quality_gates.test_command).toBeDefined();
         expect(config.quality_gates.lint_command).toBeDefined();
       });
+
+      it("has prompts for roles that need them", () => {
+        const promptMap: Record<string, string[]> = {
+          general: ["worker.md"],
+          planner: ["planning.md", "item-planner.md"],
+          refiner: ["refinement.md"],
+          reviewer: ["review.md"],
+          retro: ["retro.md"],
+          "test-engineer": ["tdd.md"],
+        };
+        for (const [role, prompts] of Object.entries(promptMap)) {
+          for (const prompt of prompts) {
+            const promptFile = path.join(
+              EXAMPLES_DIR,
+              stack,
+              ".aiscrum",
+              "roles",
+              role,
+              "prompts",
+              prompt,
+            );
+            expect(
+              fs.existsSync(promptFile),
+              `missing ${stack}/roles/${role}/prompts/${prompt}`,
+            ).toBe(true);
+          }
+        }
+      });
+
+      it("has skills for roles that need them", () => {
+        const skillMap: Record<string, string[]> = {
+          planner: ["sprint-planning"],
+          refiner: ["codebase-research", "issue-editing"],
+          reviewer: ["code-review", "tdd-workflow"],
+          retro: ["copilot-authoring"],
+        };
+        for (const [role, skills] of Object.entries(skillMap)) {
+          for (const skill of skills) {
+            const skillFile = path.join(
+              EXAMPLES_DIR,
+              stack,
+              ".aiscrum",
+              "roles",
+              role,
+              "skills",
+              skill,
+              "SKILL.md",
+            );
+            expect(
+              fs.existsSync(skillFile),
+              `missing ${stack}/roles/${role}/skills/${skill}/SKILL.md`,
+            ).toBe(true);
+          }
+        }
+      });
+    });
+  }
+});
+
+describe("prompts contain template variables", () => {
+  for (const stack of STACKS) {
+    it(`${stack} worker prompt has {{ISSUE_NUMBER}}`, () => {
+      const content = fs.readFileSync(
+        path.join(EXAMPLES_DIR, stack, ".aiscrum", "roles", "general", "prompts", "worker.md"),
+        "utf-8",
+      );
+      expect(content).toContain("{{ISSUE_NUMBER}}");
+      expect(content).toContain("{{ISSUE_TITLE}}");
+      expect(content).toContain("{{MAX_DIFF_LINES}}");
+    });
+
+    it(`${stack} planning prompt has {{SPRINT_NUMBER}}`, () => {
+      const content = fs.readFileSync(
+        path.join(EXAMPLES_DIR, stack, ".aiscrum", "roles", "planner", "prompts", "planning.md"),
+        "utf-8",
+      );
+      expect(content).toContain("{{SPRINT_NUMBER}}");
+      expect(content).toContain("{{PROJECT_NAME}}");
+    });
+  }
+});
+
+describe("skills have frontmatter", () => {
+  const allSkills = [
+    ["planner", "sprint-planning"],
+    ["refiner", "codebase-research"],
+    ["refiner", "issue-editing"],
+    ["reviewer", "code-review"],
+    ["reviewer", "tdd-workflow"],
+    ["retro", "copilot-authoring"],
+  ] as const;
+
+  for (const [role, skill] of allSkills) {
+    it(`${role}/${skill} has name and description frontmatter`, () => {
+      const content = fs.readFileSync(
+        path.join(
+          EXAMPLES_DIR,
+          "typescript",
+          ".aiscrum",
+          "roles",
+          role,
+          "skills",
+          skill,
+          "SKILL.md",
+        ),
+        "utf-8",
+      );
+      expect(content).toMatch(/^---/);
+      expect(content).toContain("name:");
+      expect(content).toContain("description:");
     });
   }
 });


### PR DESCRIPTION
Fills the gap — example configs now include the full .aiscrum/ structure matching the real setup.

## Added per role

| Role | Prompts | Skills |
|------|---------|--------|
| general | worker.md | — |
| planner | planning.md, item-planner.md | sprint-planning |
| refiner | refinement.md | codebase-research, issue-editing |
| reviewer | review.md | code-review, tdd-workflow |
| retro | retro.md | copilot-authoring |
| test-engineer | tdd.md | — |

All use `{{TEMPLATE_VARIABLE}}` placeholders. Skills have YAML frontmatter.

## Tests

148 passing (was 126) — new tests verify prompts exist, skills exist, template variables present, frontmatter valid.