### PR TITLE
chore(ci): add Dependabot, GitHub Releases and explicit publish provenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+version: 2
+
+updates:
+  # Root package — the CLI/engine itself.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    # Grouped so a quiet week lands as one PR instead of a dozen.
+    groups:
+      production-dependencies:
+        dependency-type: production
+        update-types: [minor, patch]
+      development-dependencies:
+        dependency-type: development
+        update-types: [minor, patch]
+
+  # The dashboard frontend has its own package.json + package-lock.json and is
+  # not an npm workspace, so Dependabot only sees it if it is declared here.
+  - package-ecosystem: npm
+    directory: /src/dashboard/frontend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      production-dependencies:
+        dependency-type: production
+        update-types: [minor, patch]
+      development-dependencies:
+        dependency-type: development
+        update-types: [minor, patch]
+
+  # Action versions used by ci.yml and release.yml.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
-# Publishes aiscrum-pro to npm using npm Trusted Publishing (GitHub Actions OIDC).
+# Publishes aiscrum-pro to npm using npm Trusted Publishing (GitHub Actions
+# OIDC), then mirrors the release on GitHub with notes taken from CHANGELOG.md.
 #
 # IMPORTANT: The file name must stay `.github/workflows/release.yml` — it is
 # registered as the trusted publisher on npmjs.com. Renaming it breaks OIDC auth.
@@ -14,14 +15,18 @@ on:
       - "v*"
   workflow_dispatch:
 
+# Least privilege by default; each job widens only what it needs.
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write # Required for Trusted Publishing (OIDC) and provenance.
 
     steps:
       - uses: actions/checkout@v4
@@ -44,6 +49,28 @@ jobs:
           npm install -g "npm@^11.5.1"
           npm --version
 
+      # A tag that disagrees with package.json publishes the wrong version
+      # number. Catch it before anything irreversible happens.
+      - name: Verify tag matches package.json
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "${TAG#v}" != "$PKG_VERSION" ]; then
+            echo "::error::Tag $TAG does not match package.json version $PKG_VERSION."
+            exit 1
+          fi
+          echo "Releasing $PKG_VERSION"
+
+      # The GitHub Release job needs these notes. Fail here rather than after
+      # the package is already on npm and cannot be unpublished.
+      - name: Verify CHANGELOG has release notes
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TAG: ${{ github.ref_name }}
+        run: node scripts/release-notes.mjs "$TAG" > /dev/null
+
       - name: Install dependencies
         run: npm ci
 
@@ -63,10 +90,60 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Package contents preview
-        run: npm pack --dry-run
+      # Doubles as the `files` allowlist check: the log lists everything that
+      # is about to ship.
+      - name: Pack tarball
+        run: npm pack
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-package
+          path: "*.tgz"
+          if-no-files-found: error
 
       # No NODE_AUTH_TOKEN / NPM_TOKEN: authentication happens via OIDC
       # against the trusted publisher configured on npmjs.com.
+      # `--provenance` is explicit so an unattested publish fails loudly
+      # instead of silently shipping without a supply-chain attestation.
       - name: Publish
-        run: npm publish --access public
+        run: npm publish --access public --provenance
+
+  github-release:
+    name: GitHub Release
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # Required to create the GitHub Release.
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-package
+          path: artifacts
+
+      - name: Extract release notes from CHANGELOG.md
+        env:
+          TAG: ${{ github.ref_name }}
+        run: node scripts/release-notes.mjs "$TAG" > release-notes.md
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Re-runnable: update in place if the release already exists.
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            gh release edit "$TAG" --title "$TAG" --notes-file release-notes.md
+            gh release upload "$TAG" artifacts/*.tgz --clobber
+          else
+            gh release create "$TAG" artifacts/*.tgz \
+              --title "$TAG" \
+              --notes-file release-notes.md \
+              --verify-tag
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ node_modules/
 dist/
 *.tsbuildinfo
 
+# Release tarballs from `npm pack`
+*.tgz
+
 # Testing
 coverage/
 .vitest/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- Dependabot config covering all three real ecosystems: npm at the repo root, npm for the nested `src/dashboard/frontend`, and github-actions (weekly, grouped)
+- GitHub Release step in the release workflow — attaches the `npm pack` tarball and takes notes from this file
+- `scripts/release-notes.mjs` — extracts a single version's notes from CHANGELOG.md, with tests
+- Release guard: a tag that disagrees with `package.json`, or a version with no CHANGELOG section, now fails before anything is published
+
+### Changed
+- `npm publish` now passes `--provenance` explicitly, so an unattested publish fails loudly instead of shipping silently
+- Release workflow permissions moved from workflow scope to per-job scope (`id-token: write` only for publishing, `contents: write` only for the GitHub Release)
+
 ## [0.4.0] — 2026-03-07
 
 ### Added

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Extracts the notes for a single version out of CHANGELOG.md so the release
+// workflow can feed them to `gh release create --notes-file`.
+//
+//   node scripts/release-notes.mjs v0.4.0 [path/to/CHANGELOG.md]
+//
+// Exits non-zero when the version has no section, so a release fails loudly
+// instead of publishing empty notes.
+
+import { readFileSync } from "node:fs";
+import { argv, exit, stdout } from "node:process";
+import { pathToFileURL } from "node:url";
+
+// Matches the heading styles already used in this CHANGELOG:
+//   "## [0.4.0] — 2026-03-07", "## v0.2.0", "## 0.2.0", "## [0.2.0](link)"
+const VERSION_HEADING = /^##\s+\[?v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\]?/;
+
+export function extractReleaseNotes(changelog, version) {
+  const wanted = String(version ?? "")
+    .trim()
+    .replace(/^v/, "");
+
+  if (!wanted) {
+    throw new Error("A version argument is required, e.g. `release-notes.mjs v0.4.0`.");
+  }
+
+  const lines = changelog.split(/\r?\n/);
+  const start = lines.findIndex((line) => VERSION_HEADING.exec(line)?.[1] === wanted);
+
+  if (start === -1) {
+    throw new Error(
+      `No CHANGELOG section found for version ${wanted}. ` +
+        `Add a "## [${wanted}]" heading before tagging the release.`,
+    );
+  }
+
+  // A section runs until the next level-2 heading (any heading, not just a
+  // version one, so "## [Unreleased]" also terminates it).
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => line.startsWith("## "));
+  const body = (end === -1 ? rest : rest.slice(0, end)).join("\n").trim();
+
+  if (!body) {
+    throw new Error(`The CHANGELOG section for version ${wanted} is empty.`);
+  }
+
+  return body;
+}
+
+function main() {
+  const [version, changelogPath = "CHANGELOG.md"] = argv.slice(2);
+
+  try {
+    stdout.write(`${extractReleaseNotes(readFileSync(changelogPath, "utf-8"), version)}\n`);
+  } catch (error) {
+    console.error(`release-notes: ${error.message}`);
+    exit(1);
+  }
+}
+
+// Only run the CLI when executed directly, so tests can import the function.
+if (argv[1] && import.meta.url === pathToFileURL(argv[1]).href) {
+  main();
+}

--- a/tests/release-notes.test.ts
+++ b/tests/release-notes.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const SCRIPT = resolve(import.meta.dirname, "../scripts/release-notes.mjs");
+const CHANGELOG = resolve(import.meta.dirname, "../CHANGELOG.md");
+
+function run(version: string, changelogPath = CHANGELOG): string {
+  return execFileSync(process.execPath, [SCRIPT, version, changelogPath], {
+    encoding: "utf-8",
+  }).trim();
+}
+
+function runExpectingFailure(version: string, changelogPath = CHANGELOG): string {
+  try {
+    run(version, changelogPath);
+  } catch (error) {
+    return String((error as { stderr?: string }).stderr ?? "");
+  }
+
+  throw new Error(`Expected release-notes to fail for "${version}", but it succeeded.`);
+}
+
+function fixture(contents: string): string {
+  const path = join(mkdtempSync(join(tmpdir(), "release-notes-")), "CHANGELOG.md");
+  writeFileSync(path, contents);
+  return path;
+}
+
+describe("scripts/release-notes.mjs", () => {
+  it("extracts a bracketed, dated heading", () => {
+    const notes = run("v0.4.0");
+
+    expect(notes).toContain("GitHub Pages landing site");
+    // The next section must not bleed in.
+    expect(notes).not.toContain("Interactive ACP session control");
+  });
+
+  it("extracts a bare `## vX.Y.Z` heading", () => {
+    expect(run("v0.2.0")).toContain("`/refine` ceremony");
+  });
+
+  it("accepts the version with or without a leading v", () => {
+    expect(run("0.4.0")).toBe(run("v0.4.0"));
+  });
+
+  it("stops at the next level-2 heading, including `## [Unreleased]`", () => {
+    const path = fixture(
+      [
+        "# Changelog",
+        "",
+        "## [Unreleased]",
+        "",
+        "- pending",
+        "",
+        "## [1.0.0]",
+        "",
+        "- shipped",
+        "",
+      ].join("\n"),
+    );
+
+    expect(run("1.0.0", path)).toBe("- shipped");
+  });
+
+  it("fails with an actionable message when the version has no section", () => {
+    expect(runExpectingFailure("v9.9.9")).toContain("No CHANGELOG section found for version 9.9.9");
+  });
+
+  it("fails when the section exists but is empty", () => {
+    const path = fixture(
+      ["# Changelog", "", "## [1.0.0]", "", "## [0.9.0]", "", "- old", ""].join("\n"),
+    );
+
+    expect(runExpectingFailure("1.0.0", path)).toContain("is empty");
+  });
+
+  it("has release notes for the version in package.json", () => {
+    const pkg = JSON.parse(
+      readFileSync(resolve(import.meta.dirname, "../package.json"), "utf-8"),
+    ) as { version: string };
+
+    expect(() => run(pkg.version)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Brings the repo up to the fleet standard for CI, releases, supply-chain provenance and dependency updates.

**Heads-up on the premise:** the brief described this repo as having *no workflows* and *no tag*. That was true of an older snapshot. On current `main`, `ci.yml` and npm Trusted Publishing already landed in #488 and `v0.3.0` is tagged. I audited each gap against the real `main` rather than applying the checklist blindly, so this PR **builds on** what exists instead of replacing it. Gap-by-gap status is below.

---

## Gap audit

| # | Gap | Status on `main` | This PR |
|---|-----|------------------|---------|
| 1 | CI | ✅ Already closed by #488 | No change — see "Deliberately skipped" |
| 2 | Release workflow | ⚠️ Partial: tag-triggered + builds, but **never created a GitHub Release** | ✅ New `github-release` job |
| 3 | Trusted Publishing | ⚠️ Mostly done: OIDC + no `NPM_TOKEN`, but `--provenance` not explicit | ✅ Explicit `--provenance` + per-job permissions |
| 4 | Dependabot | ❌ Missing entirely | ✅ New `.github/dependabot.yml` |

---

## What this PR adds

### Dependabot — `.github/dependabot.yml` (new)

Weekly, covering all three ecosystems that actually exist here:

- **npm at `/`** — the CLI/engine
- **npm at `/src/dashboard/frontend`** — has its own `package.json` *and* `package-lock.json` and is **not** an npm workspace, so Dependabot only sees it with a dedicated entry
- **github-actions at `/`**

Updates are grouped (prod / dev / actions) so a quiet week lands as one PR rather than a dozen.

### GitHub Releases — `release.yml`

A new `github-release` job runs on every `v*` tag after a successful publish. It extracts that version's notes from `CHANGELOG.md`, creates the GitHub Release, and attaches the `npm pack` tarball. It's re-runnable — an existing release is updated in place rather than failing.

### Explicit provenance + least privilege — `release.yml`

- `npm publish --access public --provenance`
- Permissions moved from workflow scope to **per-job** scope: `id-token: write` only on the publish job, `contents: write` only on the release job.

### Two release guards — `release.yml`

Both run **before** anything irreversible:

1. **Tag must match `package.json`** — otherwise you publish the wrong version number under the right name.
2. **Version must have a CHANGELOG section** — fails at the start rather than after the package is on npm and can't be unpublished.

### `scripts/release-notes.mjs` (new) + tests

Extracts one version's notes from `CHANGELOG.md`. This file uses **two different heading styles** (`## [0.3.0] — 2026-02-28` and `## v0.2.0`), so the extractor handles both, terminates cleanly at `## [Unreleased]`, and exits non-zero on a missing or empty section. Since it only ever executes during a release, a bug would surface at the worst possible moment — hence `tests/release-notes.test.ts` (7 tests, including a guard that the current `package.json` version always has release notes).

---

## Commands actually run

Every command below was executed locally on this branch — no workflow step is committed unverified.

| Command | Result |
|---------|--------|
| `npm ci` (root) | ✅ 264 packages |
| `npm ci` (`src/dashboard/frontend`) | ✅ |
| `npm run gate` | ✅ **823 tests / 56 files, exit 0** (format:check + lint + typecheck + test + build) |
| `npx vitest run tests/release-notes.test.ts` | ✅ 7/7 |
| `actionlint .github/workflows/*.yml` | ✅ exit 0 (incl. shellcheck on `run:` blocks) |
| `npm pack` | ✅ `aiscrum-pro-0.3.0.tgz`, matches the workflow's `*.tgz` glob |
| Tag guard, both directions | ✅ `v0.3.0` passes; `v0.4.0` correctly fails against `package.json` 0.3.0 |
| Release-notes extraction | ✅ both heading styles; missing version exits 1 |
| Pre-commit + pre-push hooks | ✅ passed (pre-push runs the full gate again) |

`lint` reports **26 warnings, 0 errors** — all pre-existing `@typescript-eslint/no-explicit-any`. Untouched.

Local Node is v22.22.3 while CI pins Node 20; `engines` is `>=20`, so both are in range. The Node 20 path is exercised by CI on this PR.

---

## The tag / publish discrepancy — investigated

The brief asked me to look into "never tagged, yet npm shows 0.3.0". Querying `registry.npmjs.org` directly (the local npm is pointed at a Microsoft proxy feed that 404s on this package):

**`v0.3.0` is fully reconciled** — tag `v0.3.0` → Release workflow run [`32783627264`] succeeded `2026-08-24T22:13:46Z` → npm publish at `22:15:03Z`. Nothing wrong there.

Three real discrepancies remain:

1. **`0.0.1` was published without a tag.** npm has it at `2026-08-24T20:33:04Z`, ~1.5h *before* `release.yml` first ran. No `v0.0.1` tag exists, so that version isn't reproducible from the repo. Only one tag exists in total (`v0.3.0`).
2. **The version line skips `0.1.0` and `0.2.0`.** `CHANGELOG.md` documents `v0.2.0`, but npm went `0.0.1` → `0.3.0`. Those two were never tagged and never published.
3. **`CHANGELOG.md` documents `[0.4.0] — 2026-03-07` as released, but `package.json` is still `0.3.0` and npm `latest` is `0.3.0`.** This is the live one: 0.4.0 is written up as shipped but was never tagged or published. The new tag-vs-`package.json` guard catches exactly this class of error — verified failing on `v0.4.0`.

Also worth recording: **`0.3.0` on npm already carries provenance attestations** (`predicateType: https://slsa.dev/provenance/v1`) even though the workflow never passed `--provenance` — Trusted Publishing generates them implicitly. Adding the flag turns an implicit, incidental guarantee into an enforced one.

I did **not** publish anything, tag anything, or bump any version. Reconciling 0.4.0 is a stakeholder call.

---

## ⚠️ One manual step remains

**The npm Trusted Publisher must be configured once on npmjs.com** — that cannot be done from this repo. On the `aiscrum-pro` package settings, the trusted publisher must point at `trsdn/aiscrum-pro` with workflow file `release.yml`.

This is why the workflow **file name and the `publish` job are unchanged** in this PR: `release.yml` is the registered publisher, and renaming it breaks OIDC auth. (The job name isn't part of the registration, but I left it alone anyway.) Given `0.3.0` published successfully with attestations, this is very likely already configured — worth confirming before the next tag.

---

## Deliberately skipped

- **Did not rewrite `ci.yml`.** It already meets the standard: `pull_request` + `push` to `main`, Node 20, and it installs the nested frontend deps with the right `cache-dependency-path`. The brief preferred calling `npm run gate`; `ci.yml` instead inlines the same five steps on purpose, which gives per-step failure visibility in the Actions UI. Rewriting a green workflow for stylistic parity is churn, so I left it. *Caveat worth knowing:* its header comment claims it "mirrors `npm run gate`", but that's maintained by hand — adding a step to `gate` will not automatically reach CI.
- **No npm publish.** Explicitly out of scope, and nothing here triggers one.
- **Did not bump `package.json` or create a `v0.4.0` tag** — a release decision, not a CI change.
- **Did not touch the 14 `npm audit` findings** (4 moderate / 8 high / 2 critical at root). Out of scope for this PR, and Dependabot will now surface them as reviewable PRs.
- **Did not weaken anything to make a workflow pass.** Nothing on `main` was failing.
