### PR TITLE
feat(release): publish a GitHub Release on every version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
-# Publishes aiscrum-pro to npm using npm Trusted Publishing (GitHub Actions OIDC).
+# Publishes aiscrum-pro to npm using npm Trusted Publishing (GitHub Actions
+# OIDC), then mirrors the release on GitHub with notes taken from CHANGELOG.md.
 #
 # IMPORTANT: The file name must stay `.github/workflows/release.yml` — it is
 # registered as the trusted publisher on npmjs.com. Renaming it breaks OIDC auth.
@@ -19,8 +20,50 @@ permissions:
   id-token: write
 
 jobs:
+  # Runs before publish so a bad tag fails in seconds, and — critically —
+  # before anything reaches npm, where it cannot be unpublished.
+  #
+  # This is a separate job rather than steps inside `publish` so the ordering
+  # is enforced by the job graph and cannot be broken by reordering steps.
+  # The job itself always runs: gating it on `refs/tags/*` would make it skip
+  # on workflow_dispatch, and a skipped dependency skips `publish` too.
+  verify:
+    name: Verify release metadata
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # A tag that disagrees with package.json publishes the wrong version
+      # number under the right name.
+      - name: Verify tag matches package.json
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "${TAG#v}" != "$PKG_VERSION" ]; then
+            echo "::error::Tag $TAG does not match package.json version $PKG_VERSION."
+            exit 1
+          fi
+          echo "Releasing $PKG_VERSION"
+
+      # The github-release job needs these notes. Without this check a tag
+      # with no CHANGELOG section would publish to npm and only then fail to
+      # build the release — or publish an empty one.
+      - name: Verify CHANGELOG has release notes
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TAG: ${{ github.ref_name }}
+        run: node scripts/release-notes.mjs "$TAG" > /dev/null
+
   publish:
     name: Publish to npm
+    needs: verify
     runs-on: ubuntu-latest
 
     steps:
@@ -70,3 +113,42 @@ jobs:
       # against the trusted publisher configured on npmjs.com.
       - name: Publish
         run: npm publish --access public
+
+  github-release:
+    name: GitHub Release
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+
+    # Job-scoped on purpose: the workflow-level block stays at
+    # `contents: read` so the publish job keeps exactly the permissions it
+    # has today. Only this job can write releases, and it gets no OIDC token.
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Extract release notes from CHANGELOG.md
+        env:
+          TAG: ${{ github.ref_name }}
+        run: node scripts/release-notes.mjs "$TAG" > release-notes.md
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Re-runnable: update in place if the release already exists.
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            gh release edit "$TAG" --title "$TAG" --notes-file release-notes.md
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes-file release-notes.md \
+              --verify-tag
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- Tag-triggered GitHub Releases: the release workflow now publishes a GitHub Release with notes taken from this file
+- `scripts/release-notes.mjs` — extracts a single version's notes from CHANGELOG.md, with tests
+- Release guards: a tag that disagrees with `package.json`, or a version with no CHANGELOG section, now fails before anything is published
+
 ## [0.4.0] — 2026-03-07
 
 ### Added

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Extracts the notes for a single version out of CHANGELOG.md so the release
+// workflow can feed them to `gh release create --notes-file`.
+//
+//   node scripts/release-notes.mjs v0.4.0 [path/to/CHANGELOG.md]
+//
+// Exits non-zero when the version has no section, so a release fails loudly
+// instead of publishing empty notes.
+
+import { readFileSync } from "node:fs";
+import { argv, exit, stdout } from "node:process";
+import { pathToFileURL } from "node:url";
+
+// Matches the heading styles already used in this CHANGELOG:
+//   "## [0.3.0] — 2026-02-28", "## v0.2.0", "## 0.2.0", "## [0.2.0](link)"
+const VERSION_HEADING = /^##\s+\[?v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\]?/;
+
+export function extractReleaseNotes(changelog, version) {
+  const wanted = String(version ?? "")
+    .trim()
+    .replace(/^v/, "");
+
+  if (!wanted) {
+    throw new Error("A version argument is required, e.g. `release-notes.mjs v0.4.0`.");
+  }
+
+  const lines = changelog.split(/\r?\n/);
+  const start = lines.findIndex((line) => VERSION_HEADING.exec(line)?.[1] === wanted);
+
+  if (start === -1) {
+    throw new Error(
+      `No CHANGELOG section found for version ${wanted}. ` +
+        `Add a "## [${wanted}]" heading before tagging the release.`,
+    );
+  }
+
+  // A section runs until the next level-2 heading (any heading, not just a
+  // version one, so "## [Unreleased]" also terminates it).
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => line.startsWith("## "));
+  const body = (end === -1 ? rest : rest.slice(0, end)).join("\n").trim();
+
+  if (!body) {
+    throw new Error(`The CHANGELOG section for version ${wanted} is empty.`);
+  }
+
+  return body;
+}
+
+function main() {
+  const [version, changelogPath = "CHANGELOG.md"] = argv.slice(2);
+
+  try {
+    stdout.write(`${extractReleaseNotes(readFileSync(changelogPath, "utf-8"), version)}\n`);
+  } catch (error) {
+    console.error(`release-notes: ${error.message}`);
+    exit(1);
+  }
+}
+
+// Only run the CLI when executed directly, so tests can import the function.
+if (argv[1] && import.meta.url === pathToFileURL(argv[1]).href) {
+  main();
+}

--- a/tests/release-notes.test.ts
+++ b/tests/release-notes.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const SCRIPT = resolve(import.meta.dirname, "../scripts/release-notes.mjs");
+const CHANGELOG = resolve(import.meta.dirname, "../CHANGELOG.md");
+
+function run(version: string, changelogPath = CHANGELOG): string {
+  return execFileSync(process.execPath, [SCRIPT, version, changelogPath], {
+    encoding: "utf-8",
+  }).trim();
+}
+
+function runExpectingFailure(version: string, changelogPath = CHANGELOG): string {
+  try {
+    run(version, changelogPath);
+  } catch (error) {
+    return String((error as { stderr?: string }).stderr ?? "");
+  }
+
+  throw new Error(`Expected release-notes to fail for "${version}", but it succeeded.`);
+}
+
+function fixture(contents: string): string {
+  const path = join(mkdtempSync(join(tmpdir(), "release-notes-")), "CHANGELOG.md");
+  writeFileSync(path, contents);
+  return path;
+}
+
+describe("scripts/release-notes.mjs", () => {
+  it("extracts a bracketed, dated heading", () => {
+    const notes = run("v0.3.0");
+
+    expect(notes).toContain("Interactive ACP session control");
+    // The next section must not bleed in.
+    expect(notes).not.toContain("`/refine` ceremony");
+  });
+
+  it("extracts a bare `## vX.Y.Z` heading", () => {
+    expect(run("v0.2.0")).toContain("`/refine` ceremony");
+  });
+
+  it("accepts the version with or without a leading v", () => {
+    expect(run("0.3.0")).toBe(run("v0.3.0"));
+  });
+
+  it("stops at the next level-2 heading, including `## [Unreleased]`", () => {
+    const path = fixture(
+      [
+        "# Changelog",
+        "",
+        "## [Unreleased]",
+        "",
+        "- pending",
+        "",
+        "## [1.0.0]",
+        "",
+        "- shipped",
+        "",
+      ].join("\n"),
+    );
+
+    expect(run("1.0.0", path)).toBe("- shipped");
+  });
+
+  it("fails with an actionable message when the version has no section", () => {
+    expect(runExpectingFailure("v9.9.9")).toContain("No CHANGELOG section found for version 9.9.9");
+  });
+
+  it("fails when the section exists but is empty", () => {
+    const path = fixture(
+      ["# Changelog", "", "## [1.0.0]", "", "## [0.9.0]", "", "- old", ""].join("\n"),
+    );
+
+    expect(runExpectingFailure("1.0.0", path)).toContain("is empty");
+  });
+
+  // The release workflow extracts notes for whatever version is being tagged,
+  // so a missing section for the current version would only surface mid-release.
+  it("has release notes for the version in package.json", () => {
+    const pkg = JSON.parse(
+      readFileSync(resolve(import.meta.dirname, "../package.json"), "utf-8"),
+    ) as { version: string };
+
+    expect(() => run(pkg.version)).not.toThrow();
+  });
+});


### PR DESCRIPTION
`release.yml` published to npm on a `v*` tag but never created a GitHub Release — and with workflow-level `contents: read` it could not have, even if it had tried. Release notes were written by hand; the existing `v0.3.0` release was created manually.

The npm/Trusted-Publishing half was already correct and is untouched here. This adds the GitHub Release half.

Independent of #490 (Dependabot) — no file overlap, mergeable in either order.

## Design

Three jobs, `verify` → `publish` → `github-release`:

| Job | Purpose | Permissions |
|---|---|---|
| `verify` *(new)* | Tag matches `package.json`; version has a CHANGELOG section | inherits `contents: read` |
| `publish` | Unchanged — npm publish via OIDC | inherits `contents: read` + `id-token: write` |
| `github-release` *(new)* | Creates the GitHub Release from CHANGELOG notes | **job-scoped** `contents: write` |

**Extends the existing workflow — no second workflow.** Two tag-triggered workflows on `v*` is how you get duplicate releases.

**`verify` is a separate job, not steps inside `publish`.** Ordering is then enforced by the job graph rather than by step order, so a later edit can't accidentally move a guard after the publish step. It also fails a bad tag in ~15s instead of after a 3-minute install/test/build.

**`verify` gates on `refs/tags/*` at step level, not job level.** A job-level `if` would skip the job on `workflow_dispatch`, and a skipped dependency skips `publish` too — that would break manual dispatch entirely.

**Fails loudly on a missing CHANGELOG section.** `scripts/release-notes.mjs` exits non-zero for a missing *or empty* section, and `verify` runs it before publish. So a tag with no notes never reaches npm, rather than publishing and then failing to build the release — or publishing an empty one.

**`scripts/release-notes.mjs`** handles both heading styles in use (`## [0.3.0] — 2026-02-28` and `## v0.2.0`) and terminates cleanly at `## [Unreleased]`. It only ever runs during a release, so a bug would surface at the worst possible moment — hence `tests/release-notes.test.ts` (7 tests, including one asserting that whatever version is in `package.json` always has notes).

## The publish job is byte-identical

Its **only** change is the added `needs: verify`. Verified structurally, not by eyeballing:

```
workflow permissions  old: {'contents': 'read', 'id-token': 'write'}
workflow permissions  new: {'contents': 'read', 'id-token': 'write'}
identical: True

publish steps identical: True (11 -> 11 steps)
publish job keys old: ['name', 'runs-on', 'steps']
publish job keys new: ['name', 'needs', 'runs-on', 'steps']
publish job-level permissions: None (inherits workflow level)
```

Workflow file name, publish step, and the workflow-level `permissions:` block are all untouched — `release.yml` is registered as the trusted publisher on npmjs.com.

I also did **not** add `npm publish --provenance`, per scope.

## Deliberately deferred: attaching the tarball

An earlier revision of this PR attached the `npm pack` tarball to the release. I dropped it: it required turning `npm pack --dry-run` into a real `npm pack` plus an upload step **inside the publish job**, which conflicts with "do not touch the publish job". The Release links to the npm package either way. Happy to add it as a follow-up if wanted — it's a one-job change if the tarball is re-fetched from the registry instead.

## ⚠️ Pre-existing version drift, deliberately not fixed

**`CHANGELOG.md` documents `[0.4.0] — 2026-03-07` as released, while `package.json` and npm `latest` are both `0.3.0`.**

This matters for reviewing this PR, because a release job keyed on CHANGELOG sections behaves surprisingly while it is true — `v0.4.0` has notes but the wrong version. The `verify` job makes that visible rather than silent:

```
[v0.3.0] tag guard:       PASS (releasing 0.3.0)
[v0.3.0] changelog guard: PASS
[v0.4.0] tag guard:       FAIL -> ::error::Tag v0.4.0 != package.json 0.3.0
[v0.4.0] changelog guard: PASS      <- notes exist, version doesn't
```

Reconciling 0.4.0 is a stakeholder decision. **Not fixed as a side effect of this PR.** Nothing here bumps, tags or publishes.

## Two findings worth recording

**1. This is a fleet pattern, not a one-off.** The same shape was found in `autocut`: `release.yml` with `contents: read`, only `pypa/gh-action-pypi-publish`, and no GitHub Release step. Package-registry publishing gets set up correctly and the GitHub Release half gets skipped, because the registry publish is the visible one and `contents: read` silently makes the other half impossible. Worth checking the rest of the fleet for the same signature: a tag-triggered workflow whose top-level permissions never grant `contents: write`.

**2. Trusted Publishing attaches provenance implicitly.** `0.3.0` on npm carries SLSA attestations (`predicateType: https://slsa.dev/provenance/v1`) despite the workflow never passing `--provenance`. This independently corroborates the same conclusion reached in the `agent-trestle` session — two repos, two separate investigations, same result. Practical consequence: `--provenance` is hardening (making an implicit guarantee explicit and enforced), not a missing-provenance fix.

## Verified

Every command run locally on this branch. No workflow step committed unexecuted.

| Check | Result |
|---|---|
| `npm ci` root + `src/dashboard/frontend` | ✅ |
| `npm run gate` — format + lint + typecheck + test + build | ✅ **823 tests / 56 files, exit 0** |
| `actionlint .github/workflows/*.yml` | ✅ exit 0 (incl. shellcheck on `run:` blocks) |
| Publish job / workflow permissions unchanged | ✅ proved by AST comparison (above) |
| Job DAG | ✅ `verify` → `publish` → `github-release` |
| Tag guard, both directions | ✅ `v0.3.0` passes, `v0.4.0` fails |
| CHANGELOG guard | ✅ passes `v0.3.0`, exits 1 on `v9.9.9`, exits 1 on empty section |
| Both heading styles | ✅ `[0.3.0] — date` and `v0.2.0` |
| `## [Unreleased]` bleed-through | ✅ none |
| Pre-commit + pre-push hooks | ✅ passed (pre-push re-runs the full gate) |

Test-count reconciliation: `origin/main` has 55 test files, this branch 56, vitest reports 56 / 823 — the 7 new tests are genuinely in that total, not silently skipped.

`lint`: **26 warnings, 0 errors**, all pre-existing `@typescript-eslint/no-explicit-any`. Untouched.
