### PR TITLE
chore(deps): add Dependabot config for all three ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+version: 2
+
+updates:
+  # Root package — the CLI/engine itself.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    # Grouped so a quiet week lands as one PR instead of a dozen.
+    groups:
+      production-dependencies:
+        dependency-type: production
+        update-types: [minor, patch]
+      development-dependencies:
+        dependency-type: development
+        update-types: [minor, patch]
+
+  # The dashboard frontend has its own package.json + package-lock.json and is
+  # not an npm workspace, so Dependabot only sees it if it is declared here.
+  - package-ecosystem: npm
+    directory: /src/dashboard/frontend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      production-dependencies:
+        dependency-type: production
+        update-types: [minor, patch]
+      development-dependencies:
+        dependency-type: development
+        update-types: [minor, patch]
+
+  # Action versions used by ci.yml and release.yml.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
Adds `.github/dependabot.yml` — the one fleet-standard gap that is genuinely missing from `origin/main`.

## Scope correction

The original gap list was generated from a **stale scan of a local checkout that was behind `origin/main`**. I re-verified every claimed gap against `origin/main` before writing anything:

| Reported gap | Verified state on `origin/main` | Verdict |
|---|---|---|
| CI — "no workflows" | `.github/workflows/ci.yml` exists — `pull_request` + `push` to `main`, Node 20, installs the nested frontend deps | ❌ **stale-scan artefact** |
| Release workflow — "none" | `.github/workflows/release.yml` exists, tag-triggered on `v*` | ❌ **stale-scan artefact** |
| Trusted Publishing — "no publish workflow" | `release.yml` already does OIDC correctly: `permissions: id-token: write`, no `NPM_TOKEN`/`NODE_AUTH_TOKEN`, npm pinned to an OIDC-capable 11.x | ❌ **stale-scan artefact** |
| LICENSE / AGENTS.md / CHANGELOG.md | All present | ❌ **stale-scan artefact** |
| **Dependabot** | **`.github/dependabot.yml` absent** | ✅ **real gap — closed here** |

Verified with `git cat-file -e origin/main:<path>` for each file. **No workflow is added, modified or deleted in this PR** — `git diff origin/main -- .github/workflows/` is empty. The trusted publishing setup is untouched.

## What this adds

Weekly updates for every ecosystem that actually exists in this repo:

- **npm at `/`** — the CLI/engine
- **npm at `/src/dashboard/frontend`** — it has its own `package.json` *and* `package-lock.json` and is **not** an npm workspace, so Dependabot only sees it with a dedicated entry
- **github-actions at `/`** — the actions used by `ci.yml` and `release.yml`

Updates are grouped (production / development / actions) so a quiet week lands as one PR rather than a dozen. `commit-message.prefix` is `chore` to match the conventional-commit types in `CONTRIBUTING.md`, which lists `feat|fix|docs|chore|refactor|test` and has no `ci` type.

## Verified

| Check | Result |
|---|---|
| Official [Dependabot v2 JSON schema](https://json.schemastore.org/dependabot-2.0.json) via `ajv` | ✅ `dependabot.json valid` |
| All three `directory:` paths exist on `origin/main` | ✅ `/`, `/src/dashboard/frontend`, `/` |
| `npm ci` (root + `src/dashboard/frontend`) | ✅ both clean |
| `npm run gate` — format + lint + typecheck + test + build | ✅ **823 tests / 56 files, exit 0** |
| Pre-commit hook | ✅ passed |
| `git diff origin/main -- .github/workflows/` | ✅ empty — workflows untouched |

This PR is config-only, so it cannot affect the gate; I ran it anyway to confirm `main` is green and that nothing here regresses it. (`lint` reports 26 pre-existing `@typescript-eslint/no-explicit-any` warnings, 0 errors — untouched.)

## The tag / publish discrepancy — investigated

The brief said "the repo has never been tagged, yet npm shows 0.3.0 published". That was also part of the stale snapshot. Querying `registry.npmjs.org` directly (the local npm is pointed at a Microsoft proxy feed that 404s on this package):

**`v0.3.0` is fully reconciled.** Tag `v0.3.0` exists on `origin/main` → the Release workflow run `32783627264` succeeded at `2026-08-24T22:13:46Z` → npm publish landed at `22:15:03Z`. That chain is intact.

Three real discrepancies do remain:

1. **`0.0.1` was published without a tag.** npm has it at `2026-08-24T20:33:04Z`, roughly 1.5h *before* `release.yml` first ran successfully. No `v0.0.1` tag exists, so that published version is not reproducible from the repo. `v0.3.0` is the only tag in the repo.
2. **The version line skips `0.1.0` and `0.2.0`.** `CHANGELOG.md` documents `v0.2.0`, but npm went `0.0.1` → `0.3.0`. Neither was tagged nor published.
3. **`CHANGELOG.md` documents `[0.4.0] — 2026-03-07` as released, but `package.json` is still `0.3.0` and npm `latest` is `0.3.0`.** This is the live one: 0.4.0 is written up as shipped but was never tagged or published.

Also worth recording: **`0.3.0` on npm already carries provenance attestations** (`predicateType: https://slsa.dev/provenance/v1`) even though `release.yml` never passes `--provenance` — npm Trusted Publishing generates them implicitly. So provenance is genuinely in place today, just implicitly rather than explicitly.

Nothing was published, tagged or version-bumped. Reconciling 0.4.0 is a stakeholder decision, not a config change.

## Escalation — one real release gap I found but did NOT fix

While auditing `release.yml` I found a gap that is **not** a stale-scan artefact and is **not** closed by this PR:

> **`release.yml` never creates a GitHub Release.** It publishes to npm on a `v*` tag, but nothing produces a GitHub Release or release notes. The existing `v0.3.0` GitHub Release was created by hand.

The fleet standard asks for "tag-triggered, builds the artifact and publishes a GitHub Release with notes from the existing CHANGELOG.md" — the npm half exists, the GitHub Release half does not.

I had implemented this (a `github-release` job plus a tested `scripts/release-notes.mjs` handling both heading styles in `CHANGELOG.md`), then **reverted it** to comply with the revised dependabot-only scope rather than widening scope on my own. Flagging it here so it isn't lost; happy to open a separate PR if wanted.

## Deliberately skipped

- **Touched no workflow.** `ci.yml` and `release.yml` are correct as-is and were explicitly out of scope.
- **No npm publish, no tag, no version bump.**
- **Did not touch the 14 `npm audit` findings** (4 moderate / 8 high / 2 critical at root). Out of scope — Dependabot will now surface them as reviewable PRs, which is rather the point.
